### PR TITLE
[WIP] Enable shellcheck on our scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,14 @@ sudo: false
 
 env: PYTHONDONTWRITEBYTECODE=x
 
+ghc: 7.8
+
 os:
     - linux
+
+install:
+  - cabal update
+  - cabal install ShellCheck
 
 branches:
   only:
@@ -18,6 +24,7 @@ cache:
         - $HOME/.venv
         - $HOME/.cache/pip
         - $HOME/wheelhouse
+        - $HOME/.cabal
 
 env:
     global:
@@ -27,6 +34,7 @@ env:
         # Core tests that we want to run first.
         - TASK=check-untagged
         - TASK=check-changelog
+        - TASK=shellcheck
         - TASK=documentation
         - TASK=lint
         - TASK=check-rst

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,9 @@ check-format: format
 
 install-core: $(PY27) $(PYPY) $(BEST_PY3) $(TOX)
 
+shellcheck:
+	shellcheck scripts/*.sh
+
 check-py27: $(PY27) $(TOX)
 	$(TOX) -e py27-full
 


### PR DESCRIPTION
I figure if we're linting our Python we should lint the code in the language we trust even less.

This is an experiment and might not work (also I can't run Haskell locally due to reasons). Also I expect it will surface a tonne of issues which I'll have to fix before it merges.