### PR TITLE
Push to SSH instead of HTTP

### DIFF
--- a/scripts/hypothesistooling.py
+++ b/scripts/hypothesistooling.py
@@ -87,8 +87,12 @@ def create_tag():
     git("config", "user.name", "Travis CI on behalf of David R. MacIver")
     git("config", "user.email", "david@drmaciver.com")
     git("config", "core.sshCommand", "ssh -i deploy_key")
+    git(
+        "remote", "add", "ssh-origin",
+        "git@github.com:HypothesisWorks/hypothesis-python.git"
+    )
     git("tag", __version__)
-    git("push", "--tags")
+    git("push", "ssh-origin", "--tags")
 
 
 def build_jobs():


### PR DESCRIPTION
The deploy almost worked then failed at the last hurdle: https://travis-ci.org/HypothesisWorks/hypothesis-python/jobs/224103554

We're adding a deploy key that can push to github, but then we're not actually using it because this is cloned from the HTTP URL! This PR fixes that by adding a remote for the ssh URL and using that to push.

It turns out that writing software you can't test is hard.