### PR TITLE
Print durations of slowest tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -158,4 +158,4 @@ commands=
     python -m pytest examples
 
 [pytest]
-addopts=--strict --tb=short -vv -p pytester --runpytest=subprocess
+addopts=--strict --tb=short -vv -p pytester --runpytest=subprocess --durations=20


### PR DESCRIPTION
This causes pytest to print out the durations in seconds of each of the 20 slowest tests in a run. This will hopefully be useful in trying to track down why builds sometimes randomly take four times as long as usual: It might not be a test that's doing it, but if it's not this will help rule that out.

We'll see a lot more than 20 timings out of this because we invoke pytest in a number of different times and places, but I don't really have a problem with that.