### PR TITLE
Simple iterables strategy

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -22,6 +22,15 @@ You should generally assume that an API is internal unless you have specific
 information to the contrary.
 
 ------------------
+3.8.0 - 2017-04-23
+------------------
+
+This is a feature release, adding the ``iterables`` strategy, equivalent
+to ``lists(...).map(iter)`` but with a much more useful repr.  You can use
+this strategy to check that code doesn't accidentally depend on sequence
+properties such as indexing support or repeated iteration.
+
+------------------
 3.7.4 - 2017-04-22
 ------------------
 

--- a/src/hypothesis/internal/compat.py
+++ b/src/hypothesis/internal/compat.py
@@ -474,6 +474,13 @@ def get_stream_enc(stream, default=None):
     return getattr(stream, 'encoding', None) or default
 
 
+def implements_iterator(it):
+    """Turn things with a __next__ attribute into iterators on Python 2."""
+    if PY2 and not hasattr(it, 'next') and hasattr(it, '__next__'):
+        it.next = it.__next__
+    return it
+
+
 if PY3:
     FileNotFoundError = FileNotFoundError
 else:

--- a/src/hypothesis/version.py
+++ b/src/hypothesis/version.py
@@ -17,5 +17,5 @@
 
 from __future__ import division, print_function, absolute_import
 
-__version_info__ = (3, 7, 4)
+__version_info__ = (3, 8, 0)
 __version__ = '.'.join(map(str, __version_info__))

--- a/tests/cover/test_custom_reprs.py
+++ b/tests/cover/test_custom_reprs.py
@@ -20,6 +20,7 @@ from __future__ import division, print_function, absolute_import
 import pytest
 
 import hypothesis.strategies as st
+from hypothesis import given
 
 
 def test_includes_non_default_args_in_repr():
@@ -57,3 +58,9 @@ def test_errors_are_deferred_until_repr_is_calculated():
 
     with pytest.raises(ValueError):
         repr(s)
+
+
+@given(st.iterables(st.integers()))
+def test_iterables_repr_is_useful(it):
+    # fairly hard-coded but useful; also ensures _values are inexhaustible
+    assert repr(it) == 'iter({!r})'.format(it._values)

--- a/tests/cover/test_direct_strategies.py
+++ b/tests/cover/test_direct_strategies.py
@@ -280,3 +280,15 @@ def test_none_lists_respect_max_size(ls):
 )
 def test_none_lists_respect_max_and_min_size(ls):
     assert 1 <= len(ls) <= 5
+
+
+@given(ds.iterables(ds.integers(), max_size=5, min_size=1))
+def test_iterables_are_exhaustible(it):
+    for _ in it:
+        pass
+    with pytest.raises(StopIteration):
+        next(it)
+
+
+def test_minimal_iterable():
+    assert list(find(ds.iterables(ds.integers()), lambda x: True)) == []


### PR DESCRIPTION
Adds an `iterables()` strategy to close #135.  It's basically `st.lists(...).map(iter)`, but with a nicer `repr`.  Imagine trying to debug a falsifying example from `<list_iterator at 0x7c1e567518>` instead of `iter([1, 2, 3])`!