### PR TITLE
Restrict CI to only building the master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ os:
     - osx
     - linux
 
+branches:
+  only:
+    - "master"
+
 cache:
     apt: true
     directories:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,10 @@ environment:
       PYTHON_VERSION: "3.4.1"
       PYTHON_ARCH: "64"
 
+branches:
+  only:
+    - master
+
 install:
   - ECHO "Filesystem root:"
   - ps: "ls \"C:/\""


### PR DESCRIPTION
This is a bit of a speculative PR and I'd like to discuss it before merge.

Travis has an annoying behaviour for pull requests where it builds each pull request twice: Once for the branch, once for the merge commit.

Given Hypothesis's painfully slow builds this is rather frustrating.

As [per the Travis documentation](https://docs.travis-ci.com/user/customizing-the-build#Building-Specific-Branches) we can turn this off and only have it build master. This should still build pull requests, or at least it was the suggested fix for https://github.com/travis-ci/travis-ci/issues/1147.

Do you think this is a good idea? It solves quite an annoying problem but I don't know how annoying not having the CI builds for our branches when we're working on them will be. It would be nice to be able to trigger Travis to run a particular commit manually but I don't think we can.

Update: This now should also do the same thing for appveyor ([as per documentation](https://www.appveyor.com/docs/branches/))