### PR TITLE
Some optimizations to the shrinker

### DIFF
--- a/src/hypothesis/internal/compat.py
+++ b/src/hypothesis/internal/compat.py
@@ -392,7 +392,7 @@ class compatbytes(bytearray):
         return compatbytes(bytearray.__add__(self, value))
 
     def __radd__(self, value):
-        return compatbytes(bytearray.__radd__(self, value))
+        return compatbytes(bytearray.__add__(value, self))
 
     def __mul__(self, value):
         return compatbytes(bytearray.__mul__(self, value))

--- a/src/hypothesis/internal/conjecture/minimizer.py
+++ b/src/hypothesis/internal/conjecture/minimizer.py
@@ -189,7 +189,7 @@ for b in hrange(10, 256):
         result.add(b ^ (1 << i))
     result.discard(b)
     assert len(result) <= 10
-    small_shrinks.append(sorted(c for c in result if c < b))
+    small_shrinks.append(sorted([c for c in result if c < b]))
 
 
 def minimize(initial, condition, random=None, cautious=False):

--- a/src/hypothesis/internal/conjecture/minimizer.py
+++ b/src/hypothesis/internal/conjecture/minimizer.py
@@ -118,7 +118,7 @@ class Minimizer(object):
                 break
         assert self.current[significant]
 
-        prefix = bytes(significant)
+        prefix = hbytes(significant)
 
         for i in range(1, self.size - significant):
             left = self.current[significant:significant + i]

--- a/src/hypothesis/internal/conjecture/minimizer.py
+++ b/src/hypothesis/internal/conjecture/minimizer.py
@@ -65,8 +65,7 @@ class Minimizer(object):
     def _shrink_index(self, i, c):
         assert isinstance(self.current, hbytes)
         assert 0 <= i < self.size
-        if self.current[i] <= c:
-            return False
+        assert self.current[i] > c
         if self.incorporate(
             self.current[:i] + hbytes([c]) +
             self.current[i + 1:]
@@ -113,7 +112,7 @@ class Minimizer(object):
                 k //= 2
 
     def rotate_suffixes(self):
-        for significant, c in enumerate(self.current):
+        for significant, c in enumerate(self.current):  # pragma: no branch
             if c:
                 break
         assert self.current[significant]

--- a/src/hypothesis/internal/conjecture/minimizer.py
+++ b/src/hypothesis/internal/conjecture/minimizer.py
@@ -86,8 +86,8 @@ class Minimizer(object):
             hbytes([255] * (self.size - i - 1))
         )
 
-    def ddlower(self, c):
-        self.ddfixate(lambda b: min(b, c))
+    def ddzero(self):
+        self.ddfixate(lambda b: 0)
 
     def ddshift(self):
         self.ddfixate(lambda b: b >> 1)
@@ -156,19 +156,13 @@ class Minimizer(object):
         while self.current and change_counter < self.changes:
             change_counter = self.changes
 
-            self.ddlower(0)
-            self.ddlower(1)
+            self.ddzero()
             self.ddshift()
             self.ddsub()
 
             if change_counter != self.changes:
                 continue
 
-            for c in sorted(set(self.current) - {0, 1, max(self.current)}):
-                self.ddlower(c)
-
-            if change_counter != self.changes:
-                continue
             self.shrink_indices()
 
             if change_counter != self.changes or self.cautious:

--- a/tests/cover/test_conjecture_engine.py
+++ b/tests/cover/test_conjecture_engine.py
@@ -439,12 +439,15 @@ def test_garbage_collects_the_database():
     seen = set()
     go = True
 
+    counter = [0]
+
     def f(data):
         x = hbytes(data.draw_bytes(512))
         if not go:
             return
-        if sum(x) >= 5000 and len(seen) < n:
+        if counter[0] % 10 == 0 and len(seen) < n:
             seen.add(x)
+        counter[0] += 1
         if x in seen:
             data.mark_interesting()
     runner = ConjectureRunner(

--- a/tests/cover/test_conjecture_engine.py
+++ b/tests/cover/test_conjecture_engine.py
@@ -442,10 +442,16 @@ def test_garbage_collects_the_database():
     counter = [0]
 
     def f(data):
+        """This function is designed to shrink very badly.
+
+        So we only occasionally mark things as interesting, and require
+        a certain amount of complexity to do so.
+
+        """
         x = hbytes(data.draw_bytes(512))
         if not go:
             return
-        if counter[0] % 10 == 0 and len(seen) < n:
+        if counter[0] % 10 == 0 and len(seen) < n and sum(x) > 1000:
             seen.add(x)
         counter[0] += 1
         if x in seen:

--- a/tests/cover/test_conjecture_engine.py
+++ b/tests/cover/test_conjecture_engine.py
@@ -450,15 +450,16 @@ def test_garbage_collects_the_database():
         counter[0] += 1
         if x in seen:
             data.mark_interesting()
-    runner = ConjectureRunner(
-        f, settings=settings(database=db, max_shrinks=2 * n), database_key=key)
+
+    local_settings = settings(database=db, max_shrinks=2 * n, timeout=-1)
+
+    runner = ConjectureRunner(f, settings=local_settings, database_key=key)
     runner.run()
     assert runner.last_data.status == Status.INTERESTING
     assert len(seen) == n
     assert set(db.fetch(key)) == seen
     go = False
-    runner = ConjectureRunner(
-        f, settings=settings(database=db, max_shrinks=2 * n), database_key=key)
+    runner = ConjectureRunner(f, settings=local_settings, database_key=key)
     runner.run()
     assert 0 < len(set(db.fetch(key))) < n
 


### PR DESCRIPTION
This is some work extracted from my ongoing work on the new backend. It makes the shrinker a fair bit faster by some more judicious choices of shrinking - there is less wasted work and bigger shrinks are achieved faster.

It has three major features:

1. A bunch of tuning of the lexicographic minimizer. In particular this removes a bunch of bulk operations that always performed a lot of attempted shrinks and rarely worked, and generalises the ddmin stuff to a set of operations that seem to do a good enough job most of the time.
2. Better duplication of blocks in the main engine - a new pass which tries many clones at once on the off chance that they'll succeed.
3. Move the whole buffer lexicographic shrink later in the process so it's not doing a lot of duplicated work.

The following is the benchmark I've been optimizing for, though it also seems to somewhat improve the runtime of parts of the test suite (probably not so that we'd notice):

```python

from hypothesis import given, settings, strategies as st, seed
import traceback
import math


N_EXAMPLES = 10 ** 3


@seed(1)
@settings(
    database=None, timeout=-1, perform_health_check=False,
    max_examples=N_EXAMPLES, max_iterations=N_EXAMPLES,
)
@given(st.lists(st.floats(), min_size=10))
def test(fs):
    assert not math.isnan(sum(fs))


if __name__ == '__main__':
    try:
        test()
    except AssertionError:
        traceback.print_exc()
```

This runs in ~2.5s on my computer on master and in ~0.9 on this branch.