### PR TITLE
Pin the version of uncompyle6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,6 @@ os:
     - osx
     - linux
 
-cache:
-    apt: true
-    directories:
-        - $HOME/.runtimes
-        - $HOME/.venv
-        - $HOME/wheelhouse
-
 env:
     global:
         - BUILD_RUNTIMES=$HOME/.runtimes

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ cache:
     directories:
         - $HOME/.runtimes
         - $HOME/.venv
-        - $HOME/.cache/pip
         - $HOME/wheelhouse
 
 env:

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ extras['django'].extend(extras['fakefactory'])
 extras[":python_version == '2.7'"] = ['enum34']
 extras[":python_version == '3.3'"] = ['enum34']
 
-install_requires = ['uncompyle6']
+install_requires = ['uncompyle6<=2.9.2']
 
 if sys.version_info[0] < 3:
     install_requires.append('enum34')

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ extras['django'].extend(extras['fakefactory'])
 extras[":python_version == '2.7'"] = ['enum34']
 extras[":python_version == '3.3'"] = ['enum34']
 
-install_requires = ['uncompyle6<=2.9.2']
+install_requires = ['uncompyle6<=2.9.1']
 
 if sys.version_info[0] < 3:
     install_requires.append('enum34')

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ extras[":python_version == '3.3'"] = ['enum34']
 
 install_requires = ['uncompyle6']
 
+
 if sys.version_info[0] < 3:
     install_requires.append('enum34')
 

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ extras['django'].extend(extras['fakefactory'])
 extras[":python_version == '2.7'"] = ['enum34']
 extras[":python_version == '3.3'"] = ['enum34']
 
-install_requires = ['uncompyle6<2.9']
+install_requires = ['xdis<=3.1.0', 'uncompyle6']
 
 if sys.version_info[0] < 3:
     install_requires.append('enum34')

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ extras['django'].extend(extras['fakefactory'])
 extras[":python_version == '2.7'"] = ['enum34']
 extras[":python_version == '3.3'"] = ['enum34']
 
-install_requires = ['xdis<=3.1.0', 'uncompyle6']
+install_requires = ['xdis<=3.1.0', 'uncompyle6<=2.9.2']
 
 if sys.version_info[0] < 3:
     install_requires.append('enum34')

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ extras['django'].extend(extras['fakefactory'])
 extras[":python_version == '2.7'"] = ['enum34']
 extras[":python_version == '3.3'"] = ['enum34']
 
-install_requires = ['xdis<=3.1.0', 'uncompyle6<=2.9.2']
+install_requires = ['uncompyle6']
 
 if sys.version_info[0] < 3:
     install_requires.append('enum34')

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ extras['django'].extend(extras['fakefactory'])
 extras[":python_version == '2.7'"] = ['enum34']
 extras[":python_version == '3.3'"] = ['enum34']
 
-install_requires = ['uncompyle6<=2.9.1']
+install_requires = ['uncompyle6<=2.9']
 
 if sys.version_info[0] < 3:
     install_requires.append('enum34')

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ extras['django'].extend(extras['fakefactory'])
 extras[":python_version == '2.7'"] = ['enum34']
 extras[":python_version == '3.3'"] = ['enum34']
 
-install_requires = ['uncompyle6<=2.9']
+install_requires = ['uncompyle6<2.9']
 
 if sys.version_info[0] < 3:
     install_requires.append('enum34')


### PR DESCRIPTION
Related to #379 – there was an uncompyle6 version bump to 2.9.3 on October 26, so slightly after the bug started appearing (but timezones, so not sure).

I don’t think this should be merged yet, but opening this PR will trigger a bunch of runs against the Hypothesis CI with the pinned version. Let’s see if the issue still repros: if not, we’ve found the bug, if yes, I’ll keep cranking down the version.
