### PR TITLE
Remove some problematic shrinker passes

### DIFF
--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -488,32 +488,6 @@ class ConjectureRunner(object):
                 )
                 i += 1
 
-            self.debug('Replacing intervals with simpler intervals')
-
-            interval_counter = -1
-            while interval_counter != self.changed:
-                interval_counter = self.changed
-                i = 0
-                alternatives = None
-                while i < len(self.last_data.intervals):
-                    if alternatives is None:
-                        alternatives = sorted(set(
-                            self.last_data.buffer[u:v]
-                            for u, v in self.last_data.intervals), key=len)
-                    u, v = self.last_data.intervals[i]
-                    for a in alternatives:
-                        buf = self.last_data.buffer
-                        if (
-                            len(a) < v - u or
-                            (len(a) == (v - u) and a < buf[u:v])
-                        ):
-                            if self.incorporate_new_buffer(
-                                buf[:u] + a + buf[v:]
-                            ):
-                                alternatives = None
-                                break
-                    i += 1
-
             if change_counter != self.changed:
                 self.debug('Restarting')
                 continue

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -492,6 +492,36 @@ class ConjectureRunner(object):
                 self.debug('Restarting')
                 continue
 
+            self.debug('Reordering blocks')
+            block_lengths = sorted(self.last_data.block_starts, reverse=True)
+            for n in block_lengths:
+                i = 1
+                while i < len(self.last_data.block_starts.get(n, ())):
+                    j = i
+                    while j > 0:
+                        buf = self.last_data.buffer
+                        blocks = self.last_data.block_starts[n]
+                        a_start = blocks[j - 1]
+                        b_start = blocks[j]
+                        a = buf[a_start:a_start + n]
+                        b = buf[b_start:b_start + n]
+                        if a <= b:
+                            break
+                        swapped = (
+                            buf[:a_start] + b + buf[a_start + n:b_start] +
+                            a + buf[b_start + n:])
+                        assert len(swapped) == len(buf)
+                        assert swapped < buf
+                        if self.incorporate_new_buffer(swapped):
+                            j -= 1
+                        else:
+                            break
+                    i += 1
+
+            if change_counter != self.changed:
+                self.debug('Restarting')
+                continue
+
             self.debug('Shuffling suffixes while shrinking %r' % (
                 self.last_data.bind_points,
             ))

--- a/src/hypothesis/internal/conjecture/minimizer.py
+++ b/src/hypothesis/internal/conjecture/minimizer.py
@@ -92,9 +92,6 @@ class Minimizer(object):
     def ddshift(self):
         self.ddfixate(lambda b: b >> 1)
 
-    def ddsub(self):
-        self.ddfixate(lambda b: max(0, b - 1))
-
     def ddfixate(self, f):
         prev = -1
         while prev != self.changes:
@@ -158,7 +155,6 @@ class Minimizer(object):
 
             self.ddzero()
             self.ddshift()
-            self.ddsub()
 
             if change_counter != self.changes:
                 continue

--- a/tests/cover/test_conjecture_engine.py
+++ b/tests/cover/test_conjecture_engine.py
@@ -470,24 +470,6 @@ def test_garbage_collects_the_database():
     assert 0 < len(set(db.fetch(key))) < n
 
 
-def test_variable_replacement():
-    @run_to_buffer
-    def x(data):
-        for _ in range(5):
-            data.start_example()
-            c = 0
-            while True:
-                d = data.draw_bytes(1)[0]
-                if not d:
-                    break
-                c += d
-            data.stop_example()
-            if c < 1000:
-                data.mark_invalid()
-        data.mark_interesting()
-    assert x == x[:x.index(0) + 1] * 5
-
-
 @given(st.randoms(), st.random_module())
 def test_maliciously_bad_generator(rnd, seed):
     rnd = Random()


### PR DESCRIPTION
This removes two passes from the shrinker:

* the ddsub pass in the lexicographic minimizer that subtracted 1 from each byte
* the interval replacement pass

These turn out to be the source of at least one flaky test in test\_example\_quality (the large union test) - both of them would occasionally get stuck there and produce bad shrinks:

* In the ddsub pass it would suffer from a problem of too many shrinks - it would perform a lot of small shrinks instead of the more desirable few numbers of large shrinks.
* the interval replacement pass was largely useless for this test but still ended up taking up a lot of time

Moreover both of these passes appear to be unneeded. The ddsub pass is mostly redundant with the later attempts to shrink individual indices, which work better because they tend to go straight for a larger shrink by starting from close to 0.

I'm not sure why the interval replacement pass is now unneeded, but all the example quality tests pass without it. It seems to be the result of improvements in the rest of the shrinker now making it largely redundant.