### PR TITLE
Avoid using str() on a bytes object on Python 3

### DIFF
--- a/src/hypothesis/database.py
+++ b/src/hypothesis/database.py
@@ -240,7 +240,11 @@ class DirectoryBasedExampleDatabase(ExampleDatabase):
     def save(self, key, value):
         path = self._value_path(key, value)
         if not os.path.exists(path):
-            tmpname = path + '.' + str(binascii.hexlify(os.urandom(16)))
+            suffix = binascii.hexlify(os.urandom(16))
+            if not isinstance(suffix, str):  # pragma: no branch
+                # On Python 3, binascii.hexlify returns bytes
+                suffix = suffix.decode('ascii')
+            tmpname = path + '.' + suffix
             with open(tmpname, 'wb') as o:
                 o.write(value)
             try:


### PR DESCRIPTION
Otherwise, when running tests using hypothesis with Python's [-b/-bb option](https://docs.python.org/3/using/cmdline.html#cmdoption-b), we'd get a warning/error:

```
hypothesis/database.py:243: in save
    tmpname = path + '.' + str(binascii.hexlify(os.urandom(16)))
E   BytesWarning: str() on a bytes instance
```

Not sure how to best test this, I just added `-bb` to the `brief` environment locally. Maybe a new tox environment, similar to the `unicode` one? Or add `-bb` to the full testsuite on Python 3?