### PR TITLE
Rationalize which version of Python 3 we use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ check-pytest30: $(TOX)
 check-pytest28: $(TOX)
 	$(TOX) -e pytest28
 
-check-quality: $(BEST_PY3) $(TOX)
+check-quality: $(TOX)
 	$(TOX) -e quality
 
 check-ancient-pip: $(PY273)
@@ -161,9 +161,8 @@ check-noformat: check-coverage check-py26 check-py27 check-py33 check-py34 check
 
 check: check-format check-noformat
 
-check-fast: lint $(BEST_PY3) $(PYPY) $(TOX)
+check-fast: lint $(PYPY) $(PY36) $(TOX)
 	$(TOX) -e pypy-brief
-	$(TOX) -e py35-brief
 	$(TOX) -e py36-prettyquick
 
 $(TOX): $(BEST_PY3) tox.ini $(TOOLS)

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ $(PYPY):
 
 $(TOOL_VIRTUALENV): $(BEST_PY3) requirements/tools.txt
 	rm -rf $(TOOL_VIRTUALENV)
-	$(PY34) -m virtualenv $(TOOL_VIRTUALENV)
+	$(BEST_PY3) -m virtualenv $(TOOL_VIRTUALENV)
 	$(TOOL_PIP) install -r requirements/tools.txt
 
 $(TOOLS): $(TOOL_VIRTUALENV)

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ check-py273: $(PY273) $(TOX)
 check-py33: $(PY33) $(TOX)
 	$(TOX) -e py33-full
 
-check-py34: $(py34) $(TOX)
+check-py34: $(PY34) $(TOX)
 	$(TOX) -e py34-full
 
 check-py35: $(PY35) $(TOX)

--- a/Makefile
+++ b/Makefile
@@ -110,13 +110,13 @@ check-py36: $(BEST_PY3) $(TOX)
 check-pypy: $(PYPY) $(TOX)
 	$(TOX) -e pypy-full
 
-check-nose: $(TOX) $(BEST_PY3)
+check-nose: $(TOX)
 	$(TOX) -e nose
 
-check-pytest30: $(TOX) $(BEST_PY3)
+check-pytest30: $(TOX)
 	$(TOX) -e pytest30
 
-check-pytest28: $(TOX) $(BEST_PY3)
+check-pytest28: $(TOX)
 	$(TOX) -e pytest28
 
 check-quality: $(BEST_PY3) $(TOX)
@@ -128,19 +128,19 @@ check-ancient-pip: $(PY273)
 
 check-pytest: check-pytest28 check-pytest30
 
-check-faker070: $(TOX) $(BEST_PY3)
+check-faker070: $(TOX)
 	$(TOX) -e faker070
 
-check-faker071: $(TOX) $(BEST_PY3)
+check-faker071: $(TOX)
 	$(TOX) -e faker071
 
-check-django18: $(TOX) $(BEST_PY3)
+check-django18: $(TOX)
 	$(TOX) -e django18
 
-check-django110: $(TOX) $(BEST_PY3)
+check-django110: $(TOX)
 	$(TOX) -e django110
 
-check-django111: $(TOX) $(BEST_PY3)
+check-django111: $(TOX)
 	$(TOX) -e django111
 
 check-django: check-django18 check-django110 check-django111
@@ -148,10 +148,10 @@ check-django: check-django18 check-django110 check-django111
 check-examples2: $(TOX) $(PY27)
 	$(TOX) -e examples2
 
-check-examples3: $(TOX) $(BEST_PY3)
+check-examples3: $(TOX)
 	$(TOX) -e examples3
 
-check-coverage: $(TOX) $(BEST_PY3)
+check-coverage: $(TOX)
 	$(TOX) -e coverage
 
 check-unicode: $(TOX) $(PY27)

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ PY35=$(BUILD_RUNTIMES)/snakepit/python3.5
 PY36=$(BUILD_RUNTIMES)/snakepit/python3.6
 PYPY=$(BUILD_RUNTIMES)/snakepit/pypy
 
+BEST_PY3=$(PY36)
+
 TOOLS=$(BUILD_RUNTIMES)/tools
 
 TOX=$(TOOLS)/tox
@@ -60,7 +62,7 @@ $(PY36):
 $(PYPY):
 	scripts/retry.sh scripts/install.sh pypy
 
-$(TOOL_VIRTUALENV): $(PY34) requirements/tools.txt
+$(TOOL_VIRTUALENV): $(BEST_PY3) requirements/tools.txt
 	rm -rf $(TOOL_VIRTUALENV)
 	$(PY34) -m virtualenv $(TOOL_VIRTUALENV)
 	$(TOOL_PIP) install -r requirements/tools.txt
@@ -85,7 +87,7 @@ check-format: format
 	find src tests -name "*.py" | xargs $(TOOL_PYTHON) scripts/check_encoding_header.py
 	git diff --exit-code
 
-install-core: $(PY27) $(PYPY) $(PY36) $(TOX)
+install-core: $(PY27) $(PYPY) $(BEST_PY3) $(TOX)
 
 check-py27: $(PY27) $(TOX)
 	$(TOX) -e py27-full
@@ -102,22 +104,22 @@ check-py34: $(py34) $(TOX)
 check-py35: $(PY35) $(TOX)
 	$(TOX) -e py35-full
 
-check-py36: $(PY36) $(TOX)
+check-py36: $(BEST_PY3) $(TOX)
 	$(TOX) -e py36-full
 
 check-pypy: $(PYPY) $(TOX)
 	$(TOX) -e pypy-full
 
-check-nose: $(TOX) $(PY35)
+check-nose: $(TOX) $(BEST_PY3)
 	$(TOX) -e nose
 
-check-pytest30: $(TOX) $(PY35)
+check-pytest30: $(TOX) $(BEST_PY3)
 	$(TOX) -e pytest30
 
-check-pytest28: $(TOX) $(PY35)
+check-pytest28: $(TOX) $(BEST_PY3)
 	$(TOX) -e pytest28
 
-check-quality: $(PY36) $(TOX)
+check-quality: $(BEST_PY3) $(TOX)
 	$(TOX) -e quality
 
 check-ancient-pip: $(PY273)
@@ -126,19 +128,19 @@ check-ancient-pip: $(PY273)
 
 check-pytest: check-pytest28 check-pytest30
 
-check-faker070: $(TOX) $(PY35)
+check-faker070: $(TOX) $(BEST_PY3)
 	$(TOX) -e faker070
 
-check-faker071: $(TOX) $(PY35)
+check-faker071: $(TOX) $(BEST_PY3)
 	$(TOX) -e faker071
 
-check-django18: $(TOX) $(PY35)
+check-django18: $(TOX) $(BEST_PY3)
 	$(TOX) -e django18
 
-check-django110: $(TOX) $(PY35)
+check-django110: $(TOX) $(BEST_PY3)
 	$(TOX) -e django110
 
-check-django111: $(TOX) $(PY35)
+check-django111: $(TOX) $(BEST_PY3)
 	$(TOX) -e django111
 
 check-django: check-django18 check-django110 check-django111
@@ -146,10 +148,10 @@ check-django: check-django18 check-django110 check-django111
 check-examples2: $(TOX) $(PY27)
 	$(TOX) -e examples2
 
-check-examples3: $(TOX) $(PY35)
+check-examples3: $(TOX) $(BEST_PY3)
 	$(TOX) -e examples3
 
-check-coverage: $(TOX) $(PY35)
+check-coverage: $(TOX) $(BEST_PY3)
 	$(TOX) -e coverage
 
 check-unicode: $(TOX) $(PY27)
@@ -159,13 +161,12 @@ check-noformat: check-coverage check-py26 check-py27 check-py33 check-py34 check
 
 check: check-format check-noformat
 
-check-fast: lint $(PY35) $(PYPY) $(TOX)
+check-fast: lint $(BEST_PY3) $(PYPY) $(TOX)
 	$(TOX) -e pypy-brief
 	$(TOX) -e py35-brief
-	$(TOX) -e py26-brief
-	$(TOX) -e py35-prettyquick
+	$(TOX) -e py36-prettyquick
 
-$(TOX): $(PY35) tox.ini $(TOOLS)
+$(TOX): $(BEST_PY3) tox.ini $(TOOLS)
 	rm -f $(TOX)
 	ln -sf $(TOOL_VIRTUALENV)/bin/tox $(TOX)
 	touch $(TOOL_VIRTUALENV)/bin/tox $(TOX)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -107,7 +107,7 @@ for var in "$@"; do
       install 3.5.1 python3.5
       ;;
     3.6)
-      install 3.6.0 python3.6
+      install 3.6.1 python3.6
       ;;
     pypy)
       install pypy-5.3.1 pypy

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,6 @@ commands =
     benchmark: python -m pytest benchmarks
 
 [testenv:quality]
-basepython=python3.6
 deps=
     -rrequirements/test.txt
 commands=
@@ -50,7 +49,6 @@ commands=
     python scripts/unicodechecker.py
 
 [testenv:faker070]
-basepython=python3.5
 deps =
     -rrequirements/test.txt
 commands =
@@ -58,7 +56,6 @@ commands =
     python -m pytest tests/fakefactory
 
 [testenv:faker071]
-basepython=python3.5
 deps =
     -rrequirements/test.txt
 commands =
@@ -66,14 +63,12 @@ commands =
     python -m pytest tests/fakefactory
 
 [testenv:django18]
-basepython=python3.4
 commands =
     pip install .[datetime]
     pip install django>=1.8,<1.8.99
     python -m tests.django.manage test tests.django
 
 [testenv:django110]
-basepython=python3.4
 commands =
     pip install .[datetime]
     pip install --no-binary :all: .[fakefactory]
@@ -81,7 +76,6 @@ commands =
     python -m tests.django.manage test tests.django
 
 [testenv:django111]
-basepython=python3.4
 commands =
     pip install .[datetime]
     pip install --no-binary :all: .[fakefactory]
@@ -89,34 +83,29 @@ commands =
     python -m tests.django.manage test tests.django
 
 [testenv:nose]
-basepython=python3.5
 deps =
     nose
 commands=
     nosetests tests/cover/test_testdecorators.py
 
 [testenv:pytest30]
-basepython=python3.5
 deps =
     -rrequirements/test.txt
 commands=
     python -m pytest tests/pytest tests/cover/test_testdecorators.py
 
 [testenv:pytest28]
-basepython=python3.5
 deps =
     -rrequirements/test.txt
 commands=
     python -m pytest tests/pytest tests/cover/test_testdecorators.py
 
 [testenv:docs]
-basepython=python3.4
 deps = sphinx
 commands=sphinx-build -W -b html -d docs/_build/doctrees   docs docs/_build/html
 
 
 [testenv:coverage]
-basepython=python3.4
 deps =
     -rrequirements/test.txt
     coverage
@@ -130,7 +119,6 @@ commands =
 [testenv:examples3]
 setenv=
     HYPOTHESIS_STRICT_MODE=true
-basepython=python3.4
 deps=
     -rrequirements/test.txt
 commands=


### PR DESCRIPTION
Depending on the phase of the task being run and the phase of the
moon, we were previously using one of Python 3.4.3, Python 3.5.1 or
Python 3.6.0 for our Python 3. This is silly and we should stop.

This updates everything to run on Python 3.6.1.

In particular:

* We now configure the best python 3 version in a single variable in the makefile
* We use tox's default of running with the same python it was launched with so we don't have to specify it in tox.in

This could use some followup work for making sure that when new Python versions come out we update our builds to use them, but I'm not going to do that now.