### PR TITLE
Take control of the time stream

### DIFF
--- a/src/hypothesis/internal/debug.py
+++ b/src/hypothesis/internal/debug.py
@@ -17,7 +17,6 @@
 
 from __future__ import division, print_function, absolute_import
 
-import math
 import time
 import signal
 
@@ -46,6 +45,9 @@ try:
                 start = time.time()
 
                 def handler(signum, frame):
+                    if time.time() <= start + seconds:
+                        signal.alarm(1)
+                        return
                     if catchable:
                         raise CatchableTimeout(
                             u'Timed out after %.2fs' % (time.time() - start))
@@ -54,7 +56,7 @@ try:
                             u'Timed out after %.2fs' % (time.time() - start))
 
                 old_handler = signal.signal(signal.SIGALRM, handler)
-                signal.alarm(int(math.ceil(seconds)))
+                signal.alarm(1)
                 try:
                     return f(*args, **kwargs)
                 finally:

--- a/tests/nocover/test_fixtures.py
+++ b/tests/nocover/test_fixtures.py
@@ -1,0 +1,28 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2016 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import time
+
+
+def test_time_consistently_increments_in_tests():
+    x = time.time()
+    y = time.time()
+    z = time.time()
+    assert y == x + 0.0001
+    assert z == y + 0.0001


### PR DESCRIPTION
This uses some judicious monkey patching to control the passage of time during our tests.

The reason for this is that when running tests on Travis, or really any computer with slightly unreliable performance, tests can currently fail because the system is under load or took a nap mid execution, etc. A lot of the current flakiness comes from this.

If instead we just pretend time passes at a uniform rate by having time increment by 100ns every time we check (I originally tried for 1ms but that turned out to be too much and a numberof the tests in test\_example\_quality failed), the testing should become much more robust.

This doesn't remove all flakiness, because we're still at the mercy of the random seed (I'm tempted to fix this by doing a fixed seed prior to each test, but I'm a little leery of doing that so if I do it'll be in a separate pull request), but it should hopefully greatly reduce it.