### PR TITLE
Make another example quality test more reliable

### DIFF
--- a/tests/quality/test_shrink_quality.py
+++ b/tests/quality/test_shrink_quality.py
@@ -490,14 +490,17 @@ def test_anti_sorted_ordered_pair():
 
 
 def test_constant_lists_of_diverse_length():
-    # This does not currently work very well. We delete, but we don't actually
-    # get all that far with simplification of the individual elements.
+    n_elements = 20
+
     result = minimal(
-        lists(constant_list(integers())),
-        lambda x: len(set(map(len, x))) >= 20,
+        lists(constant_list(integers()), min_size=n_elements),
+        lambda x: len(set(map(len, x))) >= n_elements,
         timeout_after=30,
     )
-    assert len(result) == 20
+    assert len(result) == n_elements
+    for v in result:
+        assert v == [0] * len(v)
+    assert sorted(map(len, result)) == list(hrange(n_elements))
 
 
 def test_finds_non_reversible_floats():


### PR DESCRIPTION
Now that we're "running time faster" this test seems to sometimes fail
at the generation stage with NoSuchExample.

Adding a min_size parameter there means that it should stop doing that.

While in the area I noticed we're now much better about shrinking this
example so I also added stronger assertions about the result.