### PR TITLE
Move secret decryption to deploy task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ env: PYTHONDONTWRITEBYTECODE=x
 os:
     - linux
 
-before_install:
-  - openssl aes-256-cbc -K $encrypted_39cb4cc39a80_key -iv $encrypted_39cb4cc39a80_iv -in secrets.tar.enc -out secrets.tar -d
-  - tar -xvf secrets.tar
-
 branches:
   only:
     - "master"

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ env:
 
     matrix:
         # Core tests that we want to run first.
+        - TASK=deploy
         - TASK=check-untagged
         - TASK=check-changelog
         - TASK=documentation
@@ -53,7 +54,6 @@ env:
         - TASK=check-django18
         - TASK=check-django110
         - TASK=check-django111
-        - TASK=deploy
 
 script:
     - make $TASK

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ env:
 
     matrix:
         # Core tests that we want to run first.
-        - TASK=deploy
         - TASK=check-untagged
         - TASK=check-changelog
         - TASK=documentation
@@ -54,6 +53,7 @@ env:
         - TASK=check-django18
         - TASK=check-django110
         - TASK=check-django111
+        - TASK=deploy
 
 script:
     - make $TASK

--- a/Makefile
+++ b/Makefile
@@ -100,8 +100,6 @@ check-changelog: $(BEST_PY3)
 	$(BEST_PY3) scripts/check-changelog.py
 
 deploy: $(TOOL_VIRTUALENV)
-	openssl aes-256-cbc -K $encrypted_39cb4cc39a80_key -iv $encrypted_39cb4cc39a80_iv -in secrets.tar.enc -out secrets.tar -d
-	tar -xvf secrets.tar
 	$(TOOL_PYTHON) scripts/deploy.py
 
 check-format: format

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,8 @@ check-changelog: $(BEST_PY3)
 	$(BEST_PY3) scripts/check-changelog.py
 
 deploy: $(TOOL_VIRTUALENV)
+	openssl aes-256-cbc -K $encrypted_39cb4cc39a80_key -iv $encrypted_39cb4cc39a80_iv -in secrets.tar.enc -out secrets.tar -d
+	tar -xvf secrets.tar
 	$(TOOL_PYTHON) scripts/deploy.py
 
 check-format: format

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -38,6 +38,20 @@ PENDING_STATUS = ('started', 'created')
 
 
 if __name__ == '__main__':
+
+    print("Decrypting secrets")
+
+    subprocess.check_call(
+        "openssl aes-256-cbc -K $encrypted_39cb4cc39a80_key "
+        "-iv $encrypted_39cb4cc39a80_iv -in secrets.tar.enc "
+        "-out secrets.tar -d",
+        shell=True
+    )
+
+    subprocess.check_call([
+        "tar", "-xvf", "secrets.tar",
+    ])
+
     last_release = tools.latest_version()
 
     print('Current version: %s. Latest released version: %s' % (

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -41,6 +41,13 @@ if __name__ == '__main__':
 
     print("Decrypting secrets")
 
+    # We'd normally avoid the use of shell=True, but this is more or less
+    # intended as an opaque string that was given to us by Travis that happens
+    # to be a shell command that we run, and there are a number of good reasons
+    # this particular instance is harmless and would be high effort to
+    # convert (principally: Lack of programmatic generation of the string and
+    # extensive use of environment variables in it), so we're making an
+    # exception here.
     subprocess.check_call(
         "openssl aes-256-cbc -K $encrypted_39cb4cc39a80_key "
         "-iv $encrypted_39cb4cc39a80_iv -in secrets.tar.enc "

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -39,7 +39,7 @@ PENDING_STATUS = ('started', 'created')
 
 if __name__ == '__main__':
 
-    print("Decrypting secrets")
+    print('Decrypting secrets')
 
     # We'd normally avoid the use of shell=True, but this is more or less
     # intended as an opaque string that was given to us by Travis that happens
@@ -49,14 +49,14 @@ if __name__ == '__main__':
     # extensive use of environment variables in it), so we're making an
     # exception here.
     subprocess.check_call(
-        "openssl aes-256-cbc -K $encrypted_39cb4cc39a80_key "
-        "-iv $encrypted_39cb4cc39a80_iv -in secrets.tar.enc "
-        "-out secrets.tar -d",
+        'openssl aes-256-cbc -K $encrypted_39cb4cc39a80_key '
+        '-iv $encrypted_39cb4cc39a80_iv -in secrets.tar.enc '
+        '-out secrets.tar -d',
         shell=True
     )
 
     subprocess.check_call([
-        "tar", "-xvf", "secrets.tar",
+        'tar', '-xvf', 'secrets.tar',
     ])
 
     last_release = tools.latest_version()


### PR DESCRIPTION
First item in #551

Every time I encrypt a new file this causes Travis to change its decryption key. This means that under the recommended way of decrypting (in a before\_install) *every single job in every single branch will start failing*.

This change instead localises those failures to the deploy task by running the decryption from the makefile. This will still be slightly annoying but I think is reasonable for detecting problems in the deployment before merge.