### PR TITLE
Flatten branches when using `one_of()`

### DIFF
--- a/src/hypothesis/searchstrategy/deferred.py
+++ b/src/hypothesis/searchstrategy/deferred.py
@@ -103,3 +103,7 @@ class DeferredStrategy(SearchStrategy):
 
     def do_draw(self, data):
         return data.draw(self.wrapped_strategy)
+
+    # @property
+    # def branches(self):
+    #     return self.wrapped_strategy.branches

--- a/src/hypothesis/searchstrategy/deferred.py
+++ b/src/hypothesis/searchstrategy/deferred.py
@@ -103,7 +103,3 @@ class DeferredStrategy(SearchStrategy):
 
     def do_draw(self, data):
         return data.draw(self.wrapped_strategy)
-
-    # @property
-    # def branches(self):
-    #     return self.wrapped_strategy.branches

--- a/src/hypothesis/searchstrategy/flatmapped.py
+++ b/src/hypothesis/searchstrategy/flatmapped.py
@@ -42,3 +42,7 @@ class FlatMapStrategy(SearchStrategy):
         source = data.draw(self.flatmapped_strategy)
         data.mark_bind()
         return data.draw(self.expand(source))
+
+    @property
+    def branches(self):
+        return self.flatmapped_strategy.branches

--- a/src/hypothesis/searchstrategy/flatmapped.py
+++ b/src/hypothesis/searchstrategy/flatmapped.py
@@ -45,8 +45,7 @@ class FlatMapStrategy(SearchStrategy):
 
     @property
     def branches(self):
-        branches = [
+        return [
             FlatMapStrategy(strategy=strategy, expand=self.expand)
             for strategy in self.flatmapped_strategy.branches
         ]
-        return branches

--- a/src/hypothesis/searchstrategy/flatmapped.py
+++ b/src/hypothesis/searchstrategy/flatmapped.py
@@ -45,4 +45,8 @@ class FlatMapStrategy(SearchStrategy):
 
     @property
     def branches(self):
-        return self.flatmapped_strategy.branches
+        branches = [
+            FlatMapStrategy(strategy=strategy, expand=self.expand)
+            for strategy in self.flatmapped_strategy.branches
+        ]
+        return branches

--- a/src/hypothesis/searchstrategy/strategies.py
+++ b/src/hypothesis/searchstrategy/strategies.py
@@ -233,7 +233,10 @@ class OneOfStrategy(SearchStrategy):
 
     @property
     def branches(self):
-        return self.element_strategies
+        if self.bias is None:
+            return self.element_strategies
+        else:
+            return [self]
 
 
 class MappedSearchStrategy(SearchStrategy):

--- a/src/hypothesis/searchstrategy/strategies.py
+++ b/src/hypothesis/searchstrategy/strategies.py
@@ -157,6 +157,10 @@ class SearchStrategy(object):
             strategy=self,
         )
 
+    @property
+    def branches(self):
+        return [self]
+
     def __or__(self, other):
         """Return a strategy which produces values by randomly drawing from one
         of this strategy or the other strategy.
@@ -227,6 +231,10 @@ class OneOfStrategy(SearchStrategy):
         for e in self.element_strategies:
             e.validate()
 
+    @property
+    def branches(self):
+        return self.element_strategies
+
 
 class MappedSearchStrategy(SearchStrategy):
 
@@ -270,6 +278,14 @@ class MappedSearchStrategy(SearchStrategy):
                 if data.index == i:
                     raise
         reject()
+
+    @property
+    def branches(self):
+        branches = [
+            MappedSearchStrategy(pack=self.pack, strategy=strategy)
+            for strategy in self.mapped_strategy.branches
+        ]
+        return branches
 
 
 class FilteredStrategy(SearchStrategy):

--- a/src/hypothesis/searchstrategy/strategies.py
+++ b/src/hypothesis/searchstrategy/strategies.py
@@ -281,11 +281,10 @@ class MappedSearchStrategy(SearchStrategy):
 
     @property
     def branches(self):
-        branches = [
+        return [
             MappedSearchStrategy(pack=self.pack, strategy=strategy)
             for strategy in self.mapped_strategy.branches
         ]
-        return branches
 
 
 class FilteredStrategy(SearchStrategy):

--- a/src/hypothesis/searchstrategy/strategies.py
+++ b/src/hypothesis/searchstrategy/strategies.py
@@ -324,3 +324,11 @@ class FilteredStrategy(SearchStrategy):
             self,
         ))
         data.mark_invalid()
+
+    @property
+    def branches(self):
+        branches = [
+            FilteredStrategy(strategy=strategy, condition=self.condition)
+            for strategy in self.filtered_strategy.branches
+        ]
+        return branches

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -174,16 +174,18 @@ def one_of(*args):
         except TypeError:
             pass
 
+    strategies = []
     for arg in args:
         check_strategy(arg)
-    args = [a for a in args if not a.is_empty]
+        if not arg.is_empty:
+            strategies.extend([s for s in arg.branches if not s.is_empty])
 
-    if not args:
+    if not strategies:
         return nothing()
-    if len(args) == 1:
-        return args[0]
+    if len(strategies) == 1:
+        return strategies[0]
     from hypothesis.searchstrategy.strategies import OneOfStrategy
-    return OneOfStrategy(args)
+    return OneOfStrategy(strategies)
 
 
 @cacheable

--- a/tests/nocover/test_statistical_distribution.py
+++ b/tests/nocover/test_statistical_distribution.py
@@ -417,10 +417,12 @@ test_integers_are_often_small = define_test(
     integers(), 0.2, lambda x: abs(x) <= 100
 )
 
+
 # This series of tests checks that the one_of() strategy flattens branches
-# correctly.  In this highly nested strategy, we expected that any one
-# of the eight outcomes could occur with equal probability: 1/8 = 0.125.
-# We check this is the case for values at different levels of nesting.
+# correctly.  We assert that the probability of any branch is equal
+# (1/8 = 0.125), regardless of how heavily nested it is in the `one_of()`.
+
+# This first strategy chooses an integer between 1 and 8 (inclusive).
 one_of_nested_strategy = one_of(
     just(1),
     one_of(
@@ -454,9 +456,9 @@ test_one_of_flattens_branches_8 = define_test(
     one_of_nested_strategy, 0.1, lambda x: x == 8,
 )
 
-# And now we test interactions with map().  The full set of values this
-# test produces is {1, 4, 6, 16, 20, 24, 28, 32}.  Again, we expect that
-# each value should be produce in roughly equal measure.
+
+# This strategy tests interactions with `map()`.  It generates integers from
+# the set {1, 4, 6, 16, 20, 24, 28, 32}.
 double = lambda x: x * 2
 one_of_nested_strategy_with_map = one_of(
     just(1),
@@ -485,4 +487,46 @@ test_one_of_flattens_mapped_branches_20 = define_test(
 
 test_one_of_flattens_mapped_branches_32 = define_test(
     one_of_nested_strategy_with_map, 0.1, lambda x: x == 32,
+)
+
+
+
+def fixed_list(x, size):
+    return lists(just(x), min_size=size, max_size=size)
+
+# This strategy tests interactions with `flatmap()`.  It generates lists
+# of length 1-8 (inclusive) in which every element is `None`.
+one_of_nested_strategy_with_flatmap = just(None).flatmap(
+    lambda x: one_of(
+        fixed_list(x, size=1),
+        fixed_list(x, size=2),
+        one_of(
+            fixed_list(x, size=3),
+            fixed_list(x, size=4),
+            one_of(
+                fixed_list(x, size=5),
+                fixed_list(x, size=6),
+                one_of(
+                    fixed_list(x, size=7),
+                    fixed_list(x, size=8),
+                )
+            )
+        )
+    )
+)
+
+test_one_of_flattens_flatmapped_branches_1 = define_test(
+    one_of_nested_strategy_with_flatmap, 0.1, lambda x: len(x) == 1,
+)
+
+test_one_of_flattens_flatmapped_branches_3 = define_test(
+    one_of_nested_strategy_with_flatmap, 0.1, lambda x: len(x) == 3,
+)
+
+test_one_of_flattens_flatmapped_branches_5 = define_test(
+    one_of_nested_strategy_with_flatmap, 0.1, lambda x: len(x) == 5,
+)
+
+test_one_of_flattens_flatmapped_branches_7 = define_test(
+    one_of_nested_strategy_with_flatmap, 0.1, lambda x: len(x) == 7,
 )

--- a/tests/nocover/test_statistical_distribution.py
+++ b/tests/nocover/test_statistical_distribution.py
@@ -453,3 +453,36 @@ test_one_of_flattens_branches_5 = define_test(
 test_one_of_flattens_branches_8 = define_test(
     one_of_nested_strategy, 0.1, lambda x: x == 8,
 )
+
+# And now we test interactions with map().  The full set of values this
+# test produces is {1, 4, 6, 16, 20, 24, 28, 32}.  Again, we expect that
+# each value should be produce in roughly equal measure.
+double = lambda x: x * 2
+one_of_nested_strategy_with_map = one_of(
+    just(1),
+    one_of(
+        (just(2) | just(3)).map(double),
+        one_of(
+            (just(4) | just(5)).map(double),
+            one_of(
+                (just(6) | just(7) | just(8)).map(double)
+            )
+        ).map(double)
+    )
+)
+
+test_one_of_flattens_mapped_branches_1 = define_test(
+    one_of_nested_strategy_with_map, 0.1, lambda x: x == 1,
+)
+
+test_one_of_flattens_mapped_branches_6 = define_test(
+    one_of_nested_strategy_with_map, 0.1, lambda x: x == 6,
+)
+
+test_one_of_flattens_mapped_branches_20 = define_test(
+    one_of_nested_strategy_with_map, 0.1, lambda x: x == 20,
+)
+
+test_one_of_flattens_mapped_branches_32 = define_test(
+    one_of_nested_strategy_with_map, 0.1, lambda x: x == 32,
+)

--- a/tests/nocover/test_statistical_distribution.py
+++ b/tests/nocover/test_statistical_distribution.py
@@ -419,7 +419,8 @@ test_integers_are_often_small = define_test(
 
 
 # This series of tests checks that the one_of() strategy flattens branches
-# correctly.  We assert that the probability of any branch is equal
+# correctly.  We assert that the probability of any branch is >= 0.1, compared
+# to a 1/8 = 0.125
 # (1/8 = 0.125), regardless of how heavily nested it is in the `one_of()`.
 
 # This first strategy chooses an integer between 1 and 8 (inclusive).

--- a/tests/nocover/test_statistical_distribution.py
+++ b/tests/nocover/test_statistical_distribution.py
@@ -419,47 +419,52 @@ test_integers_are_often_small = define_test(
 
 
 # This series of tests checks that the one_of() strategy flattens branches
-# correctly.  We assert that the probability of any branch is >= 0.1, compared
-# to a 1/8 = 0.125
-# (1/8 = 0.125), regardless of how heavily nested it is in the `one_of()`.
+# correctly.  We assert that the probability of any branch is >= 0.1,
+# approximately (1/8 = 0.125), regardless of how heavily nested it is in the
+# strategy.
 
-# This first strategy chooses an integer between 1 and 8 (inclusive).
+# This first strategy chooses an integer between 0 and 7 (inclusive).
 one_of_nested_strategy = one_of(
-    just(1),
+    just(0),
     one_of(
+        just(1),
         just(2),
-        just(3),
         one_of(
+            just(3),
             just(4),
-            just(5),
             one_of(
+                just(5),
                 just(6),
-                just(7),
-                just(8)
+                just(7)
             )
         )
     )
 )
 
-test_one_of_flattens_branches_1 = define_test(
-    one_of_nested_strategy, 0.1, lambda x: x == 1,
+for i in range(8):
+    exec('''test_one_of_flattens_branches_%d = define_test(
+        one_of_nested_strategy, 0.1, lambda x: x == %d
+    )''' % (i, i))
+
+
+xor_nested_strategy = (
+    just(0) | (
+        just(1) | just(2) | (
+            just(3) | just(4) | (
+                just(5) | just(6) | just(7)
+            )
+        )
+    )
 )
 
-test_one_of_flattens_branches_3 = define_test(
-    one_of_nested_strategy, 0.1, lambda x: x == 3,
-)
-
-test_one_of_flattens_branches_5 = define_test(
-    one_of_nested_strategy, 0.1, lambda x: x == 3,
-)
-
-test_one_of_flattens_branches_8 = define_test(
-    one_of_nested_strategy, 0.1, lambda x: x == 8,
-)
+for i in range(8):
+    exec('''test_xor_flattens_branches_%d = define_test(
+        xor_nested_strategy, 0.1, lambda x: x == %d
+    )''' % (i, i))
 
 
-# This strategy tests interactions with `map()`.  It generates integers from
-# the set {1, 4, 6, 16, 20, 24, 28, 32}.
+# This strategy tests interactions with `map()`.  They generate integers
+# from the set {1, 4, 6, 16, 20, 24, 28, 32}.
 double = lambda x: x * 2
 one_of_nested_strategy_with_map = one_of(
     just(1),
@@ -474,96 +479,70 @@ one_of_nested_strategy_with_map = one_of(
     )
 )
 
-test_one_of_flattens_mapped_branches_1 = define_test(
-    one_of_nested_strategy_with_map, 0.1, lambda x: x == 1,
-)
-
-test_one_of_flattens_mapped_branches_6 = define_test(
-    one_of_nested_strategy_with_map, 0.1, lambda x: x == 6,
-)
-
-test_one_of_flattens_mapped_branches_20 = define_test(
-    one_of_nested_strategy_with_map, 0.1, lambda x: x == 20,
-)
-
-test_one_of_flattens_mapped_branches_32 = define_test(
-    one_of_nested_strategy_with_map, 0.1, lambda x: x == 32,
-)
-
-
-def fixed_list(x, size):
-    return lists(just(x), min_size=size, max_size=size)
+for i in (1, 4, 6, 16, 20, 24, 28, 32):
+    exec('''test_one_of_flattens_map_branches_%d = define_test(
+        one_of_nested_strategy_with_map, 0.1, lambda x: x == %d
+    )''' % (i, i))
 
 
 # This strategy tests interactions with `flatmap()`.  It generates lists
-# of length 1-8 (inclusive) in which every element is `None`.
+# of length 0-7 (inclusive) in which every element is `None`.
 one_of_nested_strategy_with_flatmap = just(None).flatmap(
     lambda x: one_of(
-        fixed_list(x, size=1),
-        fixed_list(x, size=2),
-        one_of(
-            fixed_list(x, size=3),
-            fixed_list(x, size=4),
-            one_of(
-                fixed_list(x, size=5),
-                fixed_list(x, size=6),
-                one_of(
-                    fixed_list(x, size=7),
-                    fixed_list(x, size=8),
+        just([x] * 0), just([x] * 1), one_of(
+            just([x] * 2), just([x] * 3), one_of(
+                just([x] * 4), just([x] * 5), one_of(
+                    just([x] * 6), just([x] * 7),
                 )
             )
         )
     )
 )
 
-test_one_of_flattens_flatmapped_branches_1 = define_test(
-    one_of_nested_strategy_with_flatmap, 0.1, lambda x: len(x) == 1,
+for i in range(8):
+    exec('''test_one_of_flattens_flatmap_branches_%d = define_test(
+        one_of_nested_strategy_with_flatmap, 0.1, lambda x: len(x) == %d
+    )''' % (i, i))
+
+
+xor_nested_strategy_with_flatmap = just(None).flatmap(
+    lambda x: (
+        just([x] * 0) | just([x] * 1) | (
+            just([x] * 2) | just([x] * 3) | (
+                just([x] * 4) | just([x] * 5) | (
+                    just([x] * 6) | just([x] * 7)
+                )
+            )
+        )
+    )
 )
 
-test_one_of_flattens_flatmapped_branches_3 = define_test(
-    one_of_nested_strategy_with_flatmap, 0.1, lambda x: len(x) == 3,
-)
-
-test_one_of_flattens_flatmapped_branches_5 = define_test(
-    one_of_nested_strategy_with_flatmap, 0.1, lambda x: len(x) == 5,
-)
-
-test_one_of_flattens_flatmapped_branches_7 = define_test(
-    one_of_nested_strategy_with_flatmap, 0.1, lambda x: len(x) == 7,
-)
+for i in range(8):
+    exec('''test_xor_flattens_flatmap_branches_%d = define_test(
+        xor_nested_strategy_with_flatmap, 0.1, lambda x: len(x) == %d
+    )''' % (i, i))
 
 
 # This strategy tests interactions with `filter()`.  It generates the even
-# integers {2, 4, 6, 8} in equal measures.
+# integers {0, 2, 4, 6} in equal measures.
 one_of_nested_strategy_with_filter = one_of(
+    just(0),
     just(1),
-    just(2),
     one_of(
+        just(2),
         just(3),
-        just(4),
         one_of(
+            just(4),
             just(5),
-            just(6),
             one_of(
+                just(6),
                 just(7),
-                just(8),
             )
         )
     )
 ).filter(lambda x: x % 2 == 0)
 
-test_one_of_flattens_filtered_branches_2 = define_test(
-    one_of_nested_strategy_with_filter, 0.25, lambda x: len(x) == 2,
-)
-
-test_one_of_flattens_filtered_branches_4 = define_test(
-    one_of_nested_strategy_with_filter, 0.25, lambda x: len(x) == 4,
-)
-
-test_one_of_flattens_filtered_branches_6 = define_test(
-    one_of_nested_strategy_with_filter, 0.25, lambda x: len(x) == 6,
-)
-
-test_one_of_flattens_filtered_branches_8 = define_test(
-    one_of_nested_strategy_with_filter, 0.25, lambda x: len(x) == 8,
-)
+for i in range(4):
+    exec('''test_one_of_flattens_filter_branches_%d = define_test(
+        one_of_nested_strategy_with_filter, 0.2, lambda x: x == 2 * %d
+    )''' % (i, i))

--- a/tests/nocover/test_statistical_distribution.py
+++ b/tests/nocover/test_statistical_distribution.py
@@ -531,3 +531,39 @@ test_one_of_flattens_flatmapped_branches_5 = define_test(
 test_one_of_flattens_flatmapped_branches_7 = define_test(
     one_of_nested_strategy_with_flatmap, 0.1, lambda x: len(x) == 7,
 )
+
+
+# This strategy tests interactions with `filter()`.  It generates the even
+# integers {2, 4, 6, 8} in equal measures.
+one_of_nested_strategy_with_filter = one_of(
+    just(1),
+    just(2),
+    one_of(
+        just(3),
+        just(4),
+        one_of(
+            just(5),
+            just(6),
+            one_of(
+                just(7),
+                just(8),
+            )
+        )
+    )
+).filter(lambda x: x % 2 == 0)
+
+test_one_of_flattens_filtered_branches_2 = define_test(
+    one_of_nested_strategy_with_filter, 0.25, lambda x: len(x) == 2,
+)
+
+test_one_of_flattens_filtered_branches_4 = define_test(
+    one_of_nested_strategy_with_filter, 0.25, lambda x: len(x) == 4,
+)
+
+test_one_of_flattens_filtered_branches_6 = define_test(
+    one_of_nested_strategy_with_filter, 0.25, lambda x: len(x) == 6,
+)
+
+test_one_of_flattens_filtered_branches_8 = define_test(
+    one_of_nested_strategy_with_filter, 0.25, lambda x: len(x) == 8,
+)

--- a/tests/nocover/test_statistical_distribution.py
+++ b/tests/nocover/test_statistical_distribution.py
@@ -39,7 +39,7 @@ import hypothesis.internal.reflection as reflection
 from hypothesis import settings as Settings
 from hypothesis.errors import UnsatisfiedAssumption
 from hypothesis.strategies import just, sets, text, lists, floats, \
-    tuples, booleans, integers, sampled_from
+    one_of, tuples, booleans, integers, sampled_from
 from hypothesis.internal.compat import hrange
 from hypothesis.internal.conjecture.engine import \
     TestRunner as ConTestRunner
@@ -415,4 +415,41 @@ test_integers_are_sometimes_zero = define_test(
 
 test_integers_are_often_small = define_test(
     integers(), 0.2, lambda x: abs(x) <= 100
+)
+
+# This series of tests checks that the one_of() strategy flattens branches
+# correctly.  In this highly nested strategy, we expected that any one
+# of the eight outcomes could occur with equal probability: 1/8 = 0.125.
+# We check this is the case for values at different levels of nesting.
+one_of_nested_strategy = one_of(
+    just(1),
+    one_of(
+        just(2),
+        just(3),
+        one_of(
+            just(4),
+            just(5),
+            one_of(
+                just(6),
+                just(7),
+                just(8)
+            )
+        )
+    )
+)
+
+test_one_of_flattens_branches_1 = define_test(
+    one_of_nested_strategy, 0.1, lambda x: x == 1,
+)
+
+test_one_of_flattens_branches_3 = define_test(
+    one_of_nested_strategy, 0.1, lambda x: x == 3,
+)
+
+test_one_of_flattens_branches_5 = define_test(
+    one_of_nested_strategy, 0.1, lambda x: x == 3,
+)
+
+test_one_of_flattens_branches_8 = define_test(
+    one_of_nested_strategy, 0.1, lambda x: x == 8,
 )

--- a/tests/nocover/test_statistical_distribution.py
+++ b/tests/nocover/test_statistical_distribution.py
@@ -490,9 +490,9 @@ test_one_of_flattens_mapped_branches_32 = define_test(
 )
 
 
-
 def fixed_list(x, size):
     return lists(just(x), min_size=size, max_size=size)
+
 
 # This strategy tests interactions with `flatmap()`.  It generates lists
 # of length 1-8 (inclusive) in which every element is `None`.


### PR DESCRIPTION
This replaces #383, which was getting a bit unwieldy and which Travis appears to have forgotten about.