### PR TITLE
Improve shrinking of code using flatmap/composite

### DIFF
--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -480,24 +480,32 @@ class TestRunner(object):
                 )
                 i += 1
 
-            i = 0
-            alternatives = None
-            while i < len(self.last_data.intervals):
-                if alternatives is None:
-                    alternatives = sorted(set(
-                        self.last_data.buffer[u:v]
-                        for u, v in self.last_data.intervals), key=len)
-                u, v = self.last_data.intervals[i]
-                for a in alternatives:
-                    buf = self.last_data.buffer
-                    if (
-                        len(a) < v - u or
-                        (len(a) == (v - u) and a < buf[u:v])
-                    ):
-                        if self.incorporate_new_buffer(buf[:u] + a + buf[v:]):
-                            alternatives = None
-                            break
-                i += 1
+            self.debug('Replacing intervals with simpler intervals')
+
+            interval_counter = -1
+            while interval_counter != self.changed:
+                interval_counter = self.changed
+                i = 0
+                alternatives = None
+                while i < len(self.last_data.intervals):
+                    if alternatives is None:
+                        alternatives = sorted(set(
+                            self.last_data.buffer[u:v]
+                            for u, v in self.last_data.intervals), key=len)
+                    u, v = self.last_data.intervals[i]
+                    for a in alternatives:
+                        buf = self.last_data.buffer
+                        if (
+                            len(a) < v - u or
+                            (len(a) == (v - u) and a < buf[u:v])
+                        ):
+                            if self.incorporate_new_buffer(
+                                buf[:u] + a + buf[v:]
+                            ):
+                                alternatives = None
+                                break
+                    i += 1
+
         self.exit_reason = ExitReason.finished
 
     def event_to_string(self, event):

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -406,13 +406,20 @@ class TestRunner(object):
                     self.last_data.buffer[v:]
                 ):
                     i += 1
-            i = 0
-            while i + 1 < len(self.last_data.buffer):
-                if not self.incorporate_new_buffer(
-                    self.last_data.buffer[:i] +
-                    self.last_data.buffer[i + 1:]
-                ):
-                    i += 1
+
+            if change_counter != self.changed:
+                self.debug('Restarting')
+                continue
+
+            self.debug('Lexicographical minimization of whole buffer')
+            minimize(
+                self.last_data.buffer, self.incorporate_new_buffer,
+                cautious=True
+            )
+
+            if change_counter != self.changed:
+                self.debug('Restarting')
+                continue
 
             self.debug('Replacing blocks with simpler blocks')
             i = 0

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -376,6 +376,8 @@ class TestRunner(object):
 
         while self.changed > change_counter:
             change_counter = self.changed
+
+            self.debug('Random interval deletes')
             failed_deletes = 0
             while self.last_data.intervals and failed_deletes < 10:
                 if self.random.randint(0, 1):
@@ -394,6 +396,8 @@ class TestRunner(object):
                     failed_deletes = 0
                 else:
                     failed_deletes += 1
+
+            self.debug('Structured interval deletes')
             i = 0
             while i < len(self.last_data.intervals):
                 u, v = self.last_data.intervals[i]
@@ -409,6 +413,8 @@ class TestRunner(object):
                     self.last_data.buffer[i + 1:]
                 ):
                     i += 1
+
+            self.debug('Replacing blocks with simpler blocks')
             i = 0
             while i < len(self.last_data.blocks):
                 u, v = self.last_data.blocks[i]
@@ -427,6 +433,7 @@ class TestRunner(object):
                         break
                 i += 1
 
+            self.debug('Simultaneous shrinking of duplicated blocks')
             block_counter = -1
             while block_counter < self.changed:
                 block_counter = self.changed
@@ -453,6 +460,7 @@ class TestRunner(object):
                         self.random
                     )
 
+            self.debug('Shrinking of individual blocks')
             i = 0
             while i < len(self.last_data.blocks):
                 u, v = self.last_data.blocks[i]

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -506,6 +506,37 @@ class TestRunner(object):
                                 break
                     i += 1
 
+            if change_counter != self.changed:
+                self.debug('Restarting')
+                continue
+
+            self.debug('Shuffling suffixes while shrinking %r' % (
+                self.last_data.bind_points,
+            ))
+            b = 0
+            while b < len(self.last_data.bind_points):
+                cutoff = sorted(self.last_data.bind_points)[b]
+
+                def test_value(prefix):
+                    for t in hrange(5):
+                        alphabet = {}
+                        for i, j in self.last_data.blocks[b:]:
+                            alphabet.setdefault(j - i, []).append((i, j))
+                        if t > 0:
+                            for v in alphabet.values():
+                                self.random.shuffle(v)
+                        buf = bytearray(prefix)
+                        for i, j in self.last_data.blocks[b:]:
+                            u, v = alphabet[j - i].pop()
+                            buf.extend(self.last_data.buffer[u:v])
+                        if self.incorporate_new_buffer(hbytes(buf)):
+                            return True
+                    return False
+                minimize(
+                    self.last_data.buffer[:cutoff], test_value, cautious=True
+                )
+                b += 1
+
         self.exit_reason = ExitReason.finished
 
     def event_to_string(self, event):

--- a/src/hypothesis/internal/conjecture/minimizer.py
+++ b/src/hypothesis/internal/conjecture/minimizer.py
@@ -93,13 +93,13 @@ class Minimizer(object):
                     break
 
             for c in sorted(set(self.current), reverse=True):
-                for d in range(c):
+                for d in hrange(c):
                     if self.incorporate(
                         hbytes(d if b == c else b for b in self.current)
                     ):
                         break
 
-            for c in range(max(self.current)):
+            for c in hrange(max(self.current)):
                 k = len(self.current) // 2
                 while k > 0:
                     i = 0

--- a/src/hypothesis/searchstrategy/flatmapped.py
+++ b/src/hypothesis/searchstrategy/flatmapped.py
@@ -40,4 +40,5 @@ class FlatMapStrategy(SearchStrategy):
 
     def do_draw(self, data):
         source = data.draw(self.flatmapped_strategy)
+        data.mark_bind()
         return data.draw(self.expand(source))

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -901,7 +901,15 @@ def composite(f):
         class CompositeStrategy(SearchStrategy):
 
             def do_draw(self, data):
-                return f(data.draw, *args, **kwargs)
+                first_draw = [True]
+
+                def draw(strategy):
+                    if not first_draw[0]:
+                        data.mark_bind()
+                    first_draw[0] = False
+                    return data.draw(strategy)
+
+                return f(draw, *args, **kwargs)
         return CompositeStrategy()
     return accept
 
@@ -1032,6 +1040,7 @@ def data():
             return 'data(...)'
 
         def draw(self, strategy):
+            self.data.mark_bind()
             result = self.data.draw(strategy)
             self.count += 1
             note('Draw %d: %r' % (self.count, result))

--- a/tests/cover/test_flatmap.py
+++ b/tests/cover/test_flatmap.py
@@ -94,3 +94,13 @@ def test_mixed_list_flatmap():
     result = find(s, criterion)
     assert len(result) == 6
     assert set(result) == set([False, u''])
+
+
+@pytest.mark.parametrize('n', range(1, 10))
+def test_can_shrink_through_a_binding(n):
+    bool_lists = integers(0, 100).flatmap(
+        lambda k: lists(booleans(), min_size=k, max_size=k))
+
+    assert find(
+        bool_lists, lambda x: len(list(filter(bool, x))) >= n
+    ) == [True] * n


### PR DESCRIPTION
In existing Hypothesis there is a problem where often code
using these results in examples that don't shrink very well
because shrinking an earlier value results in changes to
the structure of the later value that no longer exhibits
the problematic behaviour.

This change introduces some limited ability to work past
that by allowing the later structure to be reordered in a
way that gives more flexible possibilities for producing
shrunk examples..

This is primarily focused on cases that use length prefixed
lists and similar concepts (hence the tests focusing on that),
but likely should work more generally.

This branch also contains a number of other improvements to
the Conjecture engine that turned out to be necessary to make
this work well, and one removal of an annoying shrinking pass
that rarely worked in the first place and never worked in the
presence of some of the other improvements that I ended up
making to it.