### PR TITLE
Add new example for test_pretty_repr

### DIFF
--- a/tests/nocover/test_pretty_repr.py
+++ b/tests/nocover/test_pretty_repr.py
@@ -17,8 +17,10 @@
 
 from __future__ import division, print_function, absolute_import
 
+from decimal import Decimal
+
 import hypothesis.strategies as st
-from hypothesis import given, settings
+from hypothesis import example, given, settings
 from hypothesis.errors import InvalidArgument
 from hypothesis.control import reject
 from hypothesis.internal.compat import OrderedDict
@@ -112,6 +114,10 @@ strategy_globals['baz'] = baz
 
 @given(Strategies)
 @settings(max_examples=2000)
+@example((
+    st.floats().map(st.float_to_decimal) |
+    st.fractions().map(lambda f: Decimal(f.numerator) / f.denominator)
+))
 def test_repr_evals_to_thing_with_same_repr(strategy):
     r = repr(strategy)
     via_eval = eval(r, strategy_globals)


### PR DESCRIPTION
This is an example spotted on Travis while testing #383. This test will definitely fail, because it represents a bug in Hypothesis. This pull request tracks getting this repr to work correctly after you’ve `eval()`'d it once.

This is also going to (probably) block merging #383 until we get it fixed, because now the CI has noticed it, it’s not going to let that branch pass until we fix this.