### PR TITLE
A start on fixing some issues with native strings

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -144,6 +144,7 @@ their individual contributions.
 * `Florian Bruhin <https://www.github.com/The-Compiler>`_
 * `follower <https://www.github.com/follower>`_
 * `Jonty Wareing <https://www.github.com/Jonty>`_ (`jonty@jonty.co.uk <mailto:jonty@jonty.co.uk>`_)
+* `Julian Berman<https://www.github.com/Julian>`_
 * `kbara <https://www.github.com/kbara>`_
 * `marekventur <https://www.github.com/marekventur>`_
 * `Marius Gedminas <https://www.github.com/mgedmin>`_ (`marius@gedmin.as <mailto:marius@gedmin.as>`_)

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -225,7 +225,7 @@ def simplify_template_such_that(
         any_simplifiers = False
         for simplify in search_strategy.simplifiers(random, t):
             debug_report(u'Applying simplification pass %s' % (
-                simplify.__name__,
+                unicode_safe_repr(simplify.__name__),
             ))
             any_simplifiers = True
             any_shrinks = False

--- a/src/hypothesis/database/backend.py
+++ b/src/hypothesis/database/backend.py
@@ -84,7 +84,7 @@ class SQLiteBackend(Backend):
                 del self.current_connection.connection
 
     def __repr__(self):
-        return u'%s(%s)' % (self.__class__.__name__, self.path)
+        return '%s(%s)' % (self.__class__.__name__, self.path)
 
     def data_type(self):
         return text_type

--- a/src/hypothesis/database/formats.py
+++ b/src/hypothesis/database/formats.py
@@ -44,7 +44,7 @@ class Format(object):
     """
 
     def __repr__(self):
-        return u'%s()' % (self.__class__.__name__,)
+        return '%s()' % (self.__class__.__name__,)
 
     @abstractmethod  # pragma: no cover
     def data_type(self):

--- a/src/hypothesis/extra/django/models.py
+++ b/src/hypothesis/extra/django/models.py
@@ -115,7 +115,7 @@ class ModelStrategy(MappedSearchStrategy):
             strategy=st.fixed_dictionaries(mappings))
 
     def __repr__(self):
-        return u'ModelStrategy(%s)' % (self.model.__name__,)
+        return 'ModelStrategy(%s)' % (self.model.__name__,)
 
     def pack(self, value):
         try:

--- a/src/hypothesis/internal/compat.py
+++ b/src/hypothesis/internal/compat.py
@@ -189,7 +189,7 @@ def qualname(f):
     except AttributeError:
         pass
     try:
-        return f.im_class.__name__ + u'.' + f.__name__
+        return f.im_class.__name__ + '.' + f.__name__
     except AttributeError:
         return f.__name__
 

--- a/src/hypothesis/searchstrategy/numbers.py
+++ b/src/hypothesis/searchstrategy/numbers.py
@@ -303,7 +303,7 @@ class FloatStrategy(SearchStrategy):
         self.int_strategy = RandomGeometricIntStrategy()
 
     def __repr__(self):
-        return u'%s()' % (self.__class__.__name__,)
+        return '%s()' % (self.__class__.__name__,)
 
     def strictly_simpler(self, x, y):
         if math.isnan(x):
@@ -398,7 +398,7 @@ class FloatStrategy(SearchStrategy):
             for m in simplify(random, int(math.floor(x))):
                 yield float(m)
         accept.__name__ = str(
-            u'simplify_integral(%s)' % (simplify.__name__,)
+            'simplify_integral(%s)' % (simplify.__name__,)
         )
         return accept
 

--- a/src/hypothesis/searchstrategy/strategies.py
+++ b/src/hypothesis/searchstrategy/strategies.py
@@ -54,10 +54,10 @@ def infinitish(x):
 def check_type(typ, value, e=WrongFormat):
     if not isinstance(value, typ):
         if isinstance(typ, tuple):
-            name = u'any of ' + u', '.join(t.__name__ for t in typ)
+            name = 'any of ' + ', '.join(t.__name__ for t in typ)
         else:
             name = typ.__name__
-        raise e(u'Value %r is not an instance of %s' % (
+        raise e('Value %r is not an instance of %s' % (
             value, name
         ))
 
@@ -232,19 +232,19 @@ class SearchStrategy(object):
         """Produce a random valid parameter for this strategy, using only data
         from the provided random number generator."""
         raise NotImplementedError(  # pragma: no cover
-            u'%s.draw_parameter()' % (self.__class__.__name__))
+            '%s.draw_parameter()' % (self.__class__.__name__))
 
     def draw_template(self, random, parameter_value):
         """Given this Random and this parameter value, produce a random valid
         template for this strategy."""
         raise NotImplementedError(  # pragma: no cover
-            u'%s.draw_template()' % (self.__class__.__name__))
+            '%s.draw_template()' % (self.__class__.__name__))
 
     def reify(self, template):
         """Given a template value, deterministically convert it into a value of
         the desired final type."""
         raise NotImplementedError(  # pragma: no cover
-            u'%s.reify()' % (self.__class__.__name__))
+            '%s.reify()' % (self.__class__.__name__))
 
     def to_basic(self, template):
         """Convert a template value for this strategy into basic data.
@@ -256,7 +256,7 @@ class SearchStrategy(object):
 
         """
         raise NotImplementedError(  # pragma: no cover
-            u'%s.to_basic()' % (self.__class__.__name__))
+            '%s.to_basic()' % (self.__class__.__name__))
 
     def from_basic(self, value):
         """Convert basic data back to a template, raising BadData if the
@@ -269,7 +269,7 @@ class SearchStrategy(object):
 
         """
         raise NotImplementedError(  # pragma: no cover
-            u'%s.from_basic()' % (self.__class__.__name__))
+            '%s.from_basic()' % (self.__class__.__name__))
 
     # Gory implementation details
 
@@ -466,7 +466,7 @@ class OneOfStrategy(SearchStrategy):
             for value in simplifier(random, template[1]):
                 yield (s, value)
         accept.__name__ = str(
-            u'element_simplifier(%d, %s)' % (
+            'element_simplifier(%d, %s)' % (
                 s, simplifier.__name__,
             )
         )
@@ -495,7 +495,7 @@ class OneOfStrategy(SearchStrategy):
                     # reliably.
                     pass
         accept.__name__ = str(
-            u'redraw_simplifier(%d)' % (child,))
+            'redraw_simplifier(%d)' % (child,))
         return accept
 
     def to_basic(self, template):
@@ -554,7 +554,7 @@ class MappedSearchStrategy(SearchStrategy):
         """Take a value produced by the underlying mapped_strategy and turn it
         into a value suitable for outputting from this strategy."""
         raise NotImplementedError(
-            u'%s.pack()' % (self.__class__.__name__))
+            '%s.pack()' % (self.__class__.__name__))
 
     def reify(self, value):
         return self.pack(self.mapped_strategy.reify(value))

--- a/src/hypothesis/searchstrategy/streams.py
+++ b/src/hypothesis/searchstrategy/streams.py
@@ -133,7 +133,7 @@ class StreamStrategy(SearchStrategy):
             for t in simplify(random, stream[i]):
                 yield template.with_value(i, t)
         accept.__name__ = str(
-            u'simplifier_for_index(%s, %d)' % (
+            'simplifier_for_index(%s, %d)' % (
                 simplify.__name__, i
             )
         )

--- a/src/hypothesis/searchstrategy/strings.py
+++ b/src/hypothesis/searchstrategy/strings.py
@@ -158,7 +158,7 @@ class OneCharStringStrategy(SearchStrategy):
                         yield c
                 lb = new_lb
         accept.__name__ = str(
-            u'try_shrink(%d, %d)' % (lo, hi)
+            'try_shrink(%d, %d)' % (lo, hi)
         )
         return accept
 

--- a/src/hypothesis/searchstrategy/wrappers.py
+++ b/src/hypothesis/searchstrategy/wrappers.py
@@ -34,7 +34,7 @@ class WrapperStrategy(SearchStrategy):
         self.template_upper_bound = self.wrapped_strategy.template_upper_bound
 
     def __repr__(self):
-        return u'%s(%r)' % (type(self).__name__, self.wrapped_strategy)
+        return '%s(%r)' % (type(self).__name__, self.wrapped_strategy)
 
     def validate(self):
         self.wrapped_strategy.validate()

--- a/src/hypothesis/stateful.py
+++ b/src/hypothesis/stateful.py
@@ -83,7 +83,7 @@ def find_breaking_runner(state_machine_factory, settings=None):
     if settings.database is not None:
         storage = settings.database.storage(
             getattr(
-                state_machine_factory, u'__name__',
+                state_machine_factory, '__name__',
                 type(state_machine_factory).__name__))
     else:
         storage = None
@@ -183,11 +183,11 @@ class GenericStateMachine(object):
 
         base_name = state_machine_class.__name__
         StateMachineTestCase.__name__ = str(
-            base_name + u'.TestCase'
+            base_name + '.TestCase'
         )
         StateMachineTestCase.__qualname__ = str(
-            getattr(state_machine_class, u'__qualname__', base_name) +
-            u'.TestCase'
+            getattr(state_machine_class, '__qualname__', base_name) +
+            '.TestCase'
         )
         state_machine_class._test_case_cache[state_machine_class] = (
             StateMachineTestCase
@@ -419,9 +419,9 @@ class StateMachineSearchStrategy(SearchStrategy):
                     n_steps=template.n_steps,
                     record=new_record,
                 )
-        accept.__name__ = str(u'convert_simplifier(%s, %d)' % (
+        accept.__name__ = 'convert_simplifier(%s, %d)' % (
             simplifier.__name__, i
-        ))
+        )
         return accept
 
     def random_discards(self, random, template):
@@ -625,7 +625,7 @@ class RuleBasedStateMachine(GenericStateMachine):
 
     def __init__(self):
         if not self.rules():
-            raise InvalidDefinition(u'Type %s defines no rules' % (
+            raise InvalidDefinition('Type %s defines no rules' % (
                 type(self).__name__,
             ))
         self.bundles = {}
@@ -633,7 +633,7 @@ class RuleBasedStateMachine(GenericStateMachine):
         self.names_to_values = {}
 
     def __repr__(self):
-        return u'%s(%s)' % (
+        return '%s(%s)' % (
             type(self).__name__,
             repr(self.bundles),
         )

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -972,10 +972,10 @@ def check_type(typ, arg):
         if isinstance(typ, type):
             typ_string = typ.__name__
         else:
-            typ_string = u'one of %s' % (
-                u', '.join(t.__name__ for t in typ))
+            typ_string = 'one of %s' % (
+                ', '.join(t.__name__ for t in typ))
         raise InvalidArgument(
-            u'Expected %s but got %r' % (typ_string, arg,))
+            'Expected %s but got %r' % (typ_string, arg,))
 
 
 def check_strategy(arg):

--- a/src/hypothesis/types.py
+++ b/src/hypothesis/types.py
@@ -92,7 +92,7 @@ class Stream(object):
             ))
 
         if not isinstance(key, int):
-            raise InvalidArgument(u'Cannot index stream with %s' % (
+            raise InvalidArgument('Cannot index stream with %s' % (
                 type(key).__name__,))
         self._thunk_to(key + 1)
         return self.fetched[key]

--- a/src/hypothesis/utils/show.py
+++ b/src/hypothesis/utils/show.py
@@ -49,7 +49,7 @@ def repr_string(value, seen):
 
 @show.extend(object)
 def generic_string(value, seen):
-    if hasattr(value, u'__name__'):
+    if hasattr(value, '__name__'):
         return value.__name__
     try:
         d = value.__dict__

--- a/tests/cover/test_non_ascii_names.py
+++ b/tests/cover/test_non_ascii_names.py
@@ -19,7 +19,6 @@ from __future__ import division, print_function, absolute_import
 import hypothesis.strategies as st
 from hypothesis import given
 
-
 ClassWithNonASCIIName = type("מחלקה", (object,), {})
 
 

--- a/tests/cover/test_non_ascii_names.py
+++ b/tests/cover/test_non_ascii_names.py
@@ -1,0 +1,28 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
+#
+# Most of this work is copyright (C) 2013-2015 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
+# full list of people who may hold copyright, and consult the git log if you
+# need to determine who owns an individual contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import hypothesis.strategies as st
+from hypothesis import given
+
+
+ClassWithNonASCIIName = type("מחלקה", (object,), {})
+
+
+@given(st.builds(ClassWithNonASCIIName))
+def test_builds_can_build_classes_with_non_ascii_names(n):
+    pass

--- a/tests/cover/test_non_ascii_names.py
+++ b/tests/cover/test_non_ascii_names.py
@@ -19,7 +19,7 @@ from __future__ import division, print_function, absolute_import
 import hypothesis.strategies as st
 from hypothesis import given
 
-ClassWithNonASCIIName = type("מחלקה", (object,), {})
+ClassWithNonASCIIName = type('מחלקה', (object,), {})
 
 
 @given(st.builds(ClassWithNonASCIIName))


### PR DESCRIPTION
This is a start towards fixing places that are trying to treat things as unicode that are actually native strings (i.e. they're supposed to be `str` on both versions).

This comes up with falsifying examples for things with non-ASCII names in particular.

I've only really fixed one of the "real bug" I ran into so far :/ which is in `builds` -- there are 4 instances of this bug in `hypothesis.core` which I can't yet fix because they use `hypothesis.reporting.report` -- I haven't looked closely at that, but it seems likely that that function (and others in there) should be taking native strings, not unicode, if they mean to actually output those strings somewhere.

Comments welcome obviously, this PR is a bit... sloppy to say the least.