### PR TITLE
Adds a `max_size` check to the `ListStrategy` while loop.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -34,9 +34,9 @@ OK, so you want to make a contribution and have sorted out the legalese. What no
 
 First off: If you're planning on implementing a new feature, talk to me first! I'll probably
 tell you to go for it, but I might have some feedback on aspects of it or tell you how it fits
-into the broader scheme of things. Remember: A feature is for 1.x, not just for Christmas. Once
+into the broader scheme of things. Remember: A feature is for 3.x, not just for Christmas. Once
 a feature is in, it can only be evolved in backwards compatible ways until I bump the "I can break
-your code" number and release Hypothesis 2.0. This means I spend a lot of time thinking about
+your code" number and release Hypothesis 4.0. This means I spend a lot of time thinking about
 getting features right. It may sometimes also mean I reject your feature, or feel you need to
 rethink it, so it's best to have that conversation early.
 
@@ -140,6 +140,7 @@ their individual contributions.
 * `Chris Down  <https://chrisdown.name>`_
 * `Christopher Martin <https://www.github.com/chris-martin>`_ (`ch.martin@gmail.com <mailto:ch.martin@gmail.com>`_)
 * `Cory Benfield <https://www.github.com/Lukasa>`_
+* `Cristi Cobzarenco <https://github.com/cristicbz>`_ (`cristi@reinfer.io <mailto:cristi@reinfer.io>`_)
 * `David Bonner <https://github.com/rascalking>`_ (`dbonner@gmail.com <mailto:dbonner@gmail.com>`_)
 * `Derek Gustafson <https://www.github.com/degustaf>`_
 * `Florian Bruhin <https://www.github.com/The-Compiler>`_

--- a/src/hypothesis/searchstrategy/collections.py
+++ b/src/hypothesis/searchstrategy/collections.py
@@ -104,7 +104,7 @@ class ListStrategy(SearchStrategy):
 
         stopping_value = 1 - 1.0 / (1 + self.average_length)
         result = []
-        while True:
+        while len(result) < self.max_size:
             data.start_example()
             more = cu.biased_coin(data, stopping_value)
             if not more:
@@ -116,8 +116,6 @@ class ListStrategy(SearchStrategy):
             value = data.draw(self.element_strategy)
             data.stop_example()
             result.append(value)
-        if self.max_size < float('inf'):
-            result = result[:self.max_size]
         return result
 
     def __repr__(self):


### PR DESCRIPTION
This kept triggering `too slow` health check failures on my tests and post-change I get a drop from ~18s to ~12s to generate my data.


I tried to run the tests locally, but they keep failing with what look like unrelated errors for python2.6:
```
Traceback (most recent call last):
  File "/home/ccc/g/hypothesis/.tox/py26-full/lib/python2.6/site-packages/_pytest/config.py", line 319, in _importconftest
    mod = conftestpath.pyimport()
  File "/home/ccc/g/hypothesis/.tox/py26-full/lib/python2.6/site-packages/py/_path/local.py", line 650, in pyimport
    __import__(modname)
  File "/home/ccc/g/hypothesis/tests/conftest.py", line 25, in <module>
    run()
  File "/home/ccc/g/hypothesis/tests/common/setup.py", line 33, in run
    charmap()
  File "/home/ccc/g/hypothesis/.tox/py26-full/lib/python2.6/site-packages/hypothesis/internal/charmap.py", line 56, in charmap
    with gzip.GzipFile(f, 'wb', mtime=1) as o:
TypeError: __init__() got an unexpected keyword argument 'mtime'
ERROR: could not load /home/ccc/g/hypothesis/tests/conftest.py

ERROR: InvocationError: '/bin/bash scripts/basic-test.sh'
```

If I remove the `mtime` arg:

```
Traceback (most recent call last):
  File "/home/ccc/g/hypothesis/.tox/py26-full/lib/python2.6/site-packages/_pytest/config.py", line 319, in _importconftest
    mod = conftestpath.pyimport()
  File "/home/ccc/g/hypothesis/.tox/py26-full/lib/python2.6/site-packages/py/_path/local.py", line 650, in pyimport
    __import__(modname)
  File "/home/ccc/g/hypothesis/tests/conftest.py", line 25, in <module>
    run()
  File "/home/ccc/g/hypothesis/tests/common/setup.py", line 33, in run
    charmap()
  File "/home/ccc/g/hypothesis/.tox/py26-full/lib/python2.6/site-packages/hypothesis/internal/charmap.py", line 56, in charmap
    with gzip.GzipFile(f, 'wb') as o:
AttributeError: GzipFile instance has no attribute '__exit__'
```

They succeed on python3 though: `1157 passed, 4 skipped, 5 pytest-warnings in 231.56 seconds`