### PR TITLE
Always check-format of all files when running in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ cache:
 env:
     global:
         - BUILD_RUNTIMES=$HOME/.runtimes
+        - FORMAT_ALL=true
 
     matrix:
         # Core tests that we want to run first.


### PR DESCRIPTION
This should unblock #575.

Plus it means that if isort/pyformat change, we pick up the new results immediately, rather than when we next edit those files.