### PR TITLE
Only run format on files that have changed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,8 @@ TOOL_PIP=$(TOOL_VIRTUALENV)/bin/pip
 BENCHMARK_VIRTUALENV:=$(BUILD_RUNTIMES)/virtualenvs/benchmark-$(shell scripts/tool-hash.py benchmark)
 BENCHMARK_PYTHON=$(BENCHMARK_VIRTUALENV)/bin/python
 
-FILES_TO_FORMAT=find src tests scripts -name '*.py' -not \( \
-								-path '*/vendor/*' -or -name test_lambda_formatting.py \
-                                -or -name header.py \
-								\)
+FILES_TO_FORMAT=$(BEST_PY3) scripts/files-to-format.py
+
 
 export PATH:=$(BUILD_RUNTIMES)/snakepit:$(TOOLS):$(PATH)
 export LC_ALL=en_US.UTF-8

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis, which may be found at
 # https://github.com/HypothesisWorks/hypothesis-python
 #
-# Most of this work is copyright (C) 2013-2016 David R. MacIver
+# Most of this work is copyright (C) 2013-2017 David R. MacIver
 # (david@drmaciver.com), but it contains contributions by others. See
 # CONTRIBUTING.rst for a full list of people who may hold copyright, and
 # consult the git log if you need to determine who owns an individual
@@ -17,16 +17,19 @@
 
 # -*- coding: utf-8 -*-
 
+from __future__ import division, print_function, absolute_import
+
 # on_rtd is whether we are on readthedocs.org
 import os
 import sys
+
+from hypothesis import __version__
+
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 sys.path.append(
-    os.path.join(os.path.dirname(__file__), "..", "src")
+    os.path.join(os.path.dirname(__file__), '..', 'src')
 )
-
-from hypothesis import __version__
 
 
 autodoc_member_order = 'bysource'

--- a/examples/test_binary_search.py
+++ b/examples/test_binary_search.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis, which may be found at
 # https://github.com/HypothesisWorks/hypothesis-python
 #
-# Most of this work is copyright (C) 2013-2016 David R. MacIver
+# Most of this work is copyright (C) 2013-2017 David R. MacIver
 # (david@drmaciver.com), but it contains contributions by others. See
 # CONTRIBUTING.rst for a full list of people who may hold copyright, and
 # consult the git log if you need to determine who owns an individual

--- a/examples/test_rle.py
+++ b/examples/test_rle.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis, which may be found at
 # https://github.com/HypothesisWorks/hypothesis-python
 #
-# Most of this work is copyright (C) 2013-2016 David R. MacIver
+# Most of this work is copyright (C) 2013-2017 David R. MacIver
 # (david@drmaciver.com), but it contains contributions by others. See
 # CONTRIBUTING.rst for a full list of people who may hold copyright, and
 # consult the git log if you need to determine who owns an individual

--- a/scripts/files-to-format.py
+++ b/scripts/files-to-format.py
@@ -28,7 +28,7 @@ sys.path.append(os.path.dirname(__file__))  # noqa
 def should_format_file(path):
     if os.path.basename(path) in ('header.py', 'test_lambda_formatting.py'):
         return False
-    if 'vendor' in path.split(os.pathsep):
+    if 'vendor' in path.split(os.path.sep):
         return False
     return path.endswith('.py')
 

--- a/scripts/files-to-format.py
+++ b/scripts/files-to-format.py
@@ -1,0 +1,47 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2017 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import os
+import sys
+
+import hypothesistooling as tools
+
+sys.path.append(os.path.dirname(__file__))  # noqa
+
+
+def should_format_file(path):
+    if os.path.basename(path) in ('header.py', 'test_lambda_formatting.py'):
+        return False
+    if '/vendor/' in path:
+        return False
+    return path.endswith('.py')
+
+
+if __name__ == '__main__':
+    changed = tools.modified_files()
+
+    format_all = os.environ.get('FORMAT_ALL', '').lower() == 'true'
+    if 'scripts/header.py' in changed:
+        format_all = True
+
+    files = tools.all_files() if format_all else changed
+
+    for f in sorted(files):
+        if should_format_file(f):
+            print(f)

--- a/scripts/files-to-format.py
+++ b/scripts/files-to-format.py
@@ -28,7 +28,7 @@ sys.path.append(os.path.dirname(__file__))  # noqa
 def should_format_file(path):
     if os.path.basename(path) in ('header.py', 'test_lambda_formatting.py'):
         return False
-    if '/vendor/' in path:
+    if 'vendor' in path.split(os.pathsep):
         return False
     return path.endswith('.py')
 

--- a/scripts/files-to-format.py
+++ b/scripts/files-to-format.py
@@ -38,6 +38,11 @@ if __name__ == '__main__':
 
     format_all = os.environ.get('FORMAT_ALL', '').lower() == 'true'
     if 'scripts/header.py' in changed:
+        # We've changed the header, so everything needs its header updated.
+        format_all = True
+    if 'requirements/tools.txt' in changed:
+        # We've changed the tools, which includes a lot of our formatting
+        # logic, so we need to rerun formatters.
         format_all = True
 
     files = tools.all_files() if format_all else changed

--- a/scripts/hypothesistooling.py
+++ b/scripts/hypothesistooling.py
@@ -156,3 +156,28 @@ def build_jobs():
         status = m['state']
         jobs.setdefault(status, []).append(name)
     return jobs
+
+
+def modified_files():
+    files = set()
+    for command in [
+        ['git', 'diff', '--name-status', latest_version(), 'HEAD'],
+        ['git', 'diff', '--name-status']
+    ]:
+        diff_output = subprocess.check_output(command).decode('ascii')
+        for l in diff_output.split('\n'):
+            if l:
+                parts = l.split('\t')
+                status = parts[0]
+                file = parts[-1]
+                assert status in ('M', 'A', 'D'), status
+                if status == 'D':
+                    continue
+                assert os.path.exists(file)
+                files.add(file)
+    return files
+
+
+def all_files():
+    return subprocess.check_output(['git', 'ls-files']).decode(
+        'ascii').split('\n')

--- a/scripts/hypothesistooling.py
+++ b/scripts/hypothesistooling.py
@@ -161,20 +161,16 @@ def build_jobs():
 def modified_files():
     files = set()
     for command in [
-        ['git', 'diff', '--name-status', latest_version(), 'HEAD'],
-        ['git', 'diff', '--name-status']
+        ['git', 'diff', '--name-only', '--diff-filter=d',
+            latest_version(), 'HEAD'],
+        ['git', 'diff', '--name-only']
     ]:
         diff_output = subprocess.check_output(command).decode('ascii')
         for l in diff_output.split('\n'):
-            if l:
-                parts = l.split('\t')
-                status = parts[0]
-                file = parts[-1]
-                assert status in ('M', 'A', 'D'), status
-                if status == 'D':
-                    continue
-                assert os.path.exists(file)
-                files.add(file)
+            filepath = l.strip()
+            if filepath:
+                assert os.path.exists(filepath)
+                files.add(filepath)
     return files
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis, which may be found at
 # https://github.com/HypothesisWorks/hypothesis-python
 #
-# Most of this work is copyright (C) 2013-2016 David R. MacIver
+# Most of this work is copyright (C) 2013-2017 David R. MacIver
 # (david@drmaciver.com), but it contains contributions by others. See
 # CONTRIBUTING.rst for a full list of people who may hold copyright, and
 # consult the git log if you need to determine who owns an individual
@@ -15,32 +15,35 @@
 #
 # END HEADER
 
-from setuptools import find_packages, setup
+from __future__ import division, print_function, absolute_import
+
 import os
 import sys
+
+from setuptools import setup, find_packages
 
 
 def local_file(name):
     return os.path.relpath(os.path.join(os.path.dirname(__file__), name))
 
 
-SOURCE = local_file("src")
-README = local_file("README.rst")
+SOURCE = local_file('src')
+README = local_file('README.rst')
 
 
 # Assignment to placate pyflakes. The actual version is from the exec that
 # follows.
 __version__ = None
 
-with open(local_file("src/hypothesis/version.py")) as o:
+with open(local_file('src/hypothesis/version.py')) as o:
     exec(o.read())
 
 assert __version__ is not None
 
 
 extras = {
-    'datetime':  ["pytz"],
-    'fakefactory': ["Faker>=0.7.0,<=0.7.1"],
+    'datetime':  ['pytz'],
+    'fakefactory': ['Faker>=0.7.0,<=0.7.1'],
     'django': ['pytz', 'django>=1.8,<2'],
     'numpy': ['numpy>=1.9.0'],
     'pytest': ['pytest>=2.8.0'],
@@ -64,7 +67,7 @@ setup(
     author='David R. MacIver',
     author_email='david@drmaciver.com',
     packages=find_packages(SOURCE),
-    package_dir={"": SOURCE},
+    package_dir={'': SOURCE},
     url='https://github.com/HypothesisWorks/hypothesis-python',
     license='MPL v2',
     description='A library for property based testing',
@@ -72,21 +75,21 @@ setup(
     extras_require=extras,
     install_requires=install_requires,
     classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
-        "Operating System :: Unix",
-        "Operating System :: POSIX",
-        "Operating System :: Microsoft :: Windows",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: Implementation :: CPython",
-        "Programming Language :: Python :: Implementation :: PyPy",
-        "Topic :: Software Development :: Testing",
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)',
+        'Operating System :: Unix',
+        'Operating System :: POSIX',
+        'Operating System :: Microsoft :: Windows',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
+        'Topic :: Software Development :: Testing',
     ],
     entry_points={
         'pytest11': ['hypothesispytest = hypothesis.extra.pytestplugin'],


### PR DESCRIPTION
You've probably noticed that format has become intolerably slow. Or you may not have because it's been intolerably slow for a while, so this might just seem normal to you.

Anyway, this mostly fixes this problem by changing the logic so that format only runs on files that have been modified since the last released version (unless the header or tools.txt have changed in which case it runs on everything). You can force the old behaviour by setting a FORMAT\_ALL environment variable.

The natural way of writing this also had the knock on effect that our formatting runs on *every* tracked Python file unless it's explicitly blacklisted. I think that's the correct behaviour, but it resulted in a number of files that were previously not formatted now being. I decided to force those to format all at once so ran make format with FORMAT\_ALL locally. As such this PR also contains formatting changes to the following files:

* docs/conf.py
* examples/test_binary_search.py
* examples/test_rle.py
* setup.py

There are no functionality changes to any of these, and the diffs aren't terribly large, but feel free to ignore them when reviewing this PR.