### PR TITLE
Use make in before_deploy instead of condition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,9 @@ notifications:
     on_success: never
     on_failure: change
 
+before_deploy:
+  - make check-deploy-and-tag
+
 deploy:
   provider: pypi
   user: DRMacIver
@@ -77,4 +80,3 @@ deploy:
   on:
     branch: master
     repo: HypothesisWorks/hypothesis-python
-    condition: make check-deploy-and-tag


### PR DESCRIPTION
According to [the Travis documentation](https://docs.travis-ci.com/user/customizing-the-build#Deploying-your-Code) the condition should be something that goes in a bash \[\[ \]\].

Rather than doing that, this instead makes it a before_deploy script. If this exits with a non-zero code then the build will error (which I think is correct behaviour) and the deploy won't run.