### PR TITLE
Add type-hint support

### DIFF
--- a/src/hypothesis/extra/typehints.py
+++ b/src/hypothesis/extra/typehints.py
@@ -1,0 +1,101 @@
+from __future__ import print_function
+import sys
+from hypothesis import strategies as st
+from hypothesis.strategies import SearchStrategy
+from typing import Dict, Tuple, List, Iterator, Set, Union, Optional, NamedTuple, Callable, Sequence, Iterable, Generator
+import operator
+from collections import OrderedDict
+compose = lambda f,g: lambda *x: f(g(*x))
+# see https://docs.python.org/3/library/typing.html
+try:
+    unicode = unicode
+except:
+    unicode = str
+    from functools import reduce
+
+primitives = {
+    str   : st.text(), # might want to default to `string.printable`
+    int   : st.integers(),
+    bool  : st.booleans(),
+    float : st.floats(),
+    type(None) : st.none(),
+    unicode : st.characters(),
+    bytes : st.binary() # this is weird because str == bytes in py2
+} # missing: fractions, decimal
+
+# it's not possible to make this typesafe, because 
+# we need `issinstance` to narrow down the types of types, 
+# and we are using `issubclass`
+# there's also a FrozenSet type
+# IO types ("file-like")
+# re type
+def type_to_strat(x): # type: (type) -> SearchStrategy
+   '''
+   Given a type, return a strategy which yields a value of that type. Types maybe complex: Union, NamedTuple, etc.
+   For more information, see https://docs.python.org/3/library/typing.html
+   Usage:
+   >>> type_to_strat(Union[int,str]).exmample()
+   . . . 3
+   '''
+   if x in primitives:
+       return primitives[x]
+   elif hasattr(x, '_fields'):# NamedTuple isn't a type, it's a function
+   #elif isinstance(x, Callable): #this catches List[T] for some reason
+       name = x.__name__
+       fts = OrderedDict(x._field_types)
+       vals = map(type_to_strat, fts.values()) 
+       # `NamedTuple` is actually a ... `namedtuple` itself
+       toArgDict = lambda xs: dict(zip(fts.keys(), xs))
+       return st.tuples(*vals).map(lambda ys: x(**toArgDict(ys)))
+   elif issubclass(x, Dict):
+       return st.dictionaries(*map(type_to_strat, x.__parameters__))
+   elif issubclass(x, Tuple): 
+       if x.__tuple_use_ellipsis__: # variable lenth tuple
+           element_type = x.__tuple_params__[0]
+           return type_to_strat(List[element_type]).map(tuple) 
+       return st.tuples(*map(type_to_strat, x.__tuple_params__))
+   elif issubclass(x, Union):
+       return reduce(operator.ior, map(type_to_strat, x.__union_params__))
+   elif issubclass(x, Optional):
+       # Optional[X] is equivalent to Union[X, type(None)]. second param is always Nonetype.
+       value = x.__union_params__[0] 
+       return (type_to_strat(value) | st.none()) # type: SearchStrategy
+   else:
+       element_type = type_to_strat(x.__parameters__[0]) 
+       if issubclass(x, list):
+           return st.lists(element_type)
+       elif issubclass(x, set):
+           return st.sets(element_type)
+       elif issubclass(x, Sequence):
+           anySizeTuple = type_to_strat(Tuple[element_type,...]) 
+           return st.sets(element_type) | st.lists(element_type) | anySizeTuple 
+       elif issubclass(x, Generator):
+           toGen = lambda xs: (x for x in xs) # type: Callable[[Iterable[T]], Generator[T]]
+           return type_to_strat(List[element_type]).map(toGen)
+       # not sure how to create an Iterable (it doesn't have an `__next__` method)
+       elif issubclass(x, Iterator)  or issubclass(x, Iteratable):
+           return type_to_strat(List[element_type]).map(iter)
+       else:
+           raise ValueError("Could not find strategy for type %s" % x) 
+
+
+def func_strat(f): 
+    # type: (Callable[...]) -> Dict[str,SearchStrategy[Any]]
+    '''
+    Given an annotated function, return a strategy which yields a dictionary mapping from the argument names to the appropriate type.
+    Usage:
+    >>> def mod_list_example(m: int, xs: List[int]) -> List[int]:
+    >>>    return list(map(lambda x: x % m, xs))
+    >>> mod_list_example(**func_strat(mod_list_example).example())
+    >>> mod_list_example(**func_strat(mod_list_example).example())
+    '''
+    argtypes = OrderedDict(f.__annotations__)
+    if 'return' in  argtypes:
+        del argtypes['return']
+    vals = map(type_to_strat, argtypes.values()) 
+    toArgDict = lambda xs: dict(zip(argtypes.keys(), xs))
+    return st.tuples(*vals).map(toArgDict)
+
+# see https://docs.python.org/3/library/typing.html
+# not Generics
+# not Callables

--- a/src/hypothesis/extra/typehints.py
+++ b/src/hypothesis/extra/typehints.py
@@ -34,7 +34,7 @@ def type_to_strat(x): # type: (type) -> SearchStrategy
    Given a type, return a strategy which yields a value of that type. Types maybe complex: Union, NamedTuple, etc.
    For more information, see https://docs.python.org/3/library/typing.html
    Usage:
-   >>> type_to_strat(Union[int,str]).exmample()
+   >> type_to_strat(Union[int,str]).exmample()
    . . . 3
    '''
    if x in primitives:
@@ -84,10 +84,10 @@ def func_strat(f):
     '''
     Given an annotated function, return a strategy which yields a dictionary mapping from the argument names to the appropriate type.
     Usage:
-    >>> def mod_list_example(m: int, xs: List[int]) -> List[int]:
-    >>>    return list(map(lambda x: x % m, xs))
-    >>> mod_list_example(**func_strat(mod_list_example).example())
-    >>> mod_list_example(**func_strat(mod_list_example).example())
+    >> def mod_list_example(m: int, xs: List[int]) -> List[int]:
+    >>    return list(map(lambda x: x % m, xs))
+    >> mod_list_example(**func_strat(mod_list_example).example())
+    >> mod_list_example(**func_strat(mod_list_example).example())
     '''
     argtypes = OrderedDict(f.__annotations__)
     if 'return' in  argtypes:

--- a/tests/typehints/test_typehints.py
+++ b/tests/typehints/test_typehints.py
@@ -1,0 +1,58 @@
+from typing import List, NamedTuple, Optional, Tuple, Union
+import unittest 
+from hypothesis.extra.typehints import type_to_strat, func_strat
+from hypothesis import given, assume
+from hypothesis.strategies import just, random_module
+import operator
+try:
+    from functools import reduce
+except:
+    pass
+fields = [('ref', str),
+          ('AO', List[int]),
+          ('DP', int),
+          ('chrom',str),
+          ('pos', int),
+          ('alt', List[str])]
+ 
+VCFRow = NamedTuple("VCFRow", fields)
+class TypeHintsTests(unittest.TestCase):
+    @given(type_to_strat(VCFRow))
+    def test_namedtuple_vcfrow(self, obj):
+        for attr, typ in fields:
+            self.assertIsInstance(getattr(obj, attr), typ)
+    
+    def test_func_strat(self): 
+       #def example_func(m: int, xs: List[int]) -> None:
+      def example_func(m, xs):
+         # type: (int, List[int]) -> None
+         self.assertIsInstance(xs, List[int])
+         self.assertIsInstance(m, int)
+      argtypes = {'m' : int, 'xs' : List[int], 'return' : None}
+      example_func.__annotations__ = argtypes
+      strat = func_strat(example_func)
+      for _ in range(20):
+          example_func(**strat.example()) 
+    
+    SimpleObj = NamedTuple("SimpleObj", [('int', int), ('bool', bool)])
+    some_types = [int, str, Optional[int], List[Tuple[int,str]], Tuple[bool, int], SimpleObj]
+    atype = reduce(operator.ior, map(just, some_types))
+    
+    
+    @given(atype, atype, atype, random_module())
+    def test_union_is_either(self, t1, t2, t3, _):
+        union = Union[t1, t2, t3]
+        strat = type_to_strat(union)
+        for _ in range(20):
+            ex = strat.example()
+            self.assertIsInstance(ex, (t1, t2, t3))
+    
+    @given(type_to_strat(Union[int, str]))
+    def test_union_produces_first(self, x):
+        assume(isinstance(x, int))
+        self.assertIsInstance(x, int)
+    
+    @given(type_to_strat(Union[int, str]))
+    def test_union_produces_second(self, y):
+        assume(isinstance(y, str))
+        self.assertIsInstance(y, str) 


### PR DESCRIPTION
Closes #293 

Example

``` python
def mod_list_example(m: int, xs: List[int]) -> List[int]:
      return list(map(lambda x: x % m, xs))

@given(func_start(mod_list_example))
def test_mod_list_example(self, args):
    result = mod_list_example(**args)
    assert all(lambda x: x < args['m'], result)
```

Works with  `NamedTuple`, `Union`, `Optional`, etc. Doesn't include support for the `IO` types, which would be interesting. 
