### PR TITLE
Remove a bit of Python 2.6-specific build code

### DIFF
--- a/scripts/basic-test.sh
+++ b/scripts/basic-test.sh
@@ -55,23 +55,17 @@ $PYTEST tests/fakefactory/
 pip uninstall -y faker
 
 if [ "$(python -c 'import platform; print(platform.python_implementation())')" != "PyPy" ]; then
-  if [ "$(python -c 'import sys; print(sys.version_info[:2] <= (2, 6))')" != "True" ] ; then
   if [ "$(python -c 'import sys; print(sys.version_info[0] == 2 or sys.version_info[:2] >= (3, 4))')" == "True" ] ; then
     pip install .[django]
     python -m tests.django.manage test tests.django
     pip uninstall -y django
   fi
-  fi
 
   if [ "$(python -c 'import sys; print(sys.version_info[:2] < (3, 5))')" = "True" ] ; then
-    if [ "$(python -c 'import sys; print(sys.version_info[:2] <= (2, 6))')" != "True" ] ; then
-      pushd $HOME
-        pip wheel numpy==1.9.2
-      popd
-      pip install --find-links=$HOME/wheelhouse numpy==1.9.2
-    else
-      pip install numpy==1.9.2
-    fi
+    pushd $HOME
+      pip wheel numpy==1.9.2
+    popd
+    pip install --find-links=$HOME/wheelhouse numpy==1.9.2
     $PYTEST tests/numpy
     pip uninstall -y numpy
   fi


### PR DESCRIPTION
Spotted while reviewing #448.

Hypothesis no longer supports Python 2.6, and if you try to run the tests (or this script) with Python 2.6, it will crash and burn long before this runs to completion. Thus these checks are redundant, let’s make the code a bit tidier.