### PR TITLE
Unified timedelta strategy

### DIFF
--- a/docs/extras.rst
+++ b/docs/extras.rst
@@ -21,8 +21,8 @@ hypothesis[datetime]
 --------------------
 
 As might be expected, this provides strategies for which generating instances
-of objects from the ``datetime`` module: ``datetime``\s, ``date``\s, and
-``time``\s. It depends on ``pytz`` to work.
+of objects from the ``datetime`` module: ``datetime``\s, ``date``\s, ``time``\s
+and ``timedelta``\s. It depends on ``pytz`` to work.
 
 It should work with just about any version of ``pytz``. ``pytz`` has a very
 stable API and Hypothesis works around a bug or two in older versions.

--- a/docs/extras.rst
+++ b/docs/extras.rst
@@ -115,6 +115,24 @@ It lives in the ``hypothesis.extra.datetime`` package.
 
     The ``allow_naive`` and ``timezones`` arguments act the same as the datetimes strategy.
 
+.. method:: timedeltas(min_value=timedelta.min, max_value=timedelta.max)
+
+    This strategy generates ``timedelta`` objects with values between `min_value` and `max_value`.
+
+    .. code-block:: pycon
+
+        >>> from hypothesis.extra.datetime import timedeltas
+        >>> from datetime import timedelta
+        >>> timedeltas().example()
+        datetime.timedelta(312117758, 82438, 23822)
+        >>> timedeltas().example()
+        datetime.timedelta(-385392744, 62116, 995342)
+        >>> timedeltas(min_value=timedelta(hours=1), max_value=timedelta(days=1)).example()
+        datetime.timedelta(0, 56116, 149715)
+
+    The ``min_value`` and ``max_value`` parameters must both be ``timedelta``s
+    themselves, though both are optional, defaulting to the corresponding
+    ``min`` and ``max`` values declared on the ``timedelta`` class.
 
 -----------------------
 hypothesis[fakefactory]

--- a/src/hypothesis/extra/datetime.py
+++ b/src/hypothesis/extra/datetime.py
@@ -123,3 +123,42 @@ def times(allow_naive=None, timezones=None):
 
 def datetime_to_time(dt):
     return dt.timetz()
+
+
+def check_valid_bound(value, name):
+    if not isinstance(value, dt.timedelta):
+        raise InvalidArgument(name + ' must be a timedelta')
+
+
+def check_valid_interval(min_value, max_value, min_name, max_name):
+    if not min_value <= max_value:
+        raise InvalidArgument(min_name + ' must equal or be less than ' + max_name)
+
+
+def timedelta_to_micros(td):
+    SECS_IN_DAY = 3600 * 24
+    MICROS_IN_SEC = 1000000
+    MICROS_IN_DAY = MICROS_IN_SEC * SECS_IN_DAY
+
+    microseconds, seconds, days = td.microseconds, td.seconds, td.days
+    return (microseconds + (seconds * MICROS_IN_SEC) + (days * MICROS_IN_DAY))
+
+
+class TimedeltaStrategy(SearchStrategy):
+
+    def __init__(self, min_value=dt.timedelta.min, max_value=dt.timedelta.max):
+        check_valid_bound(min_value, 'min_value')
+        check_valid_bound(max_value, 'max_value')
+        check_valid_interval(min_value, max_value, 'min_value', 'max_value')
+
+        self.max_micros = timedelta_to_micros(max_value)
+        self.min_micros = timedelta_to_micros(min_value)
+
+    def do_draw(self, data):
+        td_micros = cu.integer_range(data, self.min_micros, self.max_micros)
+        return dt.timedelta(microseconds=td_micros)
+
+
+@defines_strategy
+def timedeltas(min_value=dt.timedelta.min, max_value=dt.timedelta.max):
+    return TimedeltaStrategy(min_value, max_value)

--- a/src/hypothesis/extra/datetime.py
+++ b/src/hypothesis/extra/datetime.py
@@ -125,31 +125,25 @@ def datetime_to_time(dt):
     return dt.timetz()
 
 
-def check_valid_bound(value, name):
-    if not isinstance(value, dt.timedelta):
-        raise InvalidArgument(name + ' must be a timedelta')
-
-
-def check_valid_interval(min_value, max_value, min_name, max_name):
-    if not min_value <= max_value:
-        raise InvalidArgument(min_name + ' must equal or be less than ' + max_name)
-
-
-def timedelta_to_micros(td):
-    SECS_IN_DAY = 3600 * 24
-    MICROS_IN_SEC = 1000000
-    MICROS_IN_DAY = MICROS_IN_SEC * SECS_IN_DAY
-
-    microseconds, seconds, days = td.microseconds, td.seconds, td.days
-    return (microseconds + (seconds * MICROS_IN_SEC) + (days * MICROS_IN_DAY))
-
-
 class TimedeltaStrategy(SearchStrategy):
 
     def __init__(self, min_value=dt.timedelta.min, max_value=dt.timedelta.max):
-        check_valid_bound(min_value, 'min_value')
-        check_valid_bound(max_value, 'max_value')
-        check_valid_interval(min_value, max_value, 'min_value', 'max_value')
+        if not isinstance(min_value, dt.timedelta):
+            raise InvalidArgument(
+                'min_value={} must be a timedelta'.format(min_value))
+        if not isinstance(max_value, dt.timedelta):
+            raise InvalidArgument(
+                'max_value={} must be a timedelta'.format(max_value))
+        if not min_value <= max_value:
+            raise InvalidArgument(
+                'min_value={} must equal or be less than max_value={}'
+                .format(min_value, max_value))
+
+        def timedelta_to_micros(td):
+            MICROS_PER_SEC = 10 ** 6
+            MICROS_PER_DAY = MICROS_PER_SEC * 60 * 60 * 24
+            return (td.microseconds + td.seconds * MICROS_PER_SEC +
+                    td.days * MICROS_PER_DAY)
 
         self.max_micros = timedelta_to_micros(max_value)
         self.min_micros = timedelta_to_micros(min_value)

--- a/tests/datetime/test_timedelta.py
+++ b/tests/datetime/test_timedelta.py
@@ -1,0 +1,61 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2015 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import datetime as dt
+
+from hypothesis.extra.datetime import timedeltas
+from hypothesis.internal.debug import minimal
+
+
+def test_can_find_positive_delta():
+    assert minimal(timedeltas(), lambda x: x.days > 0).days == 1
+
+
+def test_can_find_negative_delta():
+    assert minimal(timedeltas(), lambda x: x.days < 0).days == -1
+
+
+def test_can_find_zero_delta():
+    minimal(
+        timedeltas(),
+        lambda x: (x.days == 0 and x.seconds == 0 and x.microseconds == 0)
+    )
+
+
+def test_can_find_off_the_second():
+    minimal(timedeltas(), lambda x: x.seconds == 0)
+
+
+def test_can_find_on_the_second():
+    minimal(timedeltas(), lambda x: x.seconds != 0)
+
+
+def test_simplifies_towards_zero_delta():
+    d = minimal(timedeltas())
+    assert d.days == 0
+    assert d.seconds == 0
+    assert d.microseconds == 0
+
+
+def test_min_value_is_respected():
+    assert minimal(timedeltas(min_value=dt.timedelta(days=10))).days == 10
+
+
+def test_max_value_is_respected():
+    assert minimal(timedeltas(max_value=dt.timedelta(days=-10))).days == -10

--- a/tests/datetime/test_timedelta.py
+++ b/tests/datetime/test_timedelta.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis, which may be found at
 # https://github.com/HypothesisWorks/hypothesis-python
 #
-# Most of this work is copyright (C) 2013-2015 David R. MacIver
+# Most of this work is copyright (C) 2013-2017 David R. MacIver
 # (david@drmaciver.com), but it contains contributions by others. See
 # CONTRIBUTING.rst for a full list of people who may hold copyright, and
 # consult the git log if you need to determine who owns an individual


### PR DESCRIPTION
Drawing together the two existing pulls, which only needed some style fixes.  Test failures are largely related to undesired minimization (towards maximally-negative deltas rather than zero) and lack of coverage.

Closes #333.  Subsumes, closes #352.  Subsumes, closes #441.