### PR TITLE
Add packaging deps to requirements/tools.txt

### DIFF
--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -18,6 +18,7 @@ MarkupSafe==1.0
 mccabe==0.6.1
 numpy==1.12.1
 packaging==16.8
+pip==9.0.1
 pkginfo==1.4.1
 pluggy==0.4.0
 py==1.4.33
@@ -32,6 +33,7 @@ pytz==2017.2
 requests==2.13.0
 requests-toolbelt==0.7.1
 restructuredtext-lint==1.0.1
+setuptools==35.0.1
 six==1.10.0
 snowballstemmer==1.2.1
 Sphinx==1.5.5
@@ -41,3 +43,4 @@ twine==1.8.1
 unify==0.2
 untokenize==0.1.1
 virtualenv==15.1.0
+wheel==0.29.0


### PR DESCRIPTION
The latest failure of the deployment code: https://travis-ci.org/HypothesisWorks/hypothesis-python/jobs/224246289#L274

I'm 99% certain this is because we have an old version of setuptools there. It turns out pip freeze omits packaging related packages by default, so our version of setuptools is unpinned. This fixes that.