### PR TITLE
Remove old versions of pytest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,17 +118,11 @@ check-pytest30: $(TOX) $(PY35)
 check-pytest28: $(TOX) $(PY35)
 	$(TOX) -e pytest28
 
-check-pytest27: $(TOX) $(PY35)
-	$(TOX) -e pytest27
-
-check-pytest26: $(TOX) $(PY35)
-	$(TOX) -e pytest26
-
 check-ancient-pip: $(PY273)
 	scripts/check-ancient-pip.sh $(PY273)
-	
 
-check-pytest: check-pytest26 check-pytest27
+
+check-pytest: check-pytest28 check-pytest30
 
 check-fakefactory060: $(TOX) $(PY35)
 	$(TOX) -e fakefactory060

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ extras = {
     'fakefactory': ["Faker>=0.7.0,<=0.7.1"],
     'django': ['pytz', 'django>=1.7'],
     'numpy': ['numpy>=1.9.0'],
-    'pytest': ['pytest>=2.7.0'],
+    'pytest': ['pytest>=2.8.0'],
 }
 
 extras['faker'] = extras['fakefactory']

--- a/tox.ini
+++ b/tox.ini
@@ -121,20 +121,6 @@ deps =
 commands=
     python -m pytest tests/pytest tests/cover/test_testdecorators.py
 
-[testenv:pytest27]
-basepython=python3.5
-deps =
-    pytest==2.7.3
-commands=
-    python -m pytest tests/pytest tests/cover/test_testdecorators.py
-
-[testenv:pytest26]
-basepython=python2.7
-deps =
-    pytest==2.6.3
-commands=
-    python -m pytest tests/cover/test_testdecorators.py
-
 [testenv:docs]
 basepython=python3.4
 deps = sphinx


### PR DESCRIPTION
Resolves #380.

As pointed out in the issue notes, the tests fail if you run them under pytest 2.6 and 2.7, and they’re no longer run in Travis anymore.

Dependencies should go forward – pytest 2.8 is ~18 months old, putting in the effort to get these old versions of pytest working again is a waste of time.