### PR TITLE
Standardize which files to format. Exclude vendor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,8 @@ TOOL_PYTHON=$(TOOL_VIRTUALENV)/bin/python
 TOOL_PIP=$(TOOL_VIRTUALENV)/bin/pip
 TOOL_INSTALL=$(TOOL_PIP) install --upgrade
 
+FILES_TO_FORMAT=find src tests -name '*.py' -not -path '*/vendor/*'
+
 export PATH:=$(BUILD_RUNTIMES)/snakepit:$(TOOLS):$(PATH)
 export LC_ALL=en_US.UTF-8
 
@@ -71,14 +73,13 @@ $(ISORT_VIRTUALENV): $(PY34)
 	$(PY34) -m virtualenv $(ISORT_VIRTUALENV)
 
 format: $(PYFORMAT) $(ISORT)
-	$(TOOL_PYTHON) scripts/enforce_header.py
+	$(FILES_TO_FORMAT) | $(TOOL_PYTHON) scripts/enforce_header.py
 	# isort will sort packages differently depending on whether they're installed
 	$(ISORT_VIRTUALENV)/bin/python -m pip install django pytz pytest fake-factory numpy flaky
-	find src tests examples -name '*.py' | xargs  env -i \
-            PATH="$(PATH)" $(ISORT) -p hypothesis -ls -m 2 -w 75 \
-			-a  "from __future__ import absolute_import, print_function, division" \
+	$(FILES_TO_FORMAT) | xargs env -i PATH="$(PATH)" $(ISORT) -p hypothesis -ls -m 2 -w 75 \
+			-a "from __future__ import absolute_import, print_function, division" \
 			-rc src tests examples
-	find src tests examples -name '*.py' | xargs $(PYFORMAT) -i
+	$(FILES_TO_FORMAT) | xargs $(PYFORMAT) -i
 
 lint: $(FLAKE8)
 	$(FLAKE8) src tests --exclude=compat.py,test_reflection.py,test_imports.py,tests/py2 --ignore=E731,E721

--- a/scripts/enforce_header.py
+++ b/scripts/enforce_header.py
@@ -1,4 +1,3 @@
-import subprocess
 import os
 import sys
 
@@ -7,29 +6,10 @@ HEADER_FILE = "scripts/header.py"
 HEADER_SOURCE = open(HEADER_FILE).read().strip()
 
 
-def all_python_files():
-    lines = subprocess.check_output([
-        "git", "ls-tree", "--full-tree", "-r", "HEAD",
-    ]).decode('utf-8').split("\n")
-    files = [
-        l.split()[-1]
-        for l in lines
-        if l
-    ]
-    return [
-        f for f in files
-        if f[-3:] == ".py"
-    ]
-
-
 def main():
     rootdir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-    print("cd %r" % (rootdir,))
     os.chdir(rootdir)
-    if len(sys.argv) > 1:
-        files = sys.argv[1:]
-    else:
-        files = all_python_files()
+    files = sys.argv[1:]
     try:
         files.remove("scripts/enforce_header.py")
     except ValueError:
@@ -60,6 +40,7 @@ def main():
             o.write("\n\n")
             o.write(source)
             o.write("\n")
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This replaces the four (!) different places we decide which files
get formatted with a single one, as a prerequisite for the actual
point of this: Formatters should not run on vendored files.

This is somewhat prompted by an intent to add another vendored
file, but it's a good change in its own right even if we don't
do that.