### PR TITLE
Rename classes whose name starts with Test

### DIFF
--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -314,8 +314,8 @@ def given(*generator_arguments, **generator_kwargs):
             perform_health_check = settings.perform_health_check
             perform_health_check &= Settings.default.perform_health_check
 
-            from hypothesis.internal.conjecture.data import TestData, Status, \
-                StopTest
+            from hypothesis.internal.conjecture.data import ConjectureData, \
+                Status, StopTest
             if not (
                 Phase.reuse in settings.phases or
                 Phase.generate in settings.phases
@@ -328,7 +328,7 @@ def given(*generator_arguments, **generator_kwargs):
                 # time to calculate any cached data. This prevents the case
                 # where the first draw of the health check takes ages because
                 # of loading unicode data the first time.
-                data = TestData(
+                data = ConjectureData(
                     max_length=settings.buffer_size,
                     draw_bytes=lambda data, n, distribution:
                     distribution(health_check_random, n)
@@ -350,7 +350,7 @@ def given(*generator_arguments, **generator_kwargs):
                     filtered_draws < 50 and overruns < 20
                 ):
                     try:
-                        data = TestData(
+                        data = ConjectureData(
                             max_length=settings.buffer_size,
                             draw_bytes=lambda data, n, distribution:
                             distribution(health_check_random, n)
@@ -463,12 +463,12 @@ def given(*generator_arguments, **generator_kwargs):
                     verbose_report(last_exception[0])
                     data.mark_interesting()
 
-            from hypothesis.internal.conjecture.engine import TestRunner
+            from hypothesis.internal.conjecture.engine import ConjectureRunner
 
             falsifying_example = None
             database_key = str_to_bytes(fully_qualified_name(test))
             start_time = time.time()
-            runner = TestRunner(
+            runner = ConjectureRunner(
                 evaluate_test_data,
                 settings=settings, random=random,
                 database_key=database_key,
@@ -518,7 +518,7 @@ def given(*generator_arguments, **generator_kwargs):
             try:
                 with settings:
                     test_runner(
-                        TestData.for_buffer(falsifying_example),
+                        ConjectureData.for_buffer(falsifying_example),
                         reify_and_execute(
                             search_strategy, test,
                             print_example=True, is_final=True
@@ -546,7 +546,7 @@ def given(*generator_arguments, **generator_kwargs):
 
             try:
                 test_runner(
-                    TestData.for_buffer(falsifying_example),
+                    ConjectureData.for_buffer(falsifying_example),
                     reify_and_execute(
                         search_strategy,
                         test_is_flaky(test, repr_for_last_exception[0]),
@@ -621,11 +621,11 @@ def find(specifier, condition, settings=None, random=None, database_key=None):
                 last_data[0] = data
         if success and not data.frozen:
             data.mark_interesting()
-    from hypothesis.internal.conjecture.engine import TestRunner
-    from hypothesis.internal.conjecture.data import TestData, Status
+    from hypothesis.internal.conjecture.engine import ConjectureRunner
+    from hypothesis.internal.conjecture.data import ConjectureData, Status
 
     start = time.time()
-    runner = TestRunner(
+    runner = ConjectureRunner(
         template_condition, settings=settings, random=random,
         database_key=database_key,
     )
@@ -633,7 +633,7 @@ def find(specifier, condition, settings=None, random=None, database_key=None):
     note_engine_for_statistics(runner)
     run_time = time.time() - start
     if runner.last_data.status == Status.INTERESTING:
-        data = TestData.for_buffer(runner.last_data.buffer)
+        data = ConjectureData.for_buffer(runner.last_data.buffer)
         with BuildContext(data):
             return data.draw(search)
     if runner.valid_examples <= settings.min_satisfying_examples:

--- a/src/hypothesis/errors.py
+++ b/src/hypothesis/errors.py
@@ -175,5 +175,5 @@ warnings.simplefilter('once', HypothesisDeprecationWarning)
 
 class Frozen(HypothesisException):
 
-    """Raised when a mutation method has been called on a TestData object after
-    freeze() has been called."""
+    """Raised when a mutation method has been called on a ConjectureData object
+    after freeze() has been called."""

--- a/src/hypothesis/executors.py
+++ b/src/hypothesis/executors.py
@@ -58,7 +58,7 @@ def default_new_style_executor(data, function):
     return function(data)
 
 
-class TestRunner(object):
+class ConjectureRunner(object):
 
     def hypothesis_execute_example_with_data(self, data, function):
         return function(data)
@@ -67,7 +67,7 @@ class TestRunner(object):
 def new_style_executor(runner):
     if runner is None:
         return default_new_style_executor
-    if isinstance(runner, TestRunner):
+    if isinstance(runner, ConjectureRunner):
         return runner.hypothesis_execute_example_with_data
 
     old_school = executor(runner)

--- a/src/hypothesis/internal/conjecture/data.py
+++ b/src/hypothesis/internal/conjecture/data.py
@@ -46,11 +46,11 @@ class StopTest(BaseException):
 global_test_counter = 0
 
 
-class TestData(object):
+class ConjectureData(object):
 
     @classmethod
     def for_buffer(self, buffer):
-        return TestData(
+        return ConjectureData(
             max_length=len(buffer),
             draw_bytes=lambda data, n, distribution:
             buffer[data.index:data.index + n]
@@ -81,7 +81,7 @@ class TestData(object):
     def __assert_not_frozen(self, name):
         if self.frozen:
             raise Frozen(
-                'Cannot call %s on frozen TestData' % (
+                'Cannot call %s on frozen ConjectureData' % (
                     name,))
 
     @property

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -27,7 +27,8 @@ from hypothesis import Phase
 from hypothesis.reporting import debug_report
 from hypothesis.internal.compat import hbytes, hrange, Counter, \
     text_type, bytes_from_list, to_bytes_sequence, unicode_safe_repr
-from hypothesis.internal.conjecture.data import Status, StopTest, TestData
+from hypothesis.internal.conjecture.data import Status, StopTest, \
+    ConjectureData
 from hypothesis.internal.conjecture.minimizer import minimize
 
 
@@ -44,7 +45,7 @@ class RunIsComplete(Exception):
     pass
 
 
-class TestRunner(object):
+class ConjectureRunner(object):
 
     def __init__(
         self, test_function, settings=None, random=None,
@@ -67,7 +68,7 @@ class TestRunner(object):
         self.events_to_strings = WeakKeyDictionary()
 
     def new_buffer(self):
-        self.last_data = TestData(
+        self.last_data = ConjectureData(
             max_length=self.settings.buffer_size,
             draw_bytes=lambda data, n, distribution:
             distribution(self.random, n)
@@ -172,7 +173,7 @@ class TestRunner(object):
         if sort_key(buffer) >= sort_key(self.last_data.buffer):
             return False
         assert sort_key(buffer) <= sort_key(self.last_data.buffer)
-        data = TestData.for_buffer(buffer)
+        data = ConjectureData.for_buffer(buffer)
         self.test_function(data)
         if self.consider_new_test_data(data):
             self.shrinks += 1
@@ -283,7 +284,7 @@ class TestRunner(object):
                 ):
                     self.exit_reason = ExitReason.max_iterations
                     return
-                data = TestData.for_buffer(existing)
+                data = ConjectureData.for_buffer(existing)
                 self.test_function(data)
                 data.freeze()
                 self.last_data = data
@@ -332,7 +333,7 @@ class TestRunner(object):
                     self.new_buffer()
                     mutator = self._new_mutator()
                 else:
-                    data = TestData(
+                    data = ConjectureData(
                         draw_bytes=mutator,
                         max_length=self.settings.buffer_size
                     )
@@ -366,7 +367,7 @@ class TestRunner(object):
             self.exit_reason = ExitReason.finished
             return
 
-        data = TestData.for_buffer(self.last_data.buffer)
+        data = ConjectureData.for_buffer(self.last_data.buffer)
         self.test_function(data)
         if data.status != Status.INTERESTING:
             self.exit_reason = ExitReason.flaky

--- a/tests/cover/test_conjecture_test_data.py
+++ b/tests/cover/test_conjecture_test_data.py
@@ -22,7 +22,8 @@ import pytest
 from hypothesis import strategies as st
 from hypothesis import given
 from hypothesis.errors import Frozen
-from hypothesis.internal.conjecture.data import Status, StopTest, TestData
+from hypothesis.internal.conjecture.data import Status, StopTest, \
+    ConjectureData
 from hypothesis.searchstrategy.strategies import SearchStrategy
 
 
@@ -32,12 +33,12 @@ def bogus_dist(dist, n):
 
 @given(st.binary())
 def test_buffer_draws_as_self(buf):
-    x = TestData.for_buffer(buf)
+    x = ConjectureData.for_buffer(buf)
     assert x.draw_bytes(len(buf), bogus_dist) == buf
 
 
 def test_cannot_draw_after_freeze():
-    x = TestData.for_buffer(b'hi')
+    x = ConjectureData.for_buffer(b'hi')
     x.draw_bytes(1)
     x.freeze()
     with pytest.raises(Frozen):
@@ -45,7 +46,7 @@ def test_cannot_draw_after_freeze():
 
 
 def test_can_double_freeze():
-    x = TestData.for_buffer(b'hi')
+    x = ConjectureData.for_buffer(b'hi')
     x.freeze()
     assert x.frozen
     x.freeze()
@@ -53,13 +54,13 @@ def test_can_double_freeze():
 
 
 def test_can_draw_zero_bytes():
-    x = TestData.for_buffer(b'')
+    x = ConjectureData.for_buffer(b'')
     for _ in range(10):
         assert x.draw_bytes(0) == b''
 
 
 def test_draw_past_end_sets_overflow():
-    x = TestData.for_buffer(bytes(5))
+    x = ConjectureData.for_buffer(bytes(5))
     with pytest.raises(StopTest) as e:
         x.draw_bytes(6)
     assert e.value.testcounter == x.testcounter
@@ -68,13 +69,13 @@ def test_draw_past_end_sets_overflow():
 
 
 def test_notes_repr():
-    x = TestData.for_buffer(b'')
+    x = ConjectureData.for_buffer(b'')
     x.note(b'hi')
     assert repr(b'hi') in x.output
 
 
 def test_can_mark_interesting():
-    x = TestData.for_buffer(bytes())
+    x = ConjectureData.for_buffer(bytes())
     with pytest.raises(StopTest):
         x.mark_interesting()
     assert x.frozen
@@ -82,7 +83,7 @@ def test_can_mark_interesting():
 
 
 def test_can_mark_invalid():
-    x = TestData.for_buffer(bytes())
+    x = ConjectureData.for_buffer(bytes())
     with pytest.raises(StopTest):
         x.mark_invalid()
     assert x.frozen
@@ -97,7 +98,7 @@ class BoomStrategy(SearchStrategy):
 
 
 def test_closes_interval_on_error_in_strategy():
-    x = TestData.for_buffer(b'hi')
+    x = ConjectureData.for_buffer(b'hi')
     with pytest.raises(ValueError):
         x.draw(BoomStrategy())
     x.freeze()
@@ -111,7 +112,7 @@ class BigStrategy(SearchStrategy):
 
 
 def test_does_not_double_freeze_in_interval_close():
-    x = TestData.for_buffer(b'hi')
+    x = ConjectureData.for_buffer(b'hi')
     with pytest.raises(StopTest):
         x.draw(BigStrategy())
     assert x.frozen

--- a/tests/cover/test_conjecture_utils.py
+++ b/tests/cover/test_conjecture_utils.py
@@ -17,9 +17,9 @@
 
 from __future__ import division, print_function, absolute_import
 
-from hypothesis.internal.conjecture.data import TestData
+from hypothesis.internal.conjecture.data import ConjectureData
 from hypothesis.internal.conjecture.utils import integer_range
 
 
 def test_does_not_draw_data_for_empty_range():
-    assert integer_range(TestData.for_buffer(b''), 1, 1) == 1
+    assert integer_range(ConjectureData.for_buffer(b''), 1, 1) == 1

--- a/tests/cover/test_control.py
+++ b/tests/cover/test_control.py
@@ -23,7 +23,7 @@ from hypothesis.errors import CleanupFailed, InvalidArgument
 from hypothesis.control import note, event, cleanup, BuildContext, \
     current_build_context, _current_build_context
 from tests.common.utils import capture_out
-from hypothesis.internal.conjecture.data import TestData as TD
+from hypothesis.internal.conjecture.data import ConjectureData as TD
 
 
 def bc():

--- a/tests/cover/test_executors.py
+++ b/tests/cover/test_executors.py
@@ -23,7 +23,7 @@ from unittest import TestCase
 import pytest
 
 from hypothesis import given, example
-from hypothesis.executors import TestRunner
+from hypothesis.executors import ConjectureRunner
 from hypothesis.strategies import booleans, integers
 
 
@@ -91,7 +91,7 @@ def test_no_boom_on_example():
     Valueless().test_no_boom_on_example()
 
 
-class TestNormal(TestRunner, TestCase):
+class TestNormal(ConjectureRunner, TestCase):
 
     @given(booleans())
     def test_stuff(self, b):

--- a/tests/cover/test_integer_ranges.py
+++ b/tests/cover/test_integer_ranges.py
@@ -19,7 +19,7 @@ from __future__ import division, print_function, absolute_import
 
 import hypothesis.strategies as st
 from hypothesis import find, given, settings
-from hypothesis.internal.conjecture.data import TestData
+from hypothesis.internal.conjecture.data import ConjectureData
 from hypothesis.internal.conjecture.utils import integer_range
 from hypothesis.searchstrategy.strategies import SearchStrategy
 
@@ -65,7 +65,7 @@ def test_intervals_shrink_to_center(inter, rnd):
 def test_distribution_is_correctly_translated(inter, rnd):
     assert inter == sorted(inter)
     lower, c1, c2, upper = inter
-    d = TestData(
+    d = ConjectureData(
         draw_bytes=lambda data, n, distribution: distribution(rnd, n),
         max_length=10 ** 6
     )

--- a/tests/cover/test_simple_strings.py
+++ b/tests/cover/test_simple_strings.py
@@ -121,6 +121,6 @@ def test_can_restrict_to_ascii_only(s):
 
 
 def test_fixed_size_bytes_just_draw_bytes():
-    from hypothesis.internal.conjecture.data import TestData
-    x = TestData.for_buffer(b'foo')
+    from hypothesis.internal.conjecture.data import ConjectureData
+    x = ConjectureData.for_buffer(b'foo')
     assert x.draw(binary(min_size=3, max_size=3)) == b'foo'

--- a/tests/nocover/test_statistical_distribution.py
+++ b/tests/nocover/test_statistical_distribution.py
@@ -42,7 +42,7 @@ from hypothesis.strategies import just, sets, text, lists, floats, \
     one_of, tuples, booleans, integers, sampled_from
 from hypothesis.internal.compat import hrange
 from hypothesis.internal.conjecture.engine import \
-    TestRunner as ConTestRunner
+    ConjectureRunner as ConConjectureRunner
 
 # We run each individual test at a very high level of significance to the
 # point where it will basically only fail if it's really really wildly wrong.
@@ -174,7 +174,7 @@ def define_test(specifier, q, predicate, condition=None):
             successful_runs[0] += 1
             if predicate(value):
                 count[0] += 1
-        ConTestRunner(
+        ConConjectureRunner(
             test_function,
             settings=Settings(
                 max_examples=MAX_RUNS,


### PR DESCRIPTION
This causes pytest warnings because they look like they're
supposed to be unittest tests, but they have an __init__ which
stops them being picked up as such.