### PR TITLE
Start testing with Django 1.11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ _build
 .runtimes
 .idea
 .vagrant
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ env:
         - TASK=check-django18
         - TASK=check-django19
         - TASK=check-django110
+        - TASK=check-django111
 
 script:
     - make $TASK

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,9 +47,7 @@ env:
         - TASK=check-fakefactory052
         - TASK=check-fakefactory053
         - TASK=check-fakefactory060
-        - TASK=check-django17
         - TASK=check-django18
-        - TASK=check-django19
         - TASK=check-django110
         - TASK=check-django111
 

--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,10 @@ check-django19: $(TOX) $(PY35)
 check-django110: $(TOX) $(PY35)
 	$(TOX) -e django110
 
-check-django: check-django17 check-django18 check-django19 check-django110
+check-django111: $(TOX) $(PY35)
+	$(TOX) -e django111
+
+check-django: check-django17 check-django18 check-django19 check-django110 check-django111
 
 check-examples2: $(TOX) $(PY27)
 	$(TOX) -e examples2

--- a/Makefile
+++ b/Makefile
@@ -140,14 +140,8 @@ check-fakefactory052: $(TOX) $(PY35)
 check-fakefactory053: $(TOX) $(PY35)
 	$(TOX) -e fakefactory053
 
-check-django17: $(TOX) $(PY35)
-	$(TOX) -e django17
-
 check-django18: $(TOX) $(PY35)
 	$(TOX) -e django18
-
-check-django19: $(TOX) $(PY35)
-	$(TOX) -e django19
 
 check-django110: $(TOX) $(PY35)
 	$(TOX) -e django110
@@ -155,7 +149,7 @@ check-django110: $(TOX) $(PY35)
 check-django111: $(TOX) $(PY35)
 	$(TOX) -e django111
 
-check-django: check-django17 check-django18 check-django19 check-django110 check-django111
+check-django: check-django18 check-django110 check-django111
 
 check-examples2: $(TOX) $(PY27)
 	$(TOX) -e examples2

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ assert __version__ is not None
 extras = {
     'datetime':  ["pytz"],
     'fakefactory': ["Faker>=0.7.0,<=0.7.1"],
-    'django': ['pytz', 'django>=1.7,<2'],
+    'django': ['pytz', 'django>=1.9,<2'],
     'numpy': ['numpy>=1.9.0'],
     'pytest': ['pytest>=2.8.0'],
 }

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ assert __version__ is not None
 extras = {
     'datetime':  ["pytz"],
     'fakefactory': ["Faker>=0.7.0,<=0.7.1"],
-    'django': ['pytz', 'django>=1.7'],
+    'django': ['pytz', 'django>=1.7,<2'],
     'numpy': ['numpy>=1.9.0'],
     'pytest': ['pytest>=2.8.0'],
 }

--- a/tests/django/toys/settings.py
+++ b/tests/django/toys/settings.py
@@ -70,9 +70,9 @@ MIDDLEWARE_CLASSES = (
     u'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )
 
-ROOT_URLCONF = u'toys.urls'
+ROOT_URLCONF = u'tests.django.toys.urls'
 
-WSGI_APPLICATION = u'toys.wsgi.application'
+WSGI_APPLICATION = u'tests.django.toys.wsgi.application'
 
 
 # Database

--- a/tests/django/toys/urls.py
+++ b/tests/django/toys/urls.py
@@ -18,12 +18,12 @@
 from __future__ import division, print_function, absolute_import
 
 from django.contrib import admin
-from django.conf.urls import url, include, patterns
+from django.conf.urls import url, include
 
-urlpatterns = patterns(u'',
-                       # Examples:
-                       # url(r'^$', 'toys.views.home', name='home'),
-                       # url(r'^blog/', include('blog.urls')),
+urlpatterns = [
+    # Examples:
+    # url(r'^$', 'toys.views.home', name='home'),
+    # url(r'^blog/', include('blog.urls')),
 
-                       url(r'^admin/', include(admin.site.urls)),
-                       )
+    url(r'^admin/', include(admin.site.urls)),
+]

--- a/tox.ini
+++ b/tox.ini
@@ -77,27 +77,11 @@ commands =
     pip install --no-binary :all: fake-factory==0.5.3
     python -m pytest tests/fakefactory
 
-[testenv:django17]
-basepython=python3.4
-commands =
-    pip install .[datetime]
-    pip install django>=1.7,<1.7.99
-    python -m tests.django.manage test tests.django
-
-
 [testenv:django18]
 basepython=python3.4
 commands =
     pip install .[datetime]
     pip install django>=1.8,<1.8.99
-    python -m tests.django.manage test tests.django
-
-[testenv:django19]
-basepython=python3.4
-commands =
-    pip install .[datetime]
-    pip install --no-binary :all: .[fakefactory]
-    pip install django>=1.9,<1.9.99
     python -m tests.django.manage test tests.django
 
 [testenv:django110]

--- a/tox.ini
+++ b/tox.ini
@@ -108,6 +108,14 @@ commands =
     pip install django>=1.10,<1.10.99
     python -m tests.django.manage test tests.django
 
+[testenv:django111]
+basepython=python3.4
+commands =
+    pip install .[datetime]
+    pip install --no-binary :all: .[fakefactory]
+    pip install django>=1.11,<1.11.99
+    python -m tests.django.manage test tests.django
+
 [testenv:nose]
 basepython=python3.5
 deps =


### PR DESCRIPTION
This may shed light on the issues we’re having in #488. If not, it would be good to do this anyway.

On an entirely separate note, it looks like [Django 1.7 has been out of support](https://www.djangoproject.com/download/) for over a year, but we still test it in CI. Time to drop it?