### PR TITLE
Bump supported fake-factory version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ assert __version__ is not None
 
 extras = {
     'datetime':  ["pytz"],
-    'fakefactory': ["fake-factory>=0.5.2,<=0.5.3"],
+    'fakefactory': ["fake-factory>=0.6.0"],
     'django': ['pytz', 'django>=1.7'],
     'numpy': ['numpy>=1.9.0'],
     'pytest': ['pytest>=2.7.0'],


### PR DESCRIPTION
I don't know why fake-factory's version was pinned but I hope the issue is fixed.