### PR TITLE
Fixed int_from_bytes under Python 2

### DIFF
--- a/src/hypothesis/internal/compat.py
+++ b/src/hypothesis/internal/compat.py
@@ -162,7 +162,7 @@ else:
         i = 0
         while i + 4 <= len(data):
             result <<= 32
-            result |= struct.unpack('>I', unpackable_data[i:i + 4])[0]
+            result |= struct.unpack('>I', str(unpackable_data[i:i + 4]))[0]
             i += 4
         while i < len(data):
             result <<= 8


### PR DESCRIPTION
Running `int_from_bytes` under python 2.7 currently causes a `struct.error` to be raised with the message "`unpack requires a string argument of length 4`" from `src/hypothesis/internal/compat:165`. This is because the second argument to `struct.unpack` should be a string instead of a `bytesarray`. This pull request fixes that.

I discovered this problem by having a test wrapped in a `@given(floats(min_value=-1.0, max_value=1.0))`, which was raising the exception.