### PR TITLE
More conservative check for source changes

### DIFF
--- a/scripts/hypothesistooling.py
+++ b/scripts/hypothesistooling.py
@@ -101,7 +101,7 @@ def has_source_changes(version):
 
     return subprocess.call([
         'git', 'diff', '--exit-code', point_of_divergence, SRC,
-    ], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL) != 0
+    ]) != 0
 
 
 def git(*args):

--- a/scripts/hypothesistooling.py
+++ b/scripts/hypothesistooling.py
@@ -96,7 +96,7 @@ def has_source_changes(version):
     # in whether *we* introduced any source changes, so we check diff from
     # there rather than the diff to the other side.
     point_of_divergence = subprocess.check_output([
-        "git", "merge-base", "HEAD", version
+        'git', 'merge-base', 'HEAD', version
     ])
 
     return subprocess.call([

--- a/scripts/hypothesistooling.py
+++ b/scripts/hypothesistooling.py
@@ -92,8 +92,15 @@ def changelog():
 
 
 def has_source_changes(version):
+    # Check where we branched off from the version. We're only interested
+    # in whether *we* introduced any source changes, so we check diff from
+    # there rather than the diff to the other side.
+    point_of_divergence = subprocess.check_output([
+        "git", "merge-base", "HEAD", version
+    ])
+
     return subprocess.call([
-        'git', 'diff', '--exit-code', version, SRC,
+        'git', 'diff', '--exit-code', point_of_divergence, SRC,
     ], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL) != 0
 
 


### PR DESCRIPTION
As @Zac-HD [points out](https://github.com/HypothesisWorks/hypothesis-python/pull/563#issuecomment-296421093), #563 is currently failing because it doesn't update the version but "has source changes". It doesn't have source changes, but it's not up to date with master so it looks like it does.

This PR refines the source check to instead look at whether there is any source diff between here and our last common ancestor with the latest release version, which is the more appropriate check: The question isn't whether there is a source difference, it's whether merging this branch will create a source difference.

It also updates the code to show the diff output, as this will make it easier to debug when it fails in future.