### PR TITLE
Remove an unused function from test_pretty_repr

### DIFF
--- a/tests/nocover/test_pretty_repr.py
+++ b/tests/nocover/test_pretty_repr.py
@@ -41,10 +41,6 @@ fns = [
 ]
 
 
-def return_args(*args, **kwargs):
-    return args, kwargs
-
-
 def builds_ignoring_invalid(target, *args, **kwargs):
     def splat(value):
         try:


### PR DESCRIPTION
This function doesn’t appear anywhere else in the codebase; let’s get rid of it.