### PR TITLE
Remove rendundant -brief testenv from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -27,13 +27,6 @@ commands =
     custom: python -m pytest {posargs}
     benchmark: python -m pytest benchmarks
 
-[testenv:py{26,27,33,34,35,py}-brief]
-deps=
-  pytest==2.8.2
-  flaky
-commands=
-    python -m pytest tests/cover/
-
 [testenv:oldpy27]
 basepython=python2.7.3
 deps=


### PR DESCRIPTION
This is already handled by the "brief:" conditional in [testenv].