### PR TITLE
chmod the deploy_key first so we don't get yelled at

### DIFF
--- a/scripts/hypothesistooling.py
+++ b/scripts/hypothesistooling.py
@@ -94,7 +94,9 @@ def create_tag():
     git("tag", __version__)
     subprocess.check_call([
         "ssh-agent", "sh", "-c",
-        "ssh-add deploy_key; git push ssh-origin --tags"
+        "chmod 0600 deploy_key && " +
+        "ssh-add deploy_key && " +
+        "git push ssh-origin --tags"
     ])
 
 


### PR DESCRIPTION
The latest obstacle to getting this new deployment stuff working: ssh-agent whines about our deploy key having too generous permissions. This fixes that by chmodding it first.