### PR TITLE
Update docs for `buffer_size` setting

### DIFF
--- a/docs/extras.rst
+++ b/docs/extras.rst
@@ -236,3 +236,7 @@ It lives in the ``hypothesis.extra.numpy`` package.
       array([-2], dtype=int8)
       >>> rla.example()
       array([ 7, -6, -2], dtype=int8)
+
+**Note**: To generate large arrays/matrices, or even medium-sized matrices that
+have 3 or more dimensions, it is necessary to increase the ``buffer_size``
+setting to be greater than it's default of ``8192``.

--- a/docs/extras.rst
+++ b/docs/extras.rst
@@ -238,5 +238,6 @@ It lives in the ``hypothesis.extra.numpy`` package.
       array([ 7, -6, -2], dtype=int8)
 
 **Note**: To generate large arrays/matrices, or even medium-sized matrices that
-have 3 or more dimensions, it is necessary to increase the ``buffer_size``
-setting to be greater than it's default of ``8192``.
+have 3 or more dimensions, it's necessary to increase the ``buffer_size``
+setting to be greater than its default of ``8192`` (see the 
+:doc:`Settings documentation <settings>` for details on how to do this).

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -43,7 +43,7 @@ Available settings
 .. autoclass:: settings
     :members: max_examples, max_iterations, min_satisfying_examples,
         max_shrinks, timeout, strict, database_file, stateful_step_count, 
-        database, perform_health_check, suppress_health_check
+        database, perform_health_check, suppress_health_check, buffer_size
 
 .. _verbose-output:
 


### PR DESCRIPTION
The default `buffer_size` doesn't really support modest sized matrices that are greater than 3 dimensions (fails to find an example for shape of `(25, 25, 2)`), and the documentation/error messages are lacking in that particular area (it took quite a bit of digging to figure out that that was the root problem).  This PR updates the documentation to make that a little bit more clear, and highlight the fact that `buffer_size` is a settings option. 