### PR TITLE
Use Django field definitions to ensure valid strategies

### DIFF
--- a/src/hypothesis/extra/django/models.py
+++ b/src/hypothesis/extra/django/models.py
@@ -17,10 +17,11 @@
 
 from __future__ import division, print_function, absolute_import
 
-import django.db.models as dm
 from decimal import Decimal
-from django.core.exceptions import ValidationError
+
+import django.db.models as dm
 from django.db import IntegrityError
+from django.core.exceptions import ValidationError
 
 import hypothesis.strategies as st
 import hypothesis.extra.fakefactory as ff
@@ -81,10 +82,8 @@ class UnmappedFieldError(Exception):
 
 
 def validator_to_filter(f):
-    """
-    Converts the field run_validators method to something suitable for use in
-    filter.
-    """
+    """Converts the field run_validators method to something suitable for use
+    in filter."""
 
     def validate(value):
         try:

--- a/tests/django/toystore/models.py
+++ b/tests/django/toystore/models.py
@@ -18,6 +18,7 @@
 from __future__ import division, print_function, absolute_import
 
 from django.db import models
+from django.core.exceptions import ValidationError
 
 
 class Company(models.Model):
@@ -73,13 +74,15 @@ class LoopB(models.Model):
     a = models.ForeignKey(u'LoopA', null=True)
 
 
-class ManyInts(models.Model):
+class ManyNumerics(models.Model):
     i1 = models.IntegerField()
     i2 = models.SmallIntegerField()
     i3 = models.BigIntegerField()
 
     p1 = models.PositiveIntegerField()
     p2 = models.PositiveSmallIntegerField()
+
+    d = models.DecimalField(decimal_places=2, max_digits=5)
 
 
 class CustomishDefault(models.Model):
@@ -96,3 +99,27 @@ class MandatoryComputed(models.Model):
         cname = kw[u'name'] + u'_company'
         kw[u'company'] = Company.objects.create(name=cname)
         super(MandatoryComputed, self).__init__(**kw)
+
+
+def validate_even(value):
+    if value % 2 != 0:
+        raise ValidationError('')
+
+
+class RestrictedFields(models.Model):
+    text_field_4 = models.TextField(max_length=4, blank=True)
+    char_field_4 = models.CharField(max_length=4, blank=True)
+    choice_field_text = models.TextField(
+        choices=(('foo', 'Foo'), ('bar', 'Bar'))
+    )
+    choice_field_int = models.IntegerField(
+        choices=((1, 'First'), (2, 'Second'))
+    )
+    null_choice_field_int = models.IntegerField(
+        choices=((1, 'First'), (2, 'Second')),
+        null=True, blank=True
+    )
+    even_number_field = models.IntegerField(
+        validators=[validate_even]
+    )
+    non_blank_text_field = models.TextField(blank=False)

--- a/tests/django/toystore/test_given_models.py
+++ b/tests/django/toystore/test_given_models.py
@@ -22,8 +22,8 @@ from hypothesis.errors import InvalidArgument
 from hypothesis.strategies import just, lists
 from hypothesis.extra.django import TestCase, TransactionTestCase
 from tests.django.toystore.models import Store, Company, Customer, \
-    ManyNumerics, SelfLoop, Customish, CustomishField, CouldBeCharming, \
-    CustomishDefault, MandatoryComputed, RestrictedFields
+    SelfLoop, Customish, ManyNumerics, CustomishField, CouldBeCharming, \
+    CustomishDefault, RestrictedFields, MandatoryComputed
 from hypothesis.extra.django.models import models, default_value, \
     add_default_field_mapping
 
@@ -105,6 +105,7 @@ class TestsNeedingRollback(TransactionTestCase):
 
 
 class TestRestrictedFields(TestCase):
+
     @given(models(RestrictedFields))
     def test_constructs_valid_instance(self, instance):
         self.assertTrue(isinstance(instance, RestrictedFields))


### PR DESCRIPTION
This pull request updates the `hypothesis.extras.django.models.models` strategy for building Django model instances from a model class.

## Motivation

Duplicating information from the field definitions into the construction of a strategy is tedious and makes it harder to start using `hypothesis` in a pre-existing Django application.

My goal was that `models(MyModel).example().full_clean()` should succeed to the extent possible.

## Changes
- The [`max_length`](https://docs.djangoproject.com/en/1.9/ref/models/fields/#django.db.models.CharField.max_length), [`blank`](https://docs.djangoproject.com/en/1.9/ref/models/fields/#blank) and [`choices`](https://docs.djangoproject.com/en/1.9/ref/models/fields/#choices) kwargs are now respected.
- Add support for `DecimalField`. This uses a custom `decimal` strategy which respects [the `max_digits` and `decimal_places` kwargs.](https://docs.djangoproject.com/en/1.9/ref/models/fields/#django.db.models.DecimalField.max_digits) I used a custom strategy since the currently existing strategy was difficult to adapt for the format Django expects, and many of its virtues (like including nan and inf are invalid according to Django's validators).
- If a field includes validators, the list of validators are used to filter the field strategy.

## Testing
I added model fields which exhibited all of the above failings, and a test that model creation on a model with many validations on its fields should have `.full_clean()` succeed. The django17-django19 tests now pass.  

I also looked through the `django.rst` documentation, and I think everything in it is still valid. I don't think new documentation is required.

## Thanks for all your hard work on this library!