### PR TITLE
Add install instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,8 @@ Quick Start/Installation
 ------------------------
 If you just want to get started:
 
-.. code-block:: sh
+.. code-block::
+
   pip install hypothesis
 
 

--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,15 @@ Hypothesis is extremely practical and advances the state of the art of
 unit testing by some way. It's easy to use, stable, and powerful. If
 you're not using Hypothesis to test your project then you're missing out.
 
+------------------------
+Quick Start/Installation
+------------------------
+If you just want to get started:
+
+.. code-block:: sh
+pip install hypothesis
+.. code-block::
+
 -----------------
 Links of interest
 -----------------

--- a/README.rst
+++ b/README.rst
@@ -32,8 +32,8 @@ Quick Start/Installation
 If you just want to get started:
 
 .. code-block:: sh
-pip install hypothesis
-.. code-block::
+  pip install hypothesis
+
 
 -----------------
 Links of interest


### PR DESCRIPTION
Having to bury into the 3rd or so page of the docs just to install `hypothesis` is annoying, especially if you just want to be sure that `pip install hypothesis` is the right command.