### PR TITLE
Don't attempt to run deploy when we don't have secure vars

### DIFF
--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -38,7 +38,7 @@ PENDING_STATUS = ('started', 'created')
 
 
 if __name__ == '__main__':
-    if os.environ.get("TRAVIS_SECURE_ENV_VARS", None) != "true":
+    if os.environ.get('TRAVIS_SECURE_ENV_VARS', None) != 'true':
         sys.exit(0)
 
     print('Decrypting secrets')

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -38,6 +38,8 @@ PENDING_STATUS = ('started', 'created')
 
 
 if __name__ == '__main__':
+    if os.environ.get("TRAVIS_SECURE_ENV_VARS", None) != "true":
+        sys.exit(0)
 
     print('Decrypting secrets')
 


### PR DESCRIPTION
Fixes #561 (I think) and thus unblocks #536 I think

The problem is that the secure environment variables aren't defined when the pull request is coming from outside the main repo. [The documentation](https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables) says we can test this with TRAVIS_SECURE_ENV_VARS, so that's what this change does: Have the deploy pass just skip entirely if the secure vars aren't defined.