### PR TITLE
Remove hypothesis.extra.django's dependence on faker

### DIFF
--- a/scripts/basic-test.sh
+++ b/scripts/basic-test.sh
@@ -46,15 +46,16 @@ if [ "$DARWIN" = true ]; then
 fi
 
 # fake-factory doesn't have a correct universal wheel
-pip install --no-use-wheel .[fakefactory]
+pip install --no-use-wheel faker
 $PYTEST tests/fakefactory/
+pip uninstall -y faker
 
 if [ "$(python -c 'import platform; print(platform.python_implementation())')" != "PyPy" ]; then
   if [ "$(python -c 'import sys; print(sys.version_info[:2] <= (2, 6))')" != "True" ] ; then
   if [ "$(python -c 'import sys; print(sys.version_info[0] == 2 or sys.version_info[:2] >= (3, 4))')" == "True" ] ; then
     pip install .[django]
     python -m tests.django.manage test tests.django
-    pip uninstall -y django faker
+    pip uninstall -y django
   fi
   fi
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ extras = {
 }
 
 extras['all'] = sorted(sum(extras.values(), []))
-extras['django'].extend(extras['fakefactory'])
 
 extras[":python_version == '2.7'"] = ['enum34']
 extras[":python_version == '3.3'"] = ['enum34']

--- a/tests/django/toystore/test_email_strategies.py
+++ b/tests/django/toystore/test_email_strategies.py
@@ -1,0 +1,34 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2016 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+from unittest import TestCase
+
+from hypothesis import given
+from hypothesis.extra.django.models import emails, domains
+
+
+class TestBasicValidation(TestCase):
+
+    @given(domains)
+    def test_is_never_bare_tld(self, d):
+        assert '.' in d
+
+    @given(emails)
+    def test_is_valid_email(self, e):
+        assert '@' in e

--- a/tox.ini
+++ b/tox.ini
@@ -73,7 +73,6 @@ commands =
 basepython=python3.4
 commands =
     pip install .[datetime]
-    pip install --no-use-wheel .[fakefactory]
     pip install django>=1.7,<1.7.99
     python -m tests.django.manage test tests.django
 
@@ -82,7 +81,6 @@ commands =
 basepython=python3.4
 commands =
     pip install .[datetime]
-    pip install --no-use-wheel .[fakefactory]
     pip install django>=1.8,<1.8.99
     python -m tests.django.manage test tests.django
 


### PR DESCRIPTION
This creates a small internal use only email strategy that replaced hypothesis.extra.django's use of the faker based email strategy.

The strategy in question is not very good, but it is mostly better than the fake factory based one (the big limitation in comparison is that the email addresses generated only contain ascii, but I think that's probably a feature rather than a bug given handling of unicode emails).

This is partly an experiment. I want to see if people mention the fake factory integration ever again when the Django integration stops needing it. The faker integration is also really slow right now, so moving it out of the critical path for testing Django is a nice bonus.