### PR TITLE
Don't run the nose CI build on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,6 +76,8 @@ matrix:
         - os: osx
           env: TASK=check-py35
         - os: osx
+          env: TASK=check-nose
+        - os: osx
           env: TASK=check-pytest28
         - os: osx
           env: TASK=check-fakefactory052


### PR DESCRIPTION
While poking around #460, I spotted that the `check-nose` task is the last of the “less important” tests that we still run on OS X. I think we should kill it.

AFAIK there’s no difference between nose on Linux vs. OS X, and because OS X has to provision a VM rather than spin up a container, it slows down the build – this is often the last job to finish.