### PR TITLE
Don't mutate arguments to given.

### DIFF
--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -144,7 +144,7 @@ class WithRunner(SearchStrategy):
         return self.base.do_draw(data)
 
 
-def given(*generator_arguments, **generator_kwargs):
+def given(*given_arguments, **given_kwargs):
     """A decorator for turning a test function that accepts arguments into a
     randomized test.
 
@@ -153,6 +153,9 @@ def given(*generator_arguments, **generator_kwargs):
 
     """
     def run_test_with_generator(test):
+        generator_arguments = tuple(given_arguments)
+        generator_kwargs = dict(given_kwargs)
+
         original_argspec = getargspec(test)
 
         def invalid(message):

--- a/tests/cover/test_given_reuse.py
+++ b/tests/cover/test_given_reuse.py
@@ -1,0 +1,53 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2016 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import pytest
+
+from hypothesis import strategies as st
+from hypothesis import given
+
+given_booleans = given(st.booleans())
+
+
+@given_booleans
+def test_has_an_arg_named_x(x):
+    pass
+
+
+@given_booleans
+def test_has_an_arg_named_y(y):
+    pass
+
+
+given_named_booleans = given(z=st.text())
+
+
+def test_fail_independently():
+    @given_named_booleans
+    def test_z1(z):
+        assert False
+
+    @given_named_booleans
+    def test_z2(z):
+        pass
+
+    with pytest.raises(AssertionError):
+        test_z1()
+
+    test_z2()


### PR DESCRIPTION
This allows us to reuse the given decorator for multiple calls.

I'm reasonably sure this bug dates back to 2013.