### PR TITLE
Reduce amount of time spent testing old Python 3 versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,8 @@ matrix:
         - os: osx
           env: TASK=check-py34
         - os: osx
+          env: TASK=check-py35
+        - os: osx
           env: TASK=check-pytest28
         - os: osx
           env: TASK=check-fakefactory052

--- a/scripts/basic-test.sh
+++ b/scripts/basic-test.sh
@@ -45,6 +45,10 @@ if [ "$DARWIN" = true ]; then
   exit 0
 fi
 
+if [ "$(python -c 'import sys; print(sys.version_info[:2] in ((2, 7), (3, 6))')" = "False" ] ; then
+  exit 0
+fi
+
 # fake-factory doesn't have a correct universal wheel
 pip install --no-binary :all: faker
 $PYTEST tests/fakefactory/


### PR DESCRIPTION
This reduces the amount of tests we run on Python 3.4 and 3.5 to try to reduce build times. The full tests still run on 3.6.