### PR TITLE
Use option group in py.test plugin

### DIFF
--- a/src/hypothesis/extra/pytestplugin.py
+++ b/src/hypothesis/extra/pytestplugin.py
@@ -43,7 +43,8 @@ if PYTEST_VERSION >= (2, 7, 0):
             self.results.append(msg)
 
     def pytest_addoption(parser):
-        parser.addoption(
+        group = parser.getgroup('hypothesis', 'Hypothesis')
+        group.addoption(
             LOAD_PROFILE_OPTION,
             action='store',
             help='Load in a registered hypothesis.settings profile'


### PR DESCRIPTION
This makes the flags show under the hypothesis label rather than
`custom flags`