### PR TITLE
Give tools virtualenv a unique name per reqs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ PYFORMAT=$(TOOLS)/pyformat
 RSTLINT=$(TOOLS)/rst-lint
 
 BROKEN_VIRTUALENV=$(BUILD_RUNTIMES)/virtualenvs/broken
-TOOL_VIRTUALENV=$(BUILD_RUNTIMES)/virtualenvs/tools
+TOOL_VIRTUALENV:=$(BUILD_RUNTIMES)/virtualenvs/tools-$(shell scripts/tool-hash.py)
 TOOL_PYTHON=$(TOOL_VIRTUALENV)/bin/python
 TOOL_PIP=$(TOOL_VIRTUALENV)/bin/pip
 
@@ -63,8 +63,8 @@ $(PY36):
 $(PYPY):
 	scripts/retry.sh scripts/install.sh pypy
 
-$(TOOL_VIRTUALENV): $(BEST_PY3) requirements/tools.txt
-	rm -rf $(TOOL_VIRTUALENV)
+$(TOOL_VIRTUALENV): $(BEST_PY3)
+	rm -rf $(BUILD_RUNTIMES)/virtualenvs/tools-*
 	$(BEST_PY3) -m virtualenv $(TOOL_VIRTUALENV)
 	$(TOOL_PIP) install -r requirements/tools.txt
 

--- a/scripts/tool-hash.py
+++ b/scripts/tool-hash.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2016 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import os
+import hashlib
+
+SCRIPTS_DIR = os.path.dirname(os.path.abspath(__file__))
+ROOT_DIR = os.path.dirname(SCRIPTS_DIR)
+
+TOOLS_FILE = os.path.join(
+    ROOT_DIR, "requirements", "tools.txt"
+)
+
+assert os.path.exists(TOOLS_FILE)
+
+if __name__ == '__main__':
+    with open(TOOLS_FILE, 'rb') as f:
+        tools = f.read()
+    print(hashlib.sha1(tools).hexdigest()[:10])


### PR DESCRIPTION
Apparently git is very timestamp happy and keeps touching tools.txt
even if it hasn't changed (and doesn't set mtime based on commits
like I thought it did). This means that the makefile repeatedly
ends up blowing away our tools virtualenv, which takes a long time
to reinstall.

This changes that approach by giving the tools virtualenv a name
based on the hash of the current contents of requirements/tools.txt
and removing the time dependency. That means that every time the
file actually changes we'll get a new tools virtualenv, but as long
as its contents remain the same we'll keep the same stable name and
not have to rebuild.