### PR TITLE
Use pytest __tracebackhide__ for better error output under pytest

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -22,6 +22,13 @@ You should generally assume that an API is internal unless you have specific
 information to the contrary.
 
 -------------------
+3.11.1 - 2017-05-28
+-------------------
+
+This is a minor ergonomics release.  Tracebacks shown by pytest no longer
+include Hypothesis internals for test functions decorated with ``@given``.
+
+-------------------
 3.11.0 - 2017-05-23
 -------------------
 

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -245,6 +245,9 @@ def execute_explicit_examples(
 
 
 def fail_health_check(settings, message, label):
+    # Tell pytest to omit the body of this function from tracebacks
+    # http://doc.pytest.org/en/latest/example/simple.html#writing-well-integrated-assertion-helpers
+    __tracebackhide__ = True
     if label in settings.suppress_health_check:
         return
     message += (
@@ -259,6 +262,8 @@ def fail_health_check(settings, message, label):
 
 
 def perform_health_checks(random, settings, test_runner, search_strategy):
+    # Tell pytest to omit the body of this function from tracebacks
+    __tracebackhide__ = True
     if not settings.perform_health_check:
         return
     if not Settings.default.perform_health_check:
@@ -471,6 +476,8 @@ class StateForActualGivenExecution(object):
             data.mark_interesting()
 
     def run(self):
+        # Tell pytest to omit the body of this function from tracebacks
+        __tracebackhide__ = True
         database_key = str_to_bytes(fully_qualified_name(self.test))
         start_time = time.time()
         runner = ConjectureRunner(
@@ -607,6 +614,9 @@ def given(*given_arguments, **given_kwargs):
             test.__name__, test.__doc__, argspec
         )
         def wrapped_test(*arguments, **kwargs):
+            # Tell pytest to omit the body of this function from tracebacks
+            __tracebackhide__ = True
+
             settings = wrapped_test._hypothesis_internal_use_settings
 
             random = get_random_for_wrapped_test(test, wrapped_test)

--- a/src/hypothesis/version.py
+++ b/src/hypothesis/version.py
@@ -17,5 +17,5 @@
 
 from __future__ import division, print_function, absolute_import
 
-__version_info__ = (3, 11, 0)
+__version_info__ = (3, 11, 1)
 __version__ = '.'.join(map(str, __version_info__))


### PR DESCRIPTION
Timeouts and health check failures currently generate large and
unhelpful verbose failure messages. Using tracebackhide prevents our
internal helpers from being shown in the detailed traceback view.

See http://doc.pytest.org/en/latest/example/simple.html#writing-well-integrated-assertion-helpers