### PR TITLE
Prevent mixing str with compatbytes on Python 2.7

### DIFF
--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -38,6 +38,8 @@ from hypothesis.executors import new_style_executor, \
 from hypothesis.reporting import report, verbose_report, current_verbosity
 from hypothesis.statistics import note_engine_for_statistics
 from hypothesis.internal.compat import getargspec, str_to_bytes
+from hypothesis.internal.escalation import \
+    escalate_hypothesis_internal_error
 from hypothesis.internal.reflection import nicerepr, arg_string, \
     impersonate, function_digest, fully_qualified_name, \
     define_function_signature, convert_positional_arguments, \
@@ -460,6 +462,7 @@ def given(*generator_arguments, **generator_kwargs):
                 ):
                     raise
                 except Exception:
+                    escalate_hypothesis_internal_error()
                     last_exception[0] = traceback.format_exc()
                     verbose_report(last_exception[0])
                     data.mark_interesting()

--- a/src/hypothesis/internal/escalation.py
+++ b/src/hypothesis/internal/escalation.py
@@ -1,0 +1,44 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2016 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import os
+import sys
+
+INTERNAL_PACKAGE_DIR = os.path.dirname(os.path.abspath(__file__))
+HYPOTHESIS_ROOT = os.path.dirname(INTERNAL_PACKAGE_DIR)
+
+FILE_CACHE = {}
+
+
+def is_hypothesis_file(filepath):
+    try:
+        return FILE_CACHE[filepath]
+    except KeyError:
+        pass
+    result = os.path.abspath(filepath).startswith(HYPOTHESIS_ROOT)
+    FILE_CACHE[filepath] = result
+    return result
+
+
+def escalate_hypothesis_internal_error():
+    error_type, _, tb = sys.exc_info()
+    import traceback
+    filepath = traceback.extract_tb(tb)[-1][0]
+    if is_hypothesis_file(filepath):
+        raise

--- a/src/hypothesis/internal/floats.py
+++ b/src/hypothesis/internal/floats.py
@@ -18,7 +18,8 @@
 from __future__ import division, print_function, absolute_import
 
 import math
-import struct
+
+from hypothesis.internal.compat import struct_pack, struct_unpack
 
 
 def sign(x):
@@ -48,11 +49,11 @@ def count_between_floats(x, y):
 
 def float_to_int(value):
     return (
-        struct.unpack(b'!Q', struct.pack(b'!d', value))[0]
+        struct_unpack(b'!Q', struct_pack(b'!d', value))[0]
     )
 
 
 def int_to_float(value):
     return (
-        struct.unpack(b'!d', struct.pack(b'!Q', value))[0]
+        struct_unpack(b'!d', struct_pack(b'!Q', value))[0]
     )

--- a/src/hypothesis/searchstrategy/numbers.py
+++ b/src/hypothesis/searchstrategy/numbers.py
@@ -18,13 +18,12 @@
 from __future__ import division, print_function, absolute_import
 
 import math
-import struct
 from collections import namedtuple
 
 import hypothesis.internal.conjecture.utils as d
 from hypothesis.control import assume
-from hypothesis.internal.compat import int_to_bytes, int_from_bytes, \
-    bytes_from_list
+from hypothesis.internal.compat import hbytes, struct_pack, int_to_bytes, \
+    struct_unpack, int_from_bytes, bytes_from_list
 from hypothesis.internal.floats import sign
 from hypothesis.searchstrategy.strategies import SearchStrategy, \
     MappedSearchStrategy
@@ -157,8 +156,8 @@ class FloatStrategy(SearchStrategy):
                         random.randint(-2 ** 63, 2 ** 63), 1
                     )
                 if self.permitted(f):
-                    return struct.pack(b'!d', f)
-        result = struct.unpack(b'!d', bytes(
+                    return struct_pack(b'!d', f)
+        result = struct_unpack(b'!d', hbytes(
             data.draw_bytes(8, draw_float_bytes)))[0]
         assume(self.permitted(result))
         return result
@@ -210,8 +209,8 @@ class FixedBoundedFloatStrategy(SearchStrategy):
                 f = random.random() * (
                     self.upper_bound - self.lower_bound
                 ) + self.lower_bound
-            return struct.pack(b'!d', f)
-        f = struct.unpack(b'!d', bytes(
+            return struct_pack(b'!d', f)
+        f = struct_unpack(b'!d', hbytes(
             data.draw_bytes(8, draw_float_bytes)))[0]
         assume(self.lower_bound <= f <= self.upper_bound)
         assume(sign(self.lower_bound) <= sign(f) <= sign(self.upper_bound))


### PR DESCRIPTION
Hey, so you know how we have that flaky test for interleaving engines?

Did you notice it was only flaky on Python 2.7? (I didn't).

It turns out that this is because shrinking doesn't work properly on Python 2.7. Oops. There are a number of mishaps where we have str where we meant to have hbytes (AKA something that actually behaves like bytes behaves on Python 3), and this was resulting in doing the wrong thing entirely.

This pulls out some of my changes from #498 which tighten up on this by raising an error when you try to mix str and compatbytes. This flushed out a few places we were doing this, which this also fixes.