### PR TITLE
Fix syntax in check for Python versions

### DIFF
--- a/scripts/basic-test.sh
+++ b/scripts/basic-test.sh
@@ -39,7 +39,7 @@ if [ "$DARWIN" = true ]; then
   exit 0
 fi
 
-if [ "$(python -c 'import sys; print(sys.version_info[:2] in ((2, 7), (3, 6))')" = "False" ] ; then
+if [ "$(python -c 'import sys; print(sys.version_info[:2] in ((2, 7), (3, 6)))')" = "False" ] ; then
   exit 0
 fi
 


### PR DESCRIPTION
The version check in #448 was wrong (missing bracket), so old Python 3 versions are still running the full suite of tests. Oops.

This should fix that. Let's double check the Travis build before merging to make sure this time.

(I have no idea how we would have tested for this except manually)