### PR TITLE
Tidy up Faker-related tests in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,9 +44,8 @@ env:
         - TASK=check-py35
         - TASK=check-nose
         - TASK=check-pytest28
-        - TASK=check-fakefactory052
-        - TASK=check-fakefactory053
-        - TASK=check-fakefactory060
+        - TASK=check-faker070
+        - TASK=check-faker071
         - TASK=check-django18
         - TASK=check-django110
         - TASK=check-django111

--- a/Makefile
+++ b/Makefile
@@ -131,14 +131,11 @@ check-ancient-pip: $(PY273)
 
 check-pytest: check-pytest28 check-pytest30
 
-check-fakefactory060: $(TOX) $(PY35)
-	$(TOX) -e fakefactory060
+check-faker070: $(TOX) $(PY35)
+	$(TOX) -e faker070
 
-check-fakefactory052: $(TOX) $(PY35)
-	$(TOX) -e fakefactory052
-
-check-fakefactory053: $(TOX) $(PY35)
-	$(TOX) -e fakefactory053
+check-faker071: $(TOX) $(PY35)
+	$(TOX) -e faker071
 
 check-django18: $(TOX) $(PY35)
 	$(TOX) -e django18

--- a/tox.ini
+++ b/tox.ini
@@ -53,28 +53,20 @@ setenv=
 commands=
     python scripts/unicodechecker.py
 
-[testenv:fakefactory052]
+[testenv:faker070]
 basepython=python3.5
 deps =
   pytest==3.0.2
 commands =
-    pip install --no-binary :all: fake-factory==0.5.2
+    pip install --no-binary :all: Faker==0.7.0
     python -m pytest tests/fakefactory
 
-[testenv:fakefactory060]
+[testenv:faker071]
 basepython=python3.5
 deps =
   pytest==3.0.2
 commands =
-    pip install --no-binary :all: fake-factory==0.6.0
-    python -m pytest tests/fakefactory
-
-[testenv:fakefactory053]
-basepython=python3.5
-deps =
-  pytest==3.0.2
-commands =
-    pip install --no-binary :all: fake-factory==0.5.3
+    pip install --no-binary :all: Faker==0.7.1
     python -m pytest tests/fakefactory
 
 [testenv:django18]


### PR DESCRIPTION
We swapped out fakefactory for Faker a while ago, but we still have tests that pin specific versions of fakefactory.  This is a pointless test – switch to tests that pin faker instead.