### PR TITLE
Track a tree of where Hypothesis has explored

### DIFF
--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -92,15 +92,10 @@ def reify_and_execute(
     print_example=False,
     is_final=False,
 ):
-    from hypothesis.strategies import random_module
-
     def run(data):
-        from hypothesis.control import note
-
         with BuildContext(data, is_final=is_final):
-            seed = data.draw(random_module()).seed
-            if seed != 0:
-                note('random.seed(%d)' % (seed,))
+            import random as rnd_module
+            rnd_module.seed(0)
             args, kwargs = data.draw(search_strategy)
 
             if print_example:

--- a/src/hypothesis/internal/conjecture/data.py
+++ b/src/hypothesis/internal/conjecture/data.py
@@ -21,8 +21,7 @@ from enum import IntEnum
 
 from hypothesis.errors import Frozen, InvalidArgument
 from hypothesis.internal.compat import hbytes, hrange, text_type, \
-    int_to_bytes, benchmark_time, unicode_safe_repr, \
-    reasonable_byte_type
+    int_to_bytes, benchmark_time, unicode_safe_repr
 
 
 def uniform(random, n):
@@ -176,7 +175,7 @@ class ConjectureData(object):
         assert self.index == initial
         self.buffer.extend(result)
         self.intervals.append((initial, self.index))
-        return reasonable_byte_type(result)
+        return hbytes(result)
 
     def mark_interesting(self):
         self.__assert_not_frozen('mark_interesting')

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -417,8 +417,8 @@ class ConjectureRunner(object):
 
             mutator = self._new_mutator()
             while (
-                self.last_data.status != Status.INTERESTING
-                and not self.__tree_is_exhausted()
+                self.last_data.status != Status.INTERESTING and
+                not self.__tree_is_exhausted()
             ):
                 if self.valid_examples >= self.settings.max_examples:
                     self.exit_reason = ExitReason.max_examples

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -473,10 +473,6 @@ class ConjectureRunner(object):
             self.exit_reason = ExitReason.finished
             return
 
-        if not self.last_data.buffer:
-            self.exit_reason = ExitReason.finished
-            return
-
         data = ConjectureData.for_buffer(self.last_data.buffer)
         self.test_function(data)
         if data.status != Status.INTERESTING:

--- a/src/hypothesis/internal/conjecture/utils.py
+++ b/src/hypothesis/internal/conjecture/utils.py
@@ -138,6 +138,8 @@ def biased_coin(data, p):
 
 
 def write(data, string):
+    assert isinstance(string, hbytes)
+
     def distribution(random, n):
         assert n == len(string)
         return string

--- a/src/hypothesis/searchstrategy/collections.py
+++ b/src/hypothesis/searchstrategy/collections.py
@@ -21,7 +21,7 @@ from collections import namedtuple
 
 import hypothesis.internal.conjecture.utils as cu
 from hypothesis.control import assume
-from hypothesis.internal.compat import OrderedDict
+from hypothesis.internal.compat import OrderedDict, hbytes
 from hypothesis.searchstrategy.strategies import SearchStrategy, \
     MappedSearchStrategy, one_of_strategies
 
@@ -62,6 +62,9 @@ class TupleStrategy(SearchStrategy):
         return self.newtuple(
             data.draw(e) for e in self.element_strategies
         )
+
+
+TERMINATOR = hbytes(b'\0')
 
 
 class ListStrategy(SearchStrategy):
@@ -118,7 +121,7 @@ class ListStrategy(SearchStrategy):
             data.stop_example()
             result.append(value)
         else:
-            cu.write(data, b'\0')
+            cu.write(data, TERMINATOR)
         return result
 
     def __repr__(self):

--- a/tests/cover/test_completion.py
+++ b/tests/cover/test_completion.py
@@ -1,0 +1,32 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2016 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+from hypothesis import strategies as st
+from hypothesis import given, settings
+
+
+@given(st.data())
+def test_never_draw_anything(data):
+    pass
+
+
+@settings(min_satisfying_examples=1000)
+@given(st.booleans())
+def test_want_more_than_exist(b):
+    pass

--- a/tests/cover/test_conjecture_engine.py
+++ b/tests/cover/test_conjecture_engine.py
@@ -18,6 +18,7 @@
 from __future__ import division, print_function, absolute_import
 
 import time
+from random import seed as seed_random
 from random import Random
 
 from hypothesis import strategies as st
@@ -472,13 +473,58 @@ def test_garbage_collects_the_database():
 
 @given(st.randoms(), st.random_module())
 def test_maliciously_bad_generator(rnd, seed):
-    rnd = Random()
-
     @run_to_buffer
     def x(data):
-        for _ in range(rnd.randint(0, 100)):
-            data.draw_bytes(rnd.randint(0, 10))
+        for _ in range(rnd.randint(1, 100)):
+            data.draw_bytes(rnd.randint(1, 10))
         if rnd.randint(0, 1):
             data.mark_invalid()
         else:
             data.mark_interesting()
+
+
+@given(st.random_module())
+def test_lot_of_dead_nodes(rnd):
+    @run_to_buffer
+    def x(data):
+        for i in range(5):
+            if data.draw_bytes(1)[0] != i:
+                data.mark_invalid()
+        data.mark_interesting()
+    assert x == hbytes([0, 1, 2, 3, 4])
+
+
+def test_one_dead_branch():
+    seed_random(0)
+    seen = set()
+
+    @run_to_buffer
+    def x(data):
+        i = data.draw_bytes(1)[0]
+        if i > 0:
+            data.mark_invalid()
+        i = data.draw_bytes(1)[0]
+        if len(seen) < 255:
+            seen.add(i)
+        elif i not in seen:
+            data.mark_interesting()
+
+
+def test_fully_exhaust_base():
+    """In this test we generate all possible values for the first byte but
+    never get to the point where we exhaust the root of the tree."""
+    seed_random(0)
+
+    seen = set()
+
+    def f(data):
+        seen.add(data.draw_bytes(2))
+
+    runner = ConjectureRunner(f, settings=settings(
+        max_examples=5000, max_iterations=10000, max_shrinks=MAX_SHRINKS,
+        buffer_size=1024,
+        database=None,
+    ))
+    runner.run()
+    assert len(seen) > 256
+    assert len({x[0] for x in seen}) == 256

--- a/tests/cover/test_duplication.py
+++ b/tests/cover/test_duplication.py
@@ -1,0 +1,69 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2016 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+from collections import Counter
+
+import pytest
+
+from hypothesis import given, settings
+from hypothesis.searchstrategy import SearchStrategy
+
+
+class Blocks(SearchStrategy):
+    def __init__(self, n):
+        self.n = n
+
+    def do_draw(self, data):
+        return data.draw_bytes(self.n)
+
+
+@pytest.mark.parametrize('n', range(1, 5))
+def test_does_not_duplicate_blocks(n):
+    counts = Counter()
+
+    @given(Blocks(n))
+    def test(b):
+        counts[b] += 1
+    test()
+    assert set(counts.values()) == {1}
+
+
+@pytest.mark.parametrize('n', range(1, 5))
+def test_mostly_does_not_duplicate_blocks_even_when_failing(n):
+    counts = Counter()
+
+    @settings(database=None)
+    @given(Blocks(n))
+    def test(b):
+        counts[b] += 1
+        if len(counts) > 3:
+            raise ValueError()
+    try:
+        test()
+    except ValueError:
+        pass
+    # There are two circumstances in which a duplicate is allowed: We replay
+    # the failing test once to check for flakiness, and then we replay the
+    # fully minimized failing test at the end to display the error. The
+    # complication comes from the fact that these may or may not be the same
+    # test case, so we can see either two test cases each run twice or one
+    # test case which has been run three times.
+    seen_counts = set(counts.values())
+    assert seen_counts in ({1, 2}, {1, 3})
+    assert len([k for k, v in counts.items() if v > 1]) <= 2

--- a/tests/cover/test_random_module.py
+++ b/tests/cover/test_random_module.py
@@ -44,33 +44,4 @@ def test_seed_random_twice(r, r2):
 
 @given(st.random_module())
 def test_does_not_fail_health_check_if_randomness_is_used(r):
-    import random
     random.getrandbits(128)
-
-
-def test_reports_non_zero_seed():
-    random.seed(0)
-    zero_value = random.randint(0, 10)
-
-    with capture_out() as out:
-        with reporting.with_reporter(reporting.default):
-            with pytest.raises(AssertionError):
-                @given(st.integers())
-                def test(r):
-                    assert random.randint(0, 10) == zero_value
-                test()
-    assert 'random.seed' in out.getvalue()
-
-
-def test_does_not_report_zero_seed():
-    random.seed(0)
-    zero_value = random.randint(0, 3)
-
-    with capture_out() as out:
-        with reporting.with_reporter(reporting.default):
-            with pytest.raises(AssertionError):
-                @given(st.integers())
-                def test(r):
-                    assert random.randint(0, 3) != zero_value
-                test()
-    assert 'random.seed' not in out.getvalue()


### PR DESCRIPTION
This lets us do two important things:

* We can avoid testing duplicate buffers, both during generation
  and shrinking.
* When shrinking we can additionally avoid testing any buffers
  that are a prefix of a buffer we've already tried (which will
  result in an overrun).

This is partly intended as a performance improvement, partly intended
as a data quality improvement. The data quality improvement is
straightforward: In cases where we previously wasted our example
budget on duplicates, we now don't.

The performance improvement in our
own tests is mild to non-existent, but that's because the actual
functions under test are quite fast. For things where that's not
the case, this should be a significant improvement. I especially
expect it to be useful for stateful testing.

Another small change this makes is that we no longer seed the
global random module to an interesting seed by default. This is
because that creates a way for values to look distinct where
they are not. Instead we just seed it to zero, and rely on the
user to ask for it if they want a more interesting seed.