### PR TITLE
Do not seed random.module from data by default

### DIFF
--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -92,15 +92,10 @@ def reify_and_execute(
     print_example=False,
     is_final=False,
 ):
-    from hypothesis.strategies import random_module
-
     def run(data):
-        from hypothesis.control import note
-
         with BuildContext(data, is_final=is_final):
-            seed = data.draw(random_module()).seed
-            if seed != 0:
-                note('random.seed(%d)' % (seed,))
+            import random as rnd_module
+            rnd_module.seed(0)
             args, kwargs = data.draw(search_strategy)
 
             if print_example:

--- a/tests/cover/test_random_module.py
+++ b/tests/cover/test_random_module.py
@@ -44,33 +44,4 @@ def test_seed_random_twice(r, r2):
 
 @given(st.random_module())
 def test_does_not_fail_health_check_if_randomness_is_used(r):
-    import random
     random.getrandbits(128)
-
-
-def test_reports_non_zero_seed():
-    random.seed(0)
-    zero_value = random.randint(0, 10)
-
-    with capture_out() as out:
-        with reporting.with_reporter(reporting.default):
-            with pytest.raises(AssertionError):
-                @given(st.integers())
-                def test(r):
-                    assert random.randint(0, 10) == zero_value
-                test()
-    assert 'random.seed' in out.getvalue()
-
-
-def test_does_not_report_zero_seed():
-    random.seed(0)
-    zero_value = random.randint(0, 3)
-
-    with capture_out() as out:
-        with reporting.with_reporter(reporting.default):
-            with pytest.raises(AssertionError):
-                @given(st.integers())
-                def test(r):
-                    assert random.randint(0, 3) != zero_value
-                test()
-    assert 'random.seed' not in out.getvalue()


### PR DESCRIPTION
The motivation for seeding the random module in tests (which remains)
is that this is a great source of people writing tests with
nondeterminism that is not under Hypothesis's control and then
blaming Hypothesis for the inevitable confusing behaviour. We used
to have a health check that complained about that, but it basically
just annoyed people because most of the time this was happening
deep in the bowels of something they were depending on.

On the other hand, doing this for every test causes a lot of annoyances
too - it makes examples look distinct when they're not, slows things
down, and generally is a constant small annoyance that can trip us
up.

So instead we implement a convenient halfway house: If we're not asked
to seed the random module explicitly, we just seed it to zero. This is
fast and avoids all the above problems while getting most of the benefits.

If a user wants to seed the random module after all, the random_module
strategy remains available for their use.

Nominally this should require a documentation update, but we (I) never
actually updated the documtation to say that random\module was
no longer necessary anyway. Oops.

This is another pull request extracted from #498, with a goal to making it a more reasonable size, so that PR will require some history wrangling once this is merged.