### PR TITLE
Remove unused pragma: no cover

### DIFF
--- a/tests/cover/test_lambda_formatting.py
+++ b/tests/cover/test_lambda_formatting.py
@@ -46,11 +46,11 @@ def test_can_get_descriptions_of_nested_lambdas_with_different_names():
 def test_source_of_lambda_is_pretty():
     assert get_pretty_function_description(
         lambda x: True
-    ) == 'lambda x: True'  # pragma: no cover
+    ) == 'lambda x: True'
 
 
 def test_variable_names_are_not_pretty():
-    t = lambda x: True  # pragma: no cover
+    t = lambda x: True
     assert get_pretty_function_description(t) == 'lambda x: True'
 
 
@@ -61,35 +61,35 @@ def test_does_not_error_on_dynamically_defined_functions():
 
 def test_collapses_whitespace_nicely():
     t = (
-        lambda x,       y:           1  # pragma: no cover
+        lambda x,       y:           1
     )
     assert get_pretty_function_description(t) == 'lambda x, y: 1'
 
 
 def test_is_not_confused_by_tuples():
-    p = (lambda x: x > 1, 2)[0]  # pragma: no cover
+    p = (lambda x: x > 1, 2)[0]
 
     assert get_pretty_function_description(p) == 'lambda x: x > 1'
 
 
 def test_strips_comments_from_the_end():
-    t = lambda x: 1  # pragma: no cover
+    t = lambda x: 1
     assert get_pretty_function_description(t) == 'lambda x: 1'
 
 
 def test_does_not_strip_hashes_within_a_string():
-    t = lambda x: '#'  # pragma: no cover
+    t = lambda x: '#'
     assert get_pretty_function_description(t) == "lambda x: '#'"
 
 
 def test_can_distinguish_between_two_lambdas_with_different_args():
-    a, b = (lambda x: 1, lambda y: 2)  # pragma: no cover
+    a, b = (lambda x: 1, lambda y: 2)
     assert get_pretty_function_description(a) == 'lambda x: 1'
     assert get_pretty_function_description(b) == 'lambda y: 2'
 
 
 def test_does_not_error_if_it_cannot_distinguish_between_two_lambdas():
-    a, b = (lambda x: 1, lambda x: 2)  # pragma: no cover
+    a, b = (lambda x: 1, lambda x: 2)
     assert 'lambda x:' in get_pretty_function_description(a)
     assert 'lambda x:' in get_pretty_function_description(b)
 

--- a/tests/cover/test_lambda_formatting.py
+++ b/tests/cover/test_lambda_formatting.py
@@ -42,6 +42,13 @@ def test_can_get_descriptions_of_nested_lambdas_with_different_names():
     assert get_pretty_function_description(ordered_pair) == \
         'lambda right: [].map(lambda length: ())'
 
+def test_does_not_error_on_unparsable_source():
+    t = [
+        lambda x: \
+        # This will break ast.parse, but the brackets are needed for the real
+        # parser to accept this lambda
+        x][0]
+    assert get_pretty_function_description(t) == 'lambda x: <unknown>'
 
 def test_source_of_lambda_is_pretty():
     assert get_pretty_function_description(

--- a/tests/cover/test_lambda_formatting.py
+++ b/tests/cover/test_lambda_formatting.py
@@ -80,7 +80,7 @@ def test_is_not_confused_by_tuples():
 
 
 def test_strips_comments_from_the_end():
-    t = lambda x: 1
+    t = lambda x: 1 # A lambda comment
     assert get_pretty_function_description(t) == 'lambda x: 1'
 
 

--- a/tests/cover/test_reflection.py
+++ b/tests/cover/test_reflection.py
@@ -81,7 +81,7 @@ def test_leaves_unknown_kwargs_in_dict():
 
 def test_errors_on_bad_kwargs():
     def bar():
-        pass    # pragma: no cover
+        pass
 
     with raises(TypeError):
         convert_keyword_arguments(bar, (), {'foo': 1})
@@ -98,14 +98,14 @@ def test_passes_varargs_correctly():
 
 def test_errors_if_keyword_precedes_positional():
     def foo(x, y):
-        pass  # pragma: no cover
+        pass
     with raises(TypeError):
         convert_keyword_arguments(foo, (1,), {'x': 2})
 
 
 def test_errors_if_not_enough_args():
     def foo(a, b, c, d=1):
-        pass  # pragma: no cover
+        pass
 
     with raises(TypeError):
         convert_keyword_arguments(foo, (1, 2), {'d': 4})
@@ -113,7 +113,7 @@ def test_errors_if_not_enough_args():
 
 def test_errors_on_extra_kwargs():
     def foo(a):
-        pass  # pragma: no cover
+        pass
 
     with raises(TypeError) as e:
         convert_keyword_arguments(foo, (1,), {'b': 1})
@@ -176,10 +176,10 @@ class Foo(object):
 
     @classmethod
     def bar(cls):
-        pass  # pragma: no cover
+        pass
 
     def baz(cls):
-        pass  # pragma: no cover
+        pass
 
     def __repr__(self):
         return 'SoNotFoo()'
@@ -205,7 +205,7 @@ def test_does_not_error_on_confused_sources():
         return f
 
     x = ed(
-        lambda x, y: (  # pragma: no cover
+        lambda x, y: (
             x * y
         ).conjugate() == x.conjugate() * y.conjugate(), complex, complex)
 


### PR DESCRIPTION
`sed -i "" 's/  # pragma: no cover$//' tests/cover/*`

This is the follow up PR from #481 