### PR TITLE
Temporarily remove the deploy functionality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,15 +68,3 @@ notifications:
       - david@drmaciver.com
     on_success: never
     on_failure: change
-
-before_deploy:
-  - make check-deploy-and-tag
-
-deploy:
-  provider: pypi
-  user: DRMacIver
-  password:
-    secure: T9tUyr9JG3KA8JprHUE8AAVaClUHHPHhiQRXC2/jHJv2EVEx2+EifkuR9sr5q1mCZ06g9v2+jhVNuaZyVuU9mmDKvJfADlPAagkCcgF/siuuJkzd3eIlELZHDtWPwKiZWCAD0Oj6yMdVB2w3/JTpJQhJx7HrL8EqbVdnN9YkMmI=
-  on:
-    branch: master
-    repo: HypothesisWorks/hypothesis-python


### PR DESCRIPTION
This is a temporary patch to fix master while I rethink how deployment works. I need to disappear for the next hour or so and will rethink how deployment should work when I get back.