### PR TITLE
Deferred strategies should unwrap their arguments

### DIFF
--- a/scripts/basic-test.sh
+++ b/scripts/basic-test.sh
@@ -30,16 +30,10 @@ fi
 
 $PYTEST --runpytest=subprocess tests/pytest
 
-if [ "$DARWIN" != true ]; then
-  for f in tests/nocover/test_*.py; do
-    $PYTEST $f
-  done
-fi
-
-
 pip install .[datetime]
 $PYTEST tests/datetime/
 pip uninstall -y pytz
+
 
 if [ "$DARWIN" = true ]; then
   exit 0
@@ -48,6 +42,10 @@ fi
 if [ "$(python -c 'import sys; print(sys.version_info[:2] in ((2, 7), (3, 6))')" = "False" ] ; then
   exit 0
 fi
+
+for f in tests/nocover/test_*.py; do
+  $PYTEST $f
+done
 
 # fake-factory doesn't have a correct universal wheel
 pip install --no-binary :all: faker

--- a/src/hypothesis/searchstrategy/deferred.py
+++ b/src/hypothesis/searchstrategy/deferred.py
@@ -31,6 +31,18 @@ def tupleize(x):
         return x
 
 
+def unwrap_strategies(s):
+    if isinstance(s, SearchStrategy):
+        while True:
+            assert isinstance(s, SearchStrategy)
+            try:
+                s = s.wrapped_strategy
+            except AttributeError:
+                return s
+    else:
+        return s
+
+
 class DeferredStrategy(SearchStrategy):
 
     """A strategy which is defined purely by conversion to and from another
@@ -64,9 +76,9 @@ class DeferredStrategy(SearchStrategy):
         if self.__wrapped_strategy is None:
             with self.__settings:
                 self.__wrapped_strategy = self.__function(
-                    *self.__args,
-                    **self.__kwargs
-                )
+                    *[unwrap_strategies(s) for s in self.__args],
+                    **{k: unwrap_strategies(v)
+                       for k, v in self.__kwargs.items()})
         return self.__wrapped_strategy
 
     def validate(self):

--- a/src/hypothesis/searchstrategy/recursive.py
+++ b/src/hypothesis/searchstrategy/recursive.py
@@ -22,7 +22,6 @@ from contextlib import contextmanager
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.reflection import get_pretty_function_description
 from hypothesis.internal.deferredformat import deferredformat
-from hypothesis.searchstrategy.wrappers import WrapperStrategy
 from hypothesis.searchstrategy.strategies import OneOfStrategy, \
     SearchStrategy
 
@@ -31,19 +30,23 @@ class LimitReached(BaseException):
     pass
 
 
-class LimitedStrategy(WrapperStrategy):
+class LimitedStrategy(SearchStrategy):
 
     def __init__(self, strategy):
-        super(LimitedStrategy, self).__init__(strategy)
+        super(LimitedStrategy, self).__init__()
+        self.base_strategy = strategy
         self.marker = 0
         self.currently_capped = False
+
+    def validate(self):
+        self.base_strategy.validate()
 
     def do_draw(self, data):
         assert self.currently_capped
         if self.marker <= 0:
             raise LimitReached()
         self.marker -= 1
-        return super(LimitedStrategy, self).do_draw(data)
+        return self.base_strategy.do_draw(data)
 
     @contextmanager
     def capped(self, max_templates):


### PR DESCRIPTION
We use deferred strategies all over the place. Unfortunately this
means a lot of indirection. Python is not very good at optimising
indirection.

This patch allows us to transparently ignore most of that
indirection by unwrapping all strategies before we create the
"real" underlying strategy.

Informal benchmarking suggests it helps some of the example
quality tests (which run draw() a lot of times) about 10-20%, but
this is obviously not that reliable.