### PR TITLE
doc: remove DefinitelyNoSuchExample error from example text

### DIFF
--- a/docs/details.rst
+++ b/docs/details.rst
@@ -418,7 +418,7 @@ example to a condition that is always false it will raise an error:
   >>> find(booleans(), lambda x: False)
   Traceback (most recent call last):
   ...
-  hypothesis.errors.DefinitelyNoSuchExample: No examples of condition lambda x: <unknown> (all 2 considered)
+  hypothesis.errors.NoSuchExample: No examples of condition lambda x: <unknown>
 
 
 


### PR DESCRIPTION
It is no longer raised, since: 2d48fcdb9d123871493fb8ba98088f42b974e344.

Signed-off-by: mulhern <amulhern@redhat.com>