### PR TITLE
Replace fakefactory tests with faker tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,8 @@ env:
         - TASK=check-py36
         - TASK=check-nose
         - TASK=check-pytest28
-        - TASK=check-fakefactory052
-        - TASK=check-fakefactory053
-        - TASK=check-fakefactory060
+        - TASK=check-faker070
+        - TASK=check-faker071
         - TASK=check-django17
         - TASK=check-django18
         - TASK=check-django19
@@ -67,11 +66,9 @@ matrix:
         - os: osx
           env: TASK=check-pytest28
         - os: osx
-          env: TASK=check-fakefactory052
+          env: TASK=check-faker070
         - os: osx
-          env: TASK=check-fakefactory053
-        - os: osx
-          env: TASK=check-fakefactory060
+          env: TASK=check-faker071
         - os: osx
           env: TASK=check-django17
         - os: osx

--- a/Makefile
+++ b/Makefile
@@ -124,14 +124,11 @@ check-ancient-pip: $(PY273)
 
 check-pytest: check-pytest28 check-pytest30
 
-check-fakefactory060: $(TOX) $(PY35)
-	$(TOX) -e fakefactory060
+check-faker070: $(TOX) $(PY35)
+	$(TOX) -e faker070
 
-check-fakefactory052: $(TOX) $(PY35)
-	$(TOX) -e fakefactory052
-
-check-fakefactory053: $(TOX) $(PY35)
-	$(TOX) -e fakefactory053
+check-faker071: $(TOX) $(PY35)
+	$(TOX) -e faker071
 
 check-django17: $(TOX) $(PY35)
 	$(TOX) -e django17

--- a/tox.ini
+++ b/tox.ini
@@ -45,28 +45,20 @@ setenv=
 commands=
     python scripts/unicodechecker.py
 
-[testenv:fakefactory052]
+[testenv:faker070]
 basepython=python3.5
 deps =
   pytest==3.0.2
 commands =
-    pip install --no-binary :all: fake-factory==0.5.2
+    pip install --no-binary :all: faker==0.7.0
     python -m pytest tests/fakefactory
 
-[testenv:fakefactory060]
+[testenv:faker071]
 basepython=python3.5
 deps =
   pytest==3.0.2
 commands =
-    pip install --no-binary :all: fake-factory==0.6.0
-    python -m pytest tests/fakefactory
-
-[testenv:fakefactory053]
-basepython=python3.5
-deps =
-  pytest==3.0.2
-commands =
-    pip install --no-binary :all: fake-factory==0.5.3
+    pip install --no-binary :all: faker==0.7.1
     python -m pytest tests/fakefactory
 
 [testenv:django17]


### PR DESCRIPTION
We had tests that checked compatibility with the supported versions
of fakefactory – except Hypothesis doesn't depend on fakefactory
any more, it depends on faker.  So these tests aren't telling us
anything.  Test against versions of faker instead.

(Related to [this comment](https://github.com/HypothesisWorks/hypothesis-python/issues/444#issuecomment-279036226))