### PR TITLE
Ignore non-function pytest items

### DIFF
--- a/src/hypothesis/extra/pytestplugin.py
+++ b/src/hypothesis/extra/pytestplugin.py
@@ -73,7 +73,9 @@ if PYTEST_VERSION >= (2, 7, 0):
 
     @pytest.mark.hookwrapper
     def pytest_runtest_call(item):
-        if not is_hypothesis_test(item.function):
+        if not hasattr(item, 'function'):
+            yield
+        elif not is_hypothesis_test(item.function):
             yield
         else:
             store = StoringReporter(item.config)


### PR DESCRIPTION
Certain py.test plugins create items that don't have a function attribute. The hypothesis plugin can ignore those.

(This affects pytest-pep8 and pytest-pylint in particular)