### PR TITLE
Add CI testing for Django 1.9/1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,8 @@ env:
         - TASK=check-fakefactory060
         - TASK=check-django17
         - TASK=check-django18
+        - TASK=check-django19
+        - TASK=check-django110
 
 script:
     - make $TASK
@@ -68,6 +70,10 @@ matrix:
           env: TASK=check-django17
         - os: osx
           env: TASK=check-django18
+        - os: osx
+          env: TASK=check-django19
+        - os: osx
+          env: TASK=check-django110
         - os: osx
           env: TASK=check-examples2
         - os: osx

--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,10 @@ check-django18: $(TOX) $(PY35)
 check-django19: $(TOX) $(PY35)
 	$(TOX) -e django19
 
-check-django: check-django17 check-django18 check-django19
+check-django110: $(TOX) $(PY35)
+	$(TOX) -e django110
+
+check-django: check-django17 check-django18 check-django19 check-django110
 
 check-examples2: $(TOX) $(PY27)
 	$(TOX) -e examples2

--- a/tox.ini
+++ b/tox.ini
@@ -92,6 +92,14 @@ commands =
     pip install django>=1.9,<1.9.99
     python -m tests.django.manage test tests.django
 
+[testenv:django110]
+basepython=python3.4
+commands =
+    pip install .[datetime]
+    pip install --no-binary :all: .[fakefactory]
+    pip install django>=1.10,<1.10.99
+    python -m tests.django.manage test tests.django
+
 [testenv:nose]
 basepython=python3.5
 deps =


### PR DESCRIPTION
* We had a tox environment and a Make task for Django 1.9, but it wasn’t being used anywhere.
* We didn’t have any testing for Django 1.10.