### PR TITLE
Fix install on debian stable and release 3.7.2

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -22,6 +22,14 @@ You should generally assume that an API is internal unless you have specific
 information to the contrary.
 
 ------------------
+3.7.2 - 2017-04-21
+------------------
+
+This reverts an undocumented change in 3.7.1 which broke installation on
+debian stable: The specifier for the hypothesis[django] extra\_requires had
+introduced a wild card, which was not supported on the default version of pip.
+
+------------------
 3.7.1 - 2017-04-21
 ------------------
 

--- a/scripts/check-ancient-pip.sh
+++ b/scripts/check-ancient-pip.sh
@@ -9,9 +9,17 @@ BROKEN_VIRTUALENV=$($PYTHON -c'import tempfile; print(tempfile.mkdtemp())')
 
 trap "rm -rf $BROKEN_VIRTUALENV" EXIT
 
+rm -rf tmp-dist-dir
+
+$PYTHON setup.py sdist --dist-dir=tmp-dist-dir
+
 $PYTHON -m pip install virtualenv
 $PYTHON -m virtualenv $BROKEN_VIRTUALENV
 $BROKEN_VIRTUALENV/bin/pip install -rrequirements/test.txt
-$BROKEN_VIRTUALENV/bin/python -m pip install --upgrade pip==1.0.0
-$BROKEN_VIRTUALENV/bin/pip install .
+
+# These are versions from debian stable as of 2017-04-21
+# See https://packages.debian.org/stable/python/
+$BROKEN_VIRTUALENV/bin/python -m pip install --upgrade pip==1.5.6
+$BROKEN_VIRTUALENV/bin/pip install --upgrade setuptools==5.5.1
+$BROKEN_VIRTUALENV/bin/pip install tmp-dist-dir/*
 $BROKEN_VIRTUALENV/bin/python -m pytest tests/cover/test_testdecorators.py

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ import sys
 def local_file(name):
     return os.path.relpath(os.path.join(os.path.dirname(__file__), name))
 
+
 SOURCE = local_file("src")
 README = local_file("README.rst")
 
@@ -40,7 +41,7 @@ assert __version__ is not None
 extras = {
     'datetime':  ["pytz"],
     'fakefactory': ["Faker>=0.7.0,<=0.7.1"],
-    'django': ['pytz', 'django>=1.8,<2,!=1.9.*'],
+    'django': ['pytz', 'django>=1.8,<2'],
     'numpy': ['numpy>=1.9.0'],
     'pytest': ['pytest>=2.8.0'],
 }

--- a/src/hypothesis/version.py
+++ b/src/hypothesis/version.py
@@ -17,5 +17,5 @@
 
 from __future__ import division, print_function, absolute_import
 
-__version_info__ = (3, 7, 1)
+__version_info__ = (3, 7, 2)
 __version__ = '.'.join(map(str, __version_info__))


### PR DESCRIPTION
Apparently #495 broke install on debian stable because people use ancient system provided pip and setuptools which can't handle wildcards in extras_require. 😭 

This PR:

* Fixes our test for old versions of pip to run the same version of setuptools and pip found in current debian stable (I verified manually that this reproduces the bug)
* Reverts #495 - I really doubt anyone is install hypothesis for django with the hypothesis[django] extra who does not already have django installed, so I think this is harmless.
* Updates the version and changelog (even though there is no code change so this is not required) so we can release 3.7.2 and fix that.