### PR TITLE
Add extra tests for utils.size.clamp and fix bug

### DIFF
--- a/src/hypothesis/utils/size.py
+++ b/src/hypothesis/utils/size.py
@@ -19,6 +19,9 @@ from __future__ import division, print_function, absolute_import
 
 
 def clamp(lower, value, upper):
+    if (lower is not None) and (upper is not None) and (lower > upper):
+        raise ValueError("Cannot clamp with lower > upper: %r > %r" %
+                         (lower, upper))
     if lower is not None:
         value = max(lower, value)
     if upper is not None:

--- a/tests/cover/test_sizes.py
+++ b/tests/cover/test_sizes.py
@@ -17,7 +17,10 @@
 
 from __future__ import division, print_function, absolute_import
 
+from hypothesis import assume, given
+from hypothesis.strategies import integers
 from hypothesis.utils.size import clamp
+import pytest
 
 
 def test_clamp():
@@ -25,3 +28,22 @@ def test_clamp():
     assert clamp(None, 10, 1) == 1
     assert clamp(1, 0, 1) == 1
     assert clamp(1, 0, None) == 1
+
+
+@given(value=integers(), bound=integers())
+def test_one_sided_clamp(value, bound):
+    assert clamp(lower=None, value=value, upper=bound) <= bound
+    assert clamp(lower=bound, value=value, upper=None) >= bound
+
+
+@given(value=integers(), lower=integers(), upper=integers())
+def test_two_sided_clamp(value, lower, upper):
+    assume(lower <= upper)
+    assert lower <= clamp(lower, value, upper) <= upper
+
+
+@given(value=integers(), lower=integers(), upper=integers())
+def test_invalid_clamp_is_error(value, lower, upper):
+    assume(lower > upper)
+    with pytest.raises(ValueError):
+        clamp(lower, value, upper)


### PR DESCRIPTION
Previously it was possible to clamp in a range with lower > upper, which doesn't make sense.  Throw a ValueError if we try to do that.

Also, there's this neat-o testing library called Hypothesis.  Add some tests using it for the `clamp()` function.