### PR TITLE
Update checks to better handle no source changes

### DIFF
--- a/scripts/check-changelog.py
+++ b/scripts/check-changelog.py
@@ -29,6 +29,11 @@ sys.path.append(os.path.dirname(__file__))  # noqa
 
 
 if __name__ == '__main__':
+
+    if not tools.has_source_changes():
+        print('No source changes found')
+        sys.exit(0)
+
     changelog = tools.changelog()
 
     if '\n%s - ' % (tools.__version__,) not in changelog:

--- a/scripts/hypothesistooling.py
+++ b/scripts/hypothesistooling.py
@@ -101,7 +101,7 @@ def has_source_changes(version):
 
     return subprocess.call([
         'git', 'diff', '--exit-code', point_of_divergence, SRC,
-    ], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL) != 0
+    ]) != 0
 
 
 def git(*args):

--- a/scripts/hypothesistooling.py
+++ b/scripts/hypothesistooling.py
@@ -91,7 +91,10 @@ def changelog():
         return i.read()
 
 
-def has_source_changes(version):
+def has_source_changes(version=None):
+    if version is None:
+        version = latest_version()
+
     # Check where we branched off from the version. We're only interested
     # in whether *we* introduced any source changes, so we check diff from
     # there rather than the diff to the other side.

--- a/scripts/hypothesistooling.py
+++ b/scripts/hypothesistooling.py
@@ -92,8 +92,15 @@ def changelog():
 
 
 def has_source_changes(version):
+    # Check where we branched off from the version. We're only interested
+    # in whether *we* introduced any source changes, so we check diff from
+    # there rather than the diff to the other side.
+    point_of_divergence = subprocess.check_output([
+        'git', 'merge-base', 'HEAD', version
+    ])
+
     return subprocess.call([
-        'git', 'diff', '--exit-code', version, SRC,
+        'git', 'diff', '--exit-code', point_of_divergence, SRC,
     ], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL) != 0
 
 

--- a/scripts/hypothesistooling.py
+++ b/scripts/hypothesistooling.py
@@ -100,10 +100,10 @@ def has_source_changes(version=None):
     # there rather than the diff to the other side.
     point_of_divergence = subprocess.check_output([
         'git', 'merge-base', 'HEAD', version
-    ])
+    ]).strip()
 
     return subprocess.call([
-        'git', 'diff', '--exit-code', point_of_divergence, SRC,
+        'git', 'diff', '--exit-code', point_of_divergence, "HEAD", "--", SRC,
     ]) != 0
 
 

--- a/scripts/hypothesistooling.py
+++ b/scripts/hypothesistooling.py
@@ -103,7 +103,7 @@ def has_source_changes(version=None):
     ]).strip()
 
     return subprocess.call([
-        'git', 'diff', '--exit-code', point_of_divergence, "HEAD", "--", SRC,
+        'git', 'diff', '--exit-code', point_of_divergence, 'HEAD', '--', SRC,
     ]) != 0
 
 


### PR DESCRIPTION
This makes a couple of changes to the build which are currently blocking e.g. #565, #566 and #563.

The core theme is that things that don't make changes to source code do not require a new version, but the checks aren't always good at realising that. In particular:

* check-changelog was checking unconditionally for the date, which it only needs to do if the current version hasn't already been released! (Or, given the version check, just whether there are source changes)
* detecting source changes was just looking at the diff between this and the last version, where it should have been looking at the diff with the last common ancestor of the current branch and the last version.

It also makes some minor changes for cleanup and debugging in the area (e.g. added a default to `has_source_changes` and made it print out the diff when there is one)