### PR TITLE
Deprecate timeout feature

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -22,6 +22,22 @@ You should generally assume that an API is internal unless you have specific
 information to the contrary.
 
 -------------------
+3.16.0 - 2017-08-04
+-------------------
+
+This release introduces a deprecation of the timeout feature. This results in
+the following changes:
+
+* Creating a settings object with an explicit timeout will emit a deprecation
+  warning.
+* If your test stops because it hits the timeout (and has not found a bug) then
+  it will emit a deprecation warning.
+* There is a new value ``unlimited`` which you can import from hypothesis.
+  ``settings(timeout=unlimited)`` will *not* cause a deprecation warning.
+* There is a new health check, ``hung_test``, which will trigger after a test
+  has been running for five minutes if it is not suppressed.
+
+-------------------
 3.15.0 - 2017-08-04
 -------------------
 

--- a/docs/healthchecks.rst
+++ b/docs/healthchecks.rst
@@ -10,14 +10,14 @@ These include detecting and warning about:
 * Strategies with very slow data generation
 * Strategies which filter out too much
 * Recursive strategies which branch too much
-* Use of the global random module
+* Tests that are unlikely to complete in a reasonable amount of time.
 
 If any of these scenarios are detected, Hypothesis will emit a warning about them.
 
 The general goal of these health checks is to warn you about things that you are doing that might
 appear to work but will either cause Hypothesis to not work correctly or to perform badly.
 
-To selectively disable health checks, use the suppress_health_check settings.
+To selectively disable health checks, use the suppress_health_check setting.
 The argument for this parameter is a list with elements drawn from any of
 the class-level attributes of the HealthCheck class.
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -217,3 +217,47 @@ by your conftest you can load one with the command line option ``--hypothesis-pr
 .. code:: bash
 
     $ py.test tests --hypothesis-profile <profile-name>
+
+
+~~~~~~~~
+Timeouts
+~~~~~~~~
+
+The `timeout` functionality of Hypothesis is being deprecated, and will
+eventually be removed. For the moment, the timeout setting can still be set
+and the old default timeout of one minute remains.
+
+If you want to future proof your code you can get
+the future behaviour by setting it to the value `unlimited`, which you can
+import from the main Hypothesis package:
+
+.. code:: python
+
+    from hypothesis import given, settings, unlimited
+    from hypothesis import strategies as st
+
+    @settings(timeout=unlimited)
+    @given(st.integers())
+    def test_something_slow(i):
+        ...
+
+This will cause your code to run until it hits the normal Hypothesis example
+limits, regardless of how long it takes. `timeout=unlimited` will remain a
+valid setting after the timeout functionality has been deprecated (but will
+then have its own deprecation cycle).
+
+There is however now a timing related health check which is designed to catch
+tests that run for ages by accident. If you really want your test to run
+forever, the following code will enable that:
+
+.. code:: python
+
+    from hypothesis import given, settings, unlimited, HealthCheck
+    from hypothesis import strategies as st
+
+    @settings(timeout=unlimited, suppress_health_check=[
+        HealthCheck.hung_test
+    ])
+    @given(st.integers())
+    def test_something_slow(i):
+        ...

--- a/scripts/unicodechecker.py
+++ b/scripts/unicodechecker.py
@@ -24,7 +24,7 @@ import warnings
 from tempfile import mkdtemp
 
 import unicodenazi
-from hypothesis import settings
+from hypothesis import settings, unlimited
 from hypothesis.configuration import set_hypothesis_home_dir
 
 warnings.filterwarnings('error', category=UnicodeWarning)
@@ -36,7 +36,7 @@ set_hypothesis_home_dir(mkdtemp())
 assert isinstance(settings, type)
 
 settings.register_profile(
-    'default', settings(timeout=-1, strict=True)
+    'default', settings(timeout=unlimited, strict=True)
 )
 settings.load_profile('default')
 

--- a/src/hypothesis/__init__.py
+++ b/src/hypothesis/__init__.py
@@ -24,7 +24,8 @@ failing examples it finds.
 """
 
 
-from hypothesis._settings import settings, Verbosity, Phase, HealthCheck
+from hypothesis._settings import settings, Verbosity, Phase, HealthCheck, \
+    unlimited
 from hypothesis.version import __version_info__, __version__
 from hypothesis.control import assume, note, reject, event
 from hypothesis.core import given, find, example, seed
@@ -40,6 +41,7 @@ __all__ = [
     'reject',
     'seed',
     'given',
+    'unlimited',
     'find',
     'example',
     'note',

--- a/src/hypothesis/version.py
+++ b/src/hypothesis/version.py
@@ -17,5 +17,5 @@
 
 from __future__ import division, print_function, absolute_import
 
-__version_info__ = (3, 15, 0)
+__version_info__ = (3, 16, 0)
 __version__ = '.'.join(map(str, __version_info__))

--- a/tests/common/setup.py
+++ b/tests/common/setup.py
@@ -21,7 +21,7 @@ import os
 import warnings
 from tempfile import mkdtemp
 
-from hypothesis import settings
+from hypothesis import settings, unlimited
 from hypothesis.configuration import set_hypothesis_home_dir
 from hypothesis.internal.charmap import charmap, charmap_file
 
@@ -35,13 +35,27 @@ def run():
     assert os.path.exists(charmap_file())
     assert isinstance(settings, type)
 
+    # We do a smoke test here before we mess around with settings.
+    x = settings()
+
+    import hypothesis._settings as settings_module
+
+    for s in settings_module.all_settings.values():
+        v = getattr(x, s.name)
+        # Check if it has a dynamically defined default and if so skip
+        # comparison.
+        if getattr(settings, s.name).show_default:
+            assert v == s.default, '%r == x.%s != s.%s == %r' % (
+                v, s.name, s.name, s.default,
+            )
+
     settings.register_profile(
-        'default', settings(timeout=-1, strict=True)
+        'default', settings(timeout=unlimited, strict=True)
     )
 
     settings.register_profile(
         'speedy', settings(
-            timeout=1, max_examples=5,
+            max_examples=5,
         ))
 
     settings.register_profile(

--- a/tests/cover/test_conjecture_engine.py
+++ b/tests/cover/test_conjecture_engine.py
@@ -22,7 +22,7 @@ from random import seed as seed_random
 from random import Random
 
 from hypothesis import strategies as st
-from hypothesis import Phase, given, settings
+from hypothesis import Phase, given, settings, unlimited
 from hypothesis.database import ExampleDatabase
 from hypothesis.internal.compat import hbytes, int_from_bytes, \
     bytes_from_list
@@ -138,7 +138,7 @@ def test_terminates_shrinks():
             data.mark_interesting()
     runner = ConjectureRunner(tf, settings=settings(
         max_examples=5000, max_iterations=10000, max_shrinks=10,
-        database=None, timeout=-1
+        database=None, timeout=unlimited,
     ))
     runner.run()
     assert runner.last_data.status == Status.INTERESTING
@@ -289,7 +289,7 @@ def test_stops_after_max_examples_when_generating():
 
 
 @given(st.random_module())
-@settings(max_shrinks=0, timeout=120, min_satisfying_examples=1)
+@settings(max_shrinks=0, min_satisfying_examples=1, max_examples=2)
 def test_interleaving_engines(rnd):
     @run_to_buffer
     def x(data):
@@ -318,7 +318,7 @@ def test_run_with_timeout_while_shrinking():
             data.mark_interesting()
 
     runner = ConjectureRunner(
-        f, settings=settings(database=None, timeout=0.2,))
+        f, settings=settings(database=None, timeout=0.2, strict=False))
     start = time.time()
     runner.run()
     assert time.time() <= start + 1
@@ -330,7 +330,7 @@ def test_run_with_timeout_while_boring():
         time.sleep(0.1)
 
     runner = ConjectureRunner(
-        f, settings=settings(database=None, timeout=0.2,))
+        f, settings=settings(database=None, timeout=0.2, strict=False))
     start = time.time()
     runner.run()
     assert time.time() <= start + 1
@@ -449,7 +449,8 @@ def test_garbage_collects_the_database():
         if x in seen:
             data.mark_interesting()
 
-    local_settings = settings(database=db, max_shrinks=2 * n, timeout=-1)
+    local_settings = settings(
+        database=db, max_shrinks=2 * n, timeout=unlimited)
 
     runner = ConjectureRunner(f, settings=local_settings, database_key=key)
     runner.run()

--- a/tests/cover/test_core.py
+++ b/tests/cover/test_core.py
@@ -72,7 +72,7 @@ def test_can_time_out_in_simplify():
     start = time.time()
     find(
         s.lists(s.booleans()), slow_always_true,
-        settings=settings(timeout=0.1, database=None)
+        settings=settings(timeout=0.1, database=None, strict=False)
     )
     finish = time.time()
     run_time = finish - start

--- a/tests/cover/test_database_backend.py
+++ b/tests/cover/test_database_backend.py
@@ -27,7 +27,7 @@ from hypothesis.database import ExampleDatabase, SQLiteExampleDatabase, \
     InMemoryExampleDatabase, DirectoryBasedExampleDatabase
 from hypothesis.strategies import lists, binary, tuples
 
-small_settings = settings(max_examples=100, timeout=4)
+small_settings = settings(max_examples=50)
 
 
 @given(lists(tuples(binary(), binary())))

--- a/tests/cover/test_database_usage.py
+++ b/tests/cover/test_database_usage.py
@@ -73,7 +73,7 @@ def test_trashes_all_invalid_examples():
             find(
                 st.binary(min_size=100),
                 lambda x: assume(not finicky) and any(x),
-                settings=settings(database=database, timeout=5),
+                settings=settings(database=database, timeout=5, strict=False),
                 database_key=key
             )
         except Unsatisfiable:

--- a/tests/cover/test_datetimes.py
+++ b/tests/cover/test_datetimes.py
@@ -22,7 +22,7 @@ import datetime as dt
 import pytest
 from flaky import flaky
 
-from hypothesis import find, given, settings
+from hypothesis import find, given, settings, unlimited
 from tests.common.debug import minimal
 from hypothesis.strategies import none, dates, times, binary, datetimes, \
     timedeltas
@@ -87,7 +87,7 @@ def test_default_datetimes_are_naive(dt):
 
 @flaky(max_runs=3, min_passes=1)
 def test_bordering_on_a_leap_year():
-    with settings(database=None, max_examples=10 ** 7, timeout=-1):
+    with settings(database=None, max_examples=10 ** 7, timeout=unlimited):
         x = minimal(datetimes(dt.datetime.min.replace(year=2003),
                               dt.datetime.max.replace(year=2005)),
                     lambda x: x.month == 2 and x.day == 29,

--- a/tests/cover/test_find.py
+++ b/tests/cover/test_find.py
@@ -92,6 +92,6 @@ def test_times_out():
         find(
             integers(),
             lambda x: time.sleep(0.05) or False,
-            settings=Settings(timeout=0.01))
+            settings=Settings(timeout=0.01, strict=False))
 
     e.value.args[0]

--- a/tests/cover/test_given_error_conditions.py
+++ b/tests/cover/test_given_error_conditions.py
@@ -28,7 +28,7 @@ from hypothesis.strategies import booleans, integers
 
 def test_raises_timeout_on_slow_test():
     @given(integers())
-    @settings(timeout=0.01)
+    @settings(timeout=0.01, strict=False)
     def test_is_slow(x):
         time.sleep(0.02)
 

--- a/tests/cover/test_health_checks.py
+++ b/tests/cover/test_health_checks.py
@@ -177,6 +177,32 @@ def test_returning_non_none_is_forbidden():
         a()
 
 
+def test_a_very_slow_test_will_fail_a_health_check():
+    @given(st.integers())
+    def a(x):
+        time.sleep(1000)
+    with raises(FailedHealthCheck):
+        a()
+
+
+def test_the_slow_test_health_check_can_be_disabled():
+    @given(st.integers())
+    @settings(suppress_health_check=[
+        HealthCheck.hung_test,
+    ])
+    def a(x):
+        time.sleep(1000)
+    a()
+
+
+def test_the_slow_test_health_only_runs_if_health_checks_are_on():
+    @given(st.integers())
+    @settings(perform_health_check=False)
+    def a(x):
+        time.sleep(1000)
+    a()
+
+
 def test_returning_non_none_does_not_fail_if_health_check_disabled():
     @given(st.integers())
     @settings(perform_health_check=False)

--- a/tests/cover/test_integer_ranges.py
+++ b/tests/cover/test_integer_ranges.py
@@ -18,7 +18,7 @@
 from __future__ import division, print_function, absolute_import
 
 import hypothesis.strategies as st
-from hypothesis import find, given, settings
+from hypothesis import find, given, settings, unlimited
 from hypothesis.internal.conjecture.utils import integer_range
 from hypothesis.searchstrategy.strategies import SearchStrategy
 
@@ -40,11 +40,11 @@ class interval(SearchStrategy):
     st.tuples(st.integers(), st.integers(), st.integers()).map(sorted),
     st.random_module(),
 )
-@settings(timeout=10, max_shrinks=0)
+@settings(max_examples=100, max_shrinks=0)
 def test_intervals_shrink_to_center(inter, rnd):
     lower, center, upper = inter
     s = interval(lower, upper, center)
-    with settings(database=None, max_shrinks=2000, timeout=-1):
+    with settings(database=None, max_shrinks=2000, timeout=unlimited):
         assert find(s, lambda x: True) == center
         if lower < center:
             assert find(s, lambda x: x < center) == center - 1

--- a/tests/cover/test_testdecorators.py
+++ b/tests/cover/test_testdecorators.py
@@ -17,7 +17,6 @@
 
 from __future__ import division, print_function, absolute_import
 
-import time
 import functools
 import threading
 from collections import namedtuple
@@ -122,57 +121,6 @@ class TestCases(object):
 def test_can_be_given_keyword_args(x, name):
     assume(x > 0)
     assert len(name) < x
-
-
-@fails_with(Unsatisfiable)
-@settings(timeout=0.1)
-@given(integers())
-def test_slow_test_times_out(x):
-    time.sleep(0.05)
-
-
-# Cheap hack to make test functions which fail on their second invocation
-calls = [0, 0, 0, 0]
-
-timeout_settings = settings(timeout=0.2, min_satisfying_examples=2)
-
-
-# The following tests exist to test that verifiers start their timeout
-# from when the test first executes, not from when it is defined.
-@fails
-@given(integers())
-@timeout_settings
-def test_slow_failing_test_1(x):
-    time.sleep(0.05)
-    assert not calls[0]
-    calls[0] = 1
-
-
-@fails
-@timeout_settings
-@given(integers())
-def test_slow_failing_test_2(x):
-    time.sleep(0.05)
-    assert not calls[1]
-    calls[1] = 1
-
-
-@fails
-@given(integers())
-@timeout_settings
-def test_slow_failing_test_3(x):
-    time.sleep(0.05)
-    assert not calls[2]
-    calls[2] = 1
-
-
-@fails
-@timeout_settings
-@given(integers())
-def test_slow_failing_test_4(x):
-    time.sleep(0.05)
-    assert not calls[3]
-    calls[3] = 1
 
 
 @fails
@@ -298,7 +246,7 @@ def test_can_find_large_sum_frozenset(xs):
 
 def test_prints_on_failure_by_default():
     @given(integers(), integers())
-    @settings(max_examples=200, timeout=-1)
+    @settings(max_examples=200)
     def test_ints_are_sorted(balthazar, evans):
         assume(evans >= 0)
         assert balthazar <= evans

--- a/tests/cover/test_timeout.py
+++ b/tests/cover/test_timeout.py
@@ -1,0 +1,96 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2017 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import time
+
+from hypothesis import given, settings
+from hypothesis.errors import Unsatisfiable
+from tests.common.utils import fails, fails_with
+from hypothesis.strategies import integers
+
+
+@fails_with(Unsatisfiable)
+@settings(timeout=0.1, strict=False)
+@given(integers())
+def test_slow_test_times_out(x):
+    time.sleep(0.05)
+
+
+# Cheap hack to make test functions which fail on their second invocation
+calls = [0, 0, 0, 0]
+
+timeout_settings = settings(
+    timeout=0.2, min_satisfying_examples=2, strict=False)
+
+
+# The following tests exist to test that verifiers start their timeout
+# from when the test first executes, not from when it is defined.
+@fails
+@given(integers())
+@timeout_settings
+def test_slow_failing_test_1(x):
+    time.sleep(0.05)
+    assert not calls[0]
+    calls[0] = 1
+
+
+@fails
+@timeout_settings
+@given(integers())
+def test_slow_failing_test_2(x):
+    time.sleep(0.05)
+    assert not calls[1]
+    calls[1] = 1
+
+
+@fails
+@given(integers())
+@timeout_settings
+def test_slow_failing_test_3(x):
+    time.sleep(0.05)
+    assert not calls[2]
+    calls[2] = 1
+
+
+@fails
+@timeout_settings
+@given(integers())
+def test_slow_failing_test_4(x):
+    time.sleep(0.05)
+    assert not calls[3]
+    calls[3] = 1
+
+
+default_timeout_settings = settings(strict=False, timeout=60)
+strict_timeout_settings = settings(default_timeout_settings, strict=True)
+
+
+@fails_with(DeprecationWarning)
+@strict_timeout_settings
+@given(integers())
+def test_deprecated_behaviour(i):
+    time.sleep(100)
+
+
+@fails_with(AssertionError)
+@strict_timeout_settings
+@given(integers())
+def test_does_not_hide_errors_with_deprecation(i):
+    time.sleep(100)
+    assert False

--- a/tests/datetime/test_datetime.py
+++ b/tests/datetime/test_datetime.py
@@ -24,7 +24,7 @@ import pytest
 from flaky import flaky
 
 import hypothesis._settings as hs
-from hypothesis import find, given, assume, settings
+from hypothesis import find, given, assume, settings, unlimited
 from hypothesis.errors import InvalidArgument
 from tests.common.debug import minimal
 from tests.common.utils import checks_deprecated_behaviour
@@ -148,7 +148,8 @@ def test_bordering_on_a_leap_year():
     x = find(
         datetimes(min_year=2002, max_year=2005),
         lambda x: x.month == 2 and x.day == 29,
-        settings=settings(database=None, max_examples=10 ** 7, timeout=-1)
+        settings=settings(
+            database=None, max_examples=10 ** 7, timeout=unlimited)
     )
     assert x.year == 2004
 

--- a/tests/nocover/test_collective_minimization.py
+++ b/tests/nocover/test_collective_minimization.py
@@ -47,8 +47,7 @@ def test_can_collectively_minimize(spec):
         xs = find(
             lists(spec, min_size=n, max_size=n),
             distinct_reprs,
-            settings=settings(
-                timeout=10.0, max_examples=2000))
+            settings=settings(max_shrinks=100, max_examples=2000))
         assert len(xs) == n
         assert 2 <= len(set((map(repr, xs)))) <= 3
     except NoSuchExample:

--- a/tests/nocover/test_git_merge.py
+++ b/tests/nocover/test_git_merge.py
@@ -136,5 +136,4 @@ class DatabaseMergingState(GenericStateMachine):
 
 
 TestMerging = DatabaseMergingState.TestCase
-TestMerging.settings = settings(
-    TestMerging.settings, timeout=60)
+TestMerging.settings = settings(TestMerging.settings, max_examples=100)

--- a/tests/nocover/test_recursive.py
+++ b/tests/nocover/test_recursive.py
@@ -122,7 +122,7 @@ def test_can_form_sets_of_recursive_data():
         lambda x: st.lists(x, min_size=5).map(tuple),
         max_leaves=20))
     xs = find(trees, lambda x: len(x) >= 5, settings=settings(
-        database=None, timeout=20, max_shrinks=1000, max_examples=1000
+        database=None, max_shrinks=1000, max_examples=1000
     ))
     assert len(xs) == 5
 
@@ -146,7 +146,6 @@ def test_can_flatmap_to_recursive_data(rnd):
         stuff, lambda x: sum(flatten(x)) >= 100,
         settings=settings(
             database=None, max_shrinks=2000, max_examples=1000,
-            timeout=20,
         ),
         random=rnd
     )

--- a/tests/nocover/test_strategy_state.py
+++ b/tests/nocover/test_strategy_state.py
@@ -21,7 +21,7 @@ import math
 import hashlib
 from random import Random
 
-from hypothesis import Verbosity, seed, given, assume, settings
+from hypothesis import Verbosity, seed, given, assume, settings, unlimited
 from hypothesis.errors import NoExamples, FailedHealthCheck
 from hypothesis.database import ExampleDatabase
 from hypothesis.stateful import Bundle, RuleBasedStateMachine, rule
@@ -232,7 +232,7 @@ TestHypothesis.settings = settings(
     TestHypothesis.settings,
     stateful_step_count=10 if PYPY else 50,
     max_shrinks=500,
-    timeout=500 if MAIN else 60,
+    timeout=unlimited,
     min_satisfying_examples=0,
     verbosity=max(TestHypothesis.settings.verbosity, Verbosity.verbose),
     max_examples=10000 if MAIN else 200,

--- a/tests/pytest/test_statistics.py
+++ b/tests/pytest/test_statistics.py
@@ -33,7 +33,7 @@ def test_all_valid(x):
     pass
 
 
-@settings(timeout=0.2, min_satisfying_examples=1)
+@settings(timeout=0.2, min_satisfying_examples=1, strict=False)
 @given(integers())
 def test_slow(x):
     time.sleep(0.1)


### PR DESCRIPTION
As per #534, timeout is a major source of flakiness for end users. It also significantly complicates our lives.

This pull request deprecates it as functionality.

The intended behaviour is:

* Users who are not currently running into the timeout in their tests or configuring it in any way will see no difference
* Everyone else will get deprecation warnings either when they set it or when their tests actually run into it
* People who want to default to the new functionality can do `settings(timeout=unlimited)` (unlimited being a new special value from Hypothesis which we will use in a few other places). This will not trigger a deprecation warning.
* Once timeout has been removed entirely (in some unspecified future version) `settings(timeout=unlimited)` will start emitting deprecation warnings. `settings(timeout=anything else)` will be an error.
* People who want the old functionality are out of luck and should reduce their max\_examples setting.