### PR TITLE
[WIP] Flatten branches when using one_of()

### DIFF
--- a/src/hypothesis/searchstrategy/deferred.py
+++ b/src/hypothesis/searchstrategy/deferred.py
@@ -103,3 +103,7 @@ class DeferredStrategy(SearchStrategy):
 
     def do_draw(self, data):
         return data.draw(self.wrapped_strategy)
+
+    # @property
+    # def branches(self):
+    #     return self.wrapped_strategy.branches

--- a/src/hypothesis/searchstrategy/flatmapped.py
+++ b/src/hypothesis/searchstrategy/flatmapped.py
@@ -42,3 +42,7 @@ class FlatMapStrategy(SearchStrategy):
         source = data.draw(self.flatmapped_strategy)
         data.mark_bind()
         return data.draw(self.expand(source))
+
+    @property
+    def branches(self):
+        return self.flatmapped_strategy.branches

--- a/src/hypothesis/searchstrategy/strategies.py
+++ b/src/hypothesis/searchstrategy/strategies.py
@@ -157,6 +157,10 @@ class SearchStrategy(object):
             strategy=self,
         )
 
+    @property
+    def branches(self):
+        return [self]
+
     def __or__(self, other):
         """Return a strategy which produces values by randomly drawing from one
         of this strategy or the other strategy.
@@ -227,6 +231,10 @@ class OneOfStrategy(SearchStrategy):
         for e in self.element_strategies:
             e.validate()
 
+    @property
+    def branches(self):
+        return self.element_strategies
+
 
 class MappedSearchStrategy(SearchStrategy):
 
@@ -270,6 +278,14 @@ class MappedSearchStrategy(SearchStrategy):
                 if data.index == i:
                     raise
         reject()
+
+    @property
+    def branches(self):
+        branches = [
+            MappedSearchStrategy(pack=self.pack, strategy=strategy)
+            for strategy in self.mapped_strategy.branches
+        ]
+        return branches
 
 
 class FilteredStrategy(SearchStrategy):

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -174,16 +174,18 @@ def one_of(*args):
         except TypeError:
             pass
 
+    strategies = []
     for arg in args:
         check_strategy(arg)
-    args = [a for a in args if not a.is_empty]
+        if not arg.is_empty:
+            strategies.extend([s for s in arg.branches if not s.is_empty])
 
-    if not args:
+    if not strategies:
         return nothing()
-    if len(args) == 1:
-        return args[0]
+    if len(strategies) == 1:
+        return strategies[0]
     from hypothesis.searchstrategy.strategies import OneOfStrategy
-    return OneOfStrategy(args)
+    return OneOfStrategy(strategies)
 
 
 @cacheable

--- a/tests/nocover/test_statistical_distribution.py
+++ b/tests/nocover/test_statistical_distribution.py
@@ -453,3 +453,36 @@ test_one_of_flattens_branches_5 = define_test(
 test_one_of_flattens_branches_8 = define_test(
     one_of_nested_strategy, 0.1, lambda x: x == 8,
 )
+
+# And now we test interactions with map().  The full set of values this
+# test produces is {1, 4, 6, 16, 20, 24, 28, 32}.  Again, we expect that
+# each value should be produce in roughly equal measure.
+double = lambda x: x * 2
+one_of_nested_strategy_with_map = one_of(
+    just(1),
+    one_of(
+        (just(2) | just(3)).map(double),
+        one_of(
+            (just(4) | just(5)).map(double),
+            one_of(
+                (just(6) | just(7) | just(8)).map(double)
+            )
+        ).map(double)
+    )
+)
+
+test_one_of_flattens_mapped_branches_1 = define_test(
+    one_of_nested_strategy_with_map, 0.1, lambda x: x == 1,
+)
+
+test_one_of_flattens_mapped_branches_6 = define_test(
+    one_of_nested_strategy_with_map, 0.1, lambda x: x == 6,
+)
+
+test_one_of_flattens_mapped_branches_20 = define_test(
+    one_of_nested_strategy_with_map, 0.1, lambda x: x == 20,
+)
+
+test_one_of_flattens_mapped_branches_32 = define_test(
+    one_of_nested_strategy_with_map, 0.1, lambda x: x == 32,
+)

--- a/tests/nocover/test_statistical_distribution.py
+++ b/tests/nocover/test_statistical_distribution.py
@@ -39,7 +39,7 @@ import hypothesis.internal.reflection as reflection
 from hypothesis import settings as Settings
 from hypothesis.errors import UnsatisfiedAssumption
 from hypothesis.strategies import just, sets, text, lists, floats, \
-    tuples, booleans, integers, sampled_from
+    one_of, tuples, booleans, integers, sampled_from
 from hypothesis.internal.compat import hrange
 from hypothesis.internal.conjecture.engine import \
     TestRunner as ConTestRunner
@@ -415,4 +415,41 @@ test_integers_are_sometimes_zero = define_test(
 
 test_integers_are_often_small = define_test(
     integers(), 0.2, lambda x: abs(x) <= 100
+)
+
+# This series of tests checks that the one_of() strategy flattens branches
+# correctly.  In this highly nested strategy, we expected that any one
+# of the eight outcomes could occur with equal probability: 1/8 = 0.125.
+# We check this is the case for values at different levels of nesting.
+one_of_nested_strategy = one_of(
+    just(1),
+    one_of(
+        just(2),
+        just(3),
+        one_of(
+            just(4),
+            just(5),
+            one_of(
+                just(6),
+                just(7),
+                just(8)
+            )
+        )
+    )
+)
+
+test_one_of_flattens_branches_1 = define_test(
+    one_of_nested_strategy, 0.1, lambda x: x == 1,
+)
+
+test_one_of_flattens_branches_3 = define_test(
+    one_of_nested_strategy, 0.1, lambda x: x == 3,
+)
+
+test_one_of_flattens_branches_5 = define_test(
+    one_of_nested_strategy, 0.1, lambda x: x == 3,
+)
+
+test_one_of_flattens_branches_8 = define_test(
+    one_of_nested_strategy, 0.1, lambda x: x == 8,
 )


### PR DESCRIPTION
There’s probably a subtlety here that I’m missing, but let’s try this anyway.

When we get the arguments to `one_of()`, look through them to see if any of them are `OneOfStrategy`, then unpick the individual strategies from that. Then you have a flat list of strategies, as if you’d supplied them as individual arguments.

---

Here’s a program to show that this patch works as intended:

```python
from collections import Counter
from hypothesis.strategies import one_of, just

strategy = one_of(
    just(1),
    one_of(
        just(2),
        just(3),
        one_of(
            just(4),
            just(5),
            one_of(
                just(6),
                just(7)
            )
        )
    )
)

m = Counter([strategy.example() for _ in range(10000)])
print(m)
```

If you run that without the patch, we see that the inner strategies are heavily penalised in the distribution:

```
Counter({1: 4961, 3: 1676, 2: 1636, 5: 576, 4: 559, 7: 312, 6: 280})
```

Whereas if you run it with the patch, you see we have a much more even distribution:

```
Counter({3: 1496, 5: 1474, 1: 1440, 7: 1413, 4: 1404, 2: 1398, 6: 1375})
```

---

Assuming this approach isn’t completely silly, I’ll need some tests for this. I assume some tests similar to the sample program are the sort of thing we’d want – draw up a large sample, and test that the spread of the distribution isn’t too large. (And if I was more awake, I’d remember the appropriate bit of statistics, but I don’t.)