### PR TITLE
Preserve a function's docstring with copy_argspec

### DIFF
--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -217,7 +217,7 @@ def given(*generator_arguments, **generator_kwargs):
 
         @impersonate(test)
         @copy_argspec(
-            test.__name__, argspec
+            test.__name__, test.__doc__, argspec
         )
         def wrapped_test(*arguments, **kwargs):
             settings = wrapped_test._hypothesis_internal_use_settings

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -39,8 +39,9 @@ from hypothesis.reporting import report, verbose_report, current_verbosity
 from hypothesis.statistics import note_engine_for_statistics
 from hypothesis.internal.compat import getargspec, str_to_bytes
 from hypothesis.internal.reflection import nicerepr, arg_string, \
-    impersonate, copy_argspec, function_digest, fully_qualified_name, \
-    convert_positional_arguments, get_pretty_function_description
+    impersonate, function_digest, fully_qualified_name, \
+    define_function_signature, convert_positional_arguments, \
+    get_pretty_function_description
 from hypothesis.searchstrategy.strategies import SearchStrategy
 
 
@@ -216,7 +217,7 @@ def given(*generator_arguments, **generator_kwargs):
         )
 
         @impersonate(test)
-        @copy_argspec(
+        @define_function_signature(
             test.__name__, test.__doc__, argspec
         )
         def wrapped_test(*arguments, **kwargs):

--- a/src/hypothesis/internal/reflection.py
+++ b/src/hypothesis/internal/reflection.py
@@ -360,7 +360,6 @@ from hypothesis.utils.conventions import not_set
 
 def accept(%(funcname)s):
     def %(name)s(%(argspec)s):
-        '''%(docstring)s'''
         return %(funcname)s(%(invocation)s)
     return %(name)s
 """.strip() + '\n'
@@ -421,12 +420,12 @@ def define_function_signature(name, docstring, argspec):
             COPY_ARGSPEC_SCRIPT % {
                 'name': name,
                 'funcname': funcname,
-                'docstring': docstring,
                 'argspec': ', '.join(parts),
                 'invocation': ', '.join(invocation_parts)
             }).accept
 
         result = base_accept(f)
+        result.__doc__ = docstring
         result.__defaults__ = argspec.defaults
         return result
     return accept

--- a/src/hypothesis/internal/reflection.py
+++ b/src/hypothesis/internal/reflection.py
@@ -366,7 +366,7 @@ def accept(%(funcname)s):
 """.strip() + '\n'
 
 
-def copy_argspec(name, docstring, argspec):
+def define_function_signature(name, docstring, argspec):
     """A decorator which sets the name, argspec and docstring of the function
     passed into it."""
     check_valid_identifier(name)
@@ -455,6 +455,6 @@ def impersonate(target):
 def proxies(target):
     def accept(proxy):
         return impersonate(target)(wraps(target)(
-            copy_argspec(
+            define_function_signature(
                 target.__name__, target.__doc__, getargspec(target))(proxy)))
     return accept

--- a/src/hypothesis/internal/reflection.py
+++ b/src/hypothesis/internal/reflection.py
@@ -360,14 +360,15 @@ from hypothesis.utils.conventions import not_set
 
 def accept(%(funcname)s):
     def %(name)s(%(argspec)s):
+        '''%(docstring)s'''
         return %(funcname)s(%(invocation)s)
     return %(name)s
 """.strip() + '\n'
 
 
-def copy_argspec(name, argspec):
-    """A decorator which sets the name and argspec of the function passed into
-    it."""
+def copy_argspec(name, docstring, argspec):
+    """A decorator which sets the name, argspec and docstring of the function
+    passed into it."""
     check_valid_identifier(name)
     for a in argspec.args:
         check_valid_identifier(a)
@@ -420,6 +421,7 @@ def copy_argspec(name, argspec):
             COPY_ARGSPEC_SCRIPT % {
                 'name': name,
                 'funcname': funcname,
+                'docstring': docstring,
                 'argspec': ', '.join(parts),
                 'invocation': ', '.join(invocation_parts)
             }).accept
@@ -453,5 +455,6 @@ def impersonate(target):
 def proxies(target):
     def accept(proxy):
         return impersonate(target)(wraps(target)(
-            copy_argspec(target.__name__, getargspec(target))(proxy)))
+            copy_argspec(
+                target.__name__, target.__doc__, getargspec(target))(proxy)))
     return accept

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -881,7 +881,7 @@ def composite(f):
 
     """
 
-    from hypothesis.internal.reflection import copy_argspec
+    from hypothesis.internal.reflection import define_function_signature
     argspec = getargspec(f)
 
     if (
@@ -902,7 +902,7 @@ def composite(f):
     )
 
     @defines_strategy
-    @copy_argspec(f.__name__, f.__doc__, new_argspec)
+    @define_function_signature(f.__name__, f.__doc__, new_argspec)
     def accept(*args, **kwargs):
         class CompositeStrategy(SearchStrategy):
 

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -902,7 +902,7 @@ def composite(f):
     )
 
     @defines_strategy
-    @copy_argspec(f.__name__, new_argspec)
+    @copy_argspec(f.__name__, f.__doc__, new_argspec)
     def accept(*args, **kwargs):
         class CompositeStrategy(SearchStrategy):
 


### PR DESCRIPTION
This means that when a strategy is wrapped with `@composite`, we
preserve the docstring of the original function.

Fixes #422.