### PR TITLE
Fixed Sphinx documentation generation of composite strategies

### DIFF
--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -30,7 +30,7 @@ from hypothesis.internal.compat import ArgSpec, text_type, getargspec, \
 from hypothesis.internal.floats import is_negative, float_to_int, \
     int_to_float, count_between_floats
 from hypothesis.utils.conventions import not_set
-from hypothesis.internal.reflection import proxies
+from hypothesis.internal.reflection import proxies, impersonate
 from hypothesis.searchstrategy.reprwrapper import ReprWrapperStrategy
 
 __all__ = [
@@ -894,6 +894,7 @@ def composite(f):
         keywords=argspec.keywords, defaults=argspec.defaults
     )
 
+    @impersonate(f)
     @defines_strategy
     @copy_argspec(f.__name__, new_argspec)
     def accept(*args, **kwargs):

--- a/tests/cover/test_composite.py
+++ b/tests/cover/test_composite.py
@@ -27,6 +27,7 @@ from hypothesis.internal.compat import hrange
 
 @st.composite
 def badly_draw_lists(draw, m=0):
+    """This is my docstring."""
     length = draw(st.integers(m, m + 10))
     return [
         draw(st.integers()) for _ in hrange(length)
@@ -95,3 +96,11 @@ def test_composite_of_lists():
         return draw(st.integers()) + draw(st.integers())
 
     assert find(st.lists(f()), lambda x: len(x) >= 10) == [0] * 10
+
+
+def test_composite_comes_from_wrapped_functions_module():
+    assert badly_draw_lists.__module__ == __name__
+
+
+def test_composite_has_wrapped_functions_documentation():
+    assert badly_draw_lists.__doc__ == 'This is my docstring.'


### PR DESCRIPTION
Currently a function wrapped in the `hypothesis.strategies.composite` decorator will lose its docstring. Sphinx is also unable to link the function to it's source code (via the sphinx.ext.viewcode extension) in the html documentation it generates.

This pull request lets the the wrapped function keep the docstring and module location from the original function.
