### PR TITLE
Don't use unicode literals

### DIFF
--- a/tests/pytest/test_capture.py
+++ b/tests/pytest/test_capture.py
@@ -15,8 +15,7 @@
 #
 # END HEADER
 
-from __future__ import division, print_function, absolute_import, \
-    unicode_literals
+from __future__ import division, print_function, absolute_import
 
 import pytest
 

--- a/tests/pytest/test_runs.py
+++ b/tests/pytest/test_runs.py
@@ -15,8 +15,7 @@
 #
 # END HEADER
 
-from __future__ import division, print_function, absolute_import, \
-    unicode_literals
+from __future__ import division, print_function, absolute_import
 
 from hypothesis import given
 from tests.common.utils import fails


### PR DESCRIPTION
unicode\_literals used to be part of our default future header, but they turn out to be an attractive nuisance and make it harder rather than easier to write correct cross-version code.

Apparently they'd lingered in precisely two places. I don't know why. I think our isort based import management doesn't remove futures, only adds them, so they were allowed to remain.

We could lint for this if we wanted to but I don't think it's worth the effort, so this is a simple PR removing the last two I found in the code (via git grep)