### PR TITLE
Fix lint failures introduced by flake8 3.2.1

### DIFF
--- a/src/hypothesis/_settings.py
+++ b/src/hypothesis/_settings.py
@@ -74,6 +74,7 @@ class settingsProperty(object):
             'default value: %r' % (getattr(settings.default, self.name),)
         ))
 
+
 default_variable = DynamicVariable(None)
 
 
@@ -493,6 +494,7 @@ class Verbosity(object):
         if isinstance(result, Verbosity):
             return result
         raise InvalidArgument('No such verbosity level %r' % (key,))
+
 
 Verbosity.quiet = Verbosity('quiet', 0)
 Verbosity.normal = Verbosity('normal', 1)

--- a/src/hypothesis/internal/charmap.py
+++ b/src/hypothesis/internal/charmap.py
@@ -33,6 +33,7 @@ def charmap_file():
         'charmap.pickle.gz'
     )
 
+
 _charmap = None
 
 

--- a/src/hypothesis/internal/conjecture/data.py
+++ b/src/hypothesis/internal/conjecture/data.py
@@ -41,6 +41,7 @@ class StopTest(BaseException):
         super(StopTest, self).__init__(repr(testcounter))
         self.testcounter = testcounter
 
+
 global_test_counter = 0
 
 

--- a/src/hypothesis/internal/debug.py
+++ b/src/hypothesis/internal/debug.py
@@ -33,6 +33,7 @@ class Timeout(BaseException):
 class CatchableTimeout(Exception):
     pass
 
+
 try:
     signal.SIGALRM
     # The tests here have a tendency to run away with themselves a it if

--- a/src/hypothesis/stateful.py
+++ b/src/hypothesis/stateful.py
@@ -196,6 +196,7 @@ class GenericStateMachine(object):
         )
         return StateMachineTestCase
 
+
 GenericStateMachine.find_breaking_runner = classmethod(find_breaking_runner)
 
 
@@ -270,6 +271,7 @@ class Bundle(SearchStrategy):
         reference = bundle.pop()
         bundle.insert(integer_range(data, 0, len(bundle)), reference)
         return machine.names_to_values[reference.name]
+
 
 RULE_MARKER = u'hypothesis_stateful_rule'
 PRECONDITION_MARKER = u'hypothesis_stateful_precondition'

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -128,6 +128,7 @@ class Nothing(SearchStrategy):
     def flatmap(self, f):
         return self
 
+
 NOTHING = Nothing()
 
 

--- a/src/hypothesis/tools/mergedbs.py
+++ b/src/hypothesis/tools/mergedbs.py
@@ -131,5 +131,6 @@ def main():
     print(u'%d new entries and %d deletions from merge' % (
         result.inserts, result.deletions))
 
+
 if __name__ == u'__main__':
     main()

--- a/src/hypothesis/vendor/pretty.py
+++ b/src/hypothesis/vendor/pretty.py
@@ -108,6 +108,7 @@ def _safe_getattr(obj, attr, default=None):
     except Exception:
         return default
 
+
 if PY3:
     CUnicodeIO = StringIO
 else:  # pragma: no cover
@@ -495,6 +496,7 @@ class GroupQueue(object):
         except ValueError:
             pass
 
+
 try:
     _baseclass_reprs = (object.__repr__, types.InstanceType.__repr__)
 except AttributeError:  # Python 3
@@ -858,6 +860,7 @@ def _counter_pprint(obj, p, cycle):
             p.text('...')
         elif len(obj):
             p.pretty(dict(obj))
+
 
 for_type_by_name('collections', 'defaultdict', _defaultdict_pprint)
 for_type_by_name('collections', 'OrderedDict', _ordereddict_pprint)

--- a/tests/common/__init__.py
+++ b/tests/common/__init__.py
@@ -54,6 +54,7 @@ ABC = namedtuple('ABC', ('a', 'b', 'c'))
 def abc(x, y, z):
     return builds(ABC, x, y, z)
 
+
 with settings(strict=False):
     standard_types = [
         lists(max_size=0), tuples(), sets(max_size=0), frozensets(max_size=0),

--- a/tests/common/utils.py
+++ b/tests/common/utils.py
@@ -64,4 +64,5 @@ def fails_with(e):
         return inverted_test
     return accepts
 
+
 fails = fails_with(AssertionError)

--- a/tests/cover/test_core.py
+++ b/tests/cover/test_core.py
@@ -78,6 +78,7 @@ def test_can_time_out_in_simplify():
     run_time = finish - start
     assert run_time <= 0.3
 
+
 some_normal_settings = settings()
 
 

--- a/tests/cover/test_database_agreement.py
+++ b/tests/cover/test_database_agreement.py
@@ -75,4 +75,5 @@ class DatabaseComparison(RuleBasedStateMachine):
             d.close()
         shutil.rmtree(self.tempd)
 
+
 TestDBs = DatabaseComparison.TestCase

--- a/tests/cover/test_pretty.py
+++ b/tests/cover/test_pretty.py
@@ -102,6 +102,7 @@ def skip_without(mod):
     except ImportError:
         return pytest.mark.skipif(True, reason='Missing %s' % (mod,))
 
+
 assert_raises = pytest.raises
 
 
@@ -148,6 +149,7 @@ class Dummy2(Dummy1):
 
 class NoModule(object):
     pass
+
 
 NoModule.__module__ = None
 

--- a/tests/cover/test_runner_strategy.py
+++ b/tests/cover/test_runner_strategy.py
@@ -69,4 +69,5 @@ class RunnerStateMachine(GenericStateMachine):
     def execute_step(self, step):
         assert self is step
 
+
 TestState = RunnerStateMachine.TestCase

--- a/tests/cover/test_stateful.py
+++ b/tests/cover/test_stateful.py
@@ -212,6 +212,7 @@ class NotTheLastMachine(RuleBasedStateMachine):
         assert v == self.last
         self.bye_called = True
 
+
 bad_machines = (
     OrderedStateMachine, SetStateMachine, BalancedTrees,
     DepthMachine, RoseTreeStateMachine, NotTheLastMachine,
@@ -354,6 +355,7 @@ class DynamicMachine(RuleBasedStateMachine):
     def test_stuff(x):
         pass
 
+
 DynamicMachine.define_rule(
     targets=(), function=lambda self: 1, arguments={}
 )
@@ -361,6 +363,7 @@ DynamicMachine.define_rule(
 
 class IntAdder(RuleBasedStateMachine):
     pass
+
 
 IntAdder.define_rule(
     targets=(u'ints',), function=lambda self, x: x, arguments={
@@ -478,6 +481,7 @@ class FailsEventually(GenericStateMachine):
     def execute_step(self, _):
         self.counter += 1
         assert self.counter < 10
+
 
 FailsEventually.TestCase.settings = Settings(
     FailsEventually.TestCase.settings, stateful_step_count=5)

--- a/tests/nocover/test_compat.py
+++ b/tests/nocover/test_compat.py
@@ -51,6 +51,7 @@ def test_qualname():
     assert qualname(Foo().bar) == u'Foo.bar'
     assert qualname(qualname) == u'qualname'
 
+
 try:
     from inspect import getargspec
 except ImportError:
@@ -72,6 +73,7 @@ def c(c, d, *ar, **k):
 def d(a1, a2=1, a3=2, a4=None):
     pass
 
+
 if getargspec is not None and HAS_SIGNATURE:
     @pytest.mark.parametrize('f', [
         a, b, c, d
@@ -88,6 +90,7 @@ if getargspec is not None and HAS_SIGNATURE:
 def test_convert_back(bs):
     bs = bytearray(bs)
     assert int_to_bytes(int_from_bytes(bs), len(bs)) == bs
+
 
 bytes8 = st.builds(bytearray, st.binary(min_size=8, max_size=8))
 

--- a/tests/nocover/test_descriptortests.py
+++ b/tests/nocover/test_descriptortests.py
@@ -134,6 +134,7 @@ TestDiverseFlatmap = strategy_test_suite(
 def integers_from(x):
     return integers(min_value=x)
 
+
 TestManyFlatmaps = strategy_test_suite(
     integers()
     .flatmap(integers_from)
@@ -186,6 +187,7 @@ def tight_integer_list(draw):
     x = draw(integers())
     y = draw(integers(min_value=x))
     return draw(lists(integers(min_value=x, max_value=y)))
+
 
 TestComposite = strategy_test_suite(tight_integer_list())
 

--- a/tests/nocover/test_strategy_state.py
+++ b/tests/nocover/test_strategy_state.py
@@ -228,6 +228,7 @@ class HypothesisSpec(RuleBasedStateMachine):
     def repr_is_good(self, strat):
         assert u' at 0x' not in repr(strat)
 
+
 MAIN = __name__ == u'__main__'
 
 TestHypothesis = HypothesisSpec.TestCase

--- a/tests/py3/test_asyncio.py
+++ b/tests/py3/test_asyncio.py
@@ -60,5 +60,6 @@ class TestAsyncio(TestCase):
         yield from asyncio.sleep(0.001)
         assert x
 
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
[flake8 3.2.0](http://flake8.pycqa.org/en/latest/release-notes/3.2.0.html) (and then 3.2.1) were released about a fortnight ago, and the new checks are breaking the tests on #396. This patch gets the lint check passing again.

(Actually, looking at the pycodestyle release notes, it looks like this was an existing check that was previously broken. Oh well, same effect on us.)