### PR TITLE
Add whitespace linting to docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,8 +182,9 @@ check-fast: lint $(PYPY) $(PY36) $(TOX)
 	$(TOX) -e pypy-brief
 	$(TOX) -e py36-prettyquick
 
-check-rst: $(RSTLINT)
+check-rst: $(RSTLINT) $(FLAKE8)
 	$(RSTLINT) *.rst
+	$(FLAKE8) --select=W191,W291,W292,W293,W391 *.rst docs/*.rst
 
 secret.tar.enc: deploy_key .pypirc
 	rm -f secrets.tar secrets.tar.enc
@@ -195,7 +196,7 @@ check-benchmark: $(BENCHMARK_VIRTUALENV)
 	PYTHONPATH=src $(BENCHMARK_PYTHON) scripts/benchmarks.py --check --nruns=100
 
 build-new-benchmark-data: $(BENCHMARK_VIRTUALENV)
-	PYTHONPATH=src $(BENCHMARK_PYTHON) scripts/benchmarks.py --skip-existing --nruns=1000 
+	PYTHONPATH=src $(BENCHMARK_PYTHON) scripts/benchmarks.py --skip-existing --nruns=1000
 
 update-improved-benchmark-data: $(BENCHMARK_VIRTUALENV)
 	PYTHONPATH=src $(BENCHMARK_PYTHON) scripts/benchmarks.py --update=improved --nruns=1000

--- a/docs/details.rst
+++ b/docs/details.rst
@@ -88,7 +88,7 @@ which describe some aspect of the data generation:
   @given(st.integers().filter(lambda x: x % 2 == 0))
   def test_even_integers(i):
       pass
-    
+
 You would see something like:
 
 .. code-block:: none
@@ -571,4 +571,3 @@ It is *not* permitted for a single example to be a mix of positional and
 keyword arguments. Either are fine, and you can use one in one example and the
 other in another example if for some reason you really want to, but a single
 example must be consistent.
-

--- a/docs/extras.rst
+++ b/docs/extras.rst
@@ -195,4 +195,3 @@ hypothesis.extra.numpy adds support for testing your Numpy code with Hypothesis.
 This includes generating arrays, array shapes, and both scalar or compound dtypes.
 
 Like the Django extra, :doc:`Numpy has it's own page <numpy>`.
-

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -42,7 +42,7 @@ Available settings
 .. module:: hypothesis
 .. autoclass:: settings
     :members: max_examples, max_iterations, min_satisfying_examples,
-        max_shrinks, timeout, strict, database_file, stateful_step_count, 
+        max_shrinks, timeout, strict, database_file, stateful_step_count,
         database, perform_health_check, suppress_health_check, buffer_size
 
 .. _verbose-output:
@@ -241,4 +241,3 @@ by your conftest you can load one with the command line option ``--hypothesis-pr
 .. code:: bash
 
     $ py.test tests --hypothesis-profile <profile-name>
-

--- a/docs/stateful.rst
+++ b/docs/stateful.rst
@@ -59,7 +59,7 @@ You define a rule based state machine as follows:
 
   import unittest
   from collections import namedtuple
-  
+
   from hypothesis import strategies as st
   from hypothesis.stateful import RuleBasedStateMachine, Bundle, rule
 
@@ -139,7 +139,7 @@ So lets balance some trees.
 .. code:: python
 
     from collections import namedtuple
-    
+
     from hypothesis import strategies as st
     from hypothesis.stateful import RuleBasedStateMachine, Bundle, rule
 


### PR DESCRIPTION
Turns out flake8 is perfectly happy to lint files that don’t contain any Python. This patch tells it just to look for whitespace errors, nothing else.

Resolves #559.