### PR TITLE
Check examples in docstrings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,3 +237,4 @@ clean:
 
 documentation: $(SPHINX_BUILD) docs/*.rst
 	PYTHONPATH=src $(SPHINX_BUILD) -W -b html -d docs/_build/doctrees docs docs/_build/html
+	PYTHONPATH=src $(SPHINX_BUILD) -W -b doctest -d docs/_build/doctrees docs docs/_build/html

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -22,6 +22,13 @@ You should generally assume that an API is internal unless you have specific
 information to the contrary.
 
 ------------------
+3.8.1 - 2017-04-25
+------------------
+
+This is a documentation release.  Almost all code examples are now doctests
+checked in CI, eliminating stale examples.
+
+------------------
 3.8.0 - 2017-04-23
 ------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,6 +36,7 @@ autodoc_member_order = 'bysource'
 
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx.ext.doctest',
     'sphinx.ext.viewcode',
     'sphinx.ext.intersphinx',
 ]
@@ -68,6 +69,15 @@ intersphinx_mapping = {
 }
 
 autodoc_mock_imports = ['numpy']
+
+doctest_global_setup = '''
+# Some standard imports
+from hypothesis import *
+from hypothesis.strategies import *
+# Ensure that output (including from strategies) is deterministic
+import random
+random.seed(0)
+'''
 
 
 # -- Options for HTML output ----------------------------------------------

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -61,20 +61,21 @@ you're not sure how many you'll need in advance. For this, we have streaming
 types.
 
 
-.. code-block:: pycon
+.. doctest::
 
-    >>> from hypothesis.strategies import streaming, integers
-    >>> x = streaming(integers()).example()
+    >>> from hypothesis.types import Stream
+    >>> x = Stream(iter(integers().example, None))
+    >>> # Equivalent to `streaming(integers()).example()`, which is not supported
     >>> x
     Stream(...)
     >>> x[2]
-    209
+    131
     >>> x
-    Stream(32, 132, 209, ...)
+    Stream(-225, 50, 131, ...)
     >>> x[10]
-    130
+    127
     >>> x
-    Stream(32, 132, 209, 843, -19, 58, 141, -1046, 37, 243, 130, ...)
+    Stream(-225, 50, 131, 30781241791694610923869406150329382725, 89, 62248, 107, 35771, -113, 79, 127, ...)
 
 Think of a Stream as an infinite list where we've only evaluated as much as
 we need to. As per above, you can index into it and the stream will be evaluated up to
@@ -83,49 +84,47 @@ that index and no further.
 You can iterate over it too (warning: iter on a stream given to you
 by Hypothesis in this way will never terminate):
 
-.. code-block:: pycon
+.. doctest::
 
     >>> it = iter(x)
     >>> next(it)
-    32
+    -225
     >>> next(it)
-    132
+    50
     >>> next(it)
-    209
-    >>> next(it)
-    843
+    131
 
 Slicing will also work, and will give you back Streams. If you set an upper
 bound then iter on those streams *will* terminate:
 
-.. code-block:: pycon
+.. doctest::
 
     >>> list(x[:5])
-    [32, 132, 209, 843, -19]
+    [-225, 50, 131, 30781241791694610923869406150329382725, 89]
     >>> y = x[1::2]
     >>> y
     Stream(...)
     >>> y[0]
-    132
+    50
     >>> y[1]
-    843
+    30781241791694610923869406150329382725
     >>> y
-    Stream(132, 843, ...)
+    Stream(50, 30781241791694610923869406150329382725, ...)
 
 You can also apply a function to transform a stream:
 
-.. code-block:: pycon
+.. doctest::
 
-    >>> t = streaming(int).example()
+    >>> t = x[20:]
     >>> tm = t.map(lambda n: n * 2)
     >>> tm[0]
-    26
+    -344
     >>> t[0]
-    13
+    -172
     >>> tm
-    Stream(26, ...)
+    Stream(-344, ...)
     >>> t
-    Stream(13, ...)
+    Stream(-172, ...)
 
 map creates a new stream where each element of the stream is the function
 applied to the corresponding element of the original stream. Evaluating the
@@ -159,10 +158,10 @@ f(s.example()). i.e. we draw an example from s and then apply f to it.
 
 e.g.:
 
-.. code-block:: pycon
+.. doctest::
 
   >>> lists(integers()).map(sorted).example()
-  [1, 5, 17, 21, 24, 30, 45, 82, 88, 88, 90, 96, 105]
+  [-224, -222, 16, 159, 120699286316048]
 
 Note that many things that you might use mapping for can also be done with the
 builds function in hypothesis.strategies.
@@ -174,23 +173,21 @@ Filtering
 filter lets you reject some examples. s.filter(f).example() is some example
 of s such that f(s) is truthy.
 
-.. code-block:: pycon
+.. doctest::
 
   >>> integers().filter(lambda x: x > 11).example()
-  1873
+  1609027033942695427531
   >>> integers().filter(lambda x: x > 11).example()
-  73
+  251
 
 It's important to note that filter isn't magic and if your condition is too
 hard to satisfy then this can fail:
 
-.. code-block:: pycon
+.. doctest::
 
   >>> integers().filter(lambda x: False).example()
   Traceback (most recent call last):
-    File "<stdin>", line 1, in <module>
-    File "/home/david/projects/hypothesis/src/hypothesis/searchstrategy/strategies.py", line 175, in example
-      'Could not find any valid examples in 20 tries'
+    ...
   hypothesis.errors.NoExamples: Could not find any valid examples in 20 tries
 
 In general you should try to use filter only to avoid corner cases that you
@@ -201,11 +198,11 @@ and then use filter to remove things that didn't work out. So for example if you
 wanted pairs of integers (x,y) such that x < y you could do the following:
 
 
-.. code-block:: pycon
+.. doctest::
 
-  >>> tuples(integers(), integers())).map(
+  >>> tuples(integers(), integers()).map(
   ... lambda x: tuple(sorted(x))).filter(lambda x: x[0] != x[1]).example()
-  (42, 1281698)
+  (180, 241)
 
 ----------------------------
 Chaining strategies together
@@ -221,18 +218,15 @@ relationships to eachother.
 For example suppose we wanted to generate a list of lists of the same
 length:
 
-
 .. code-block:: pycon
 
-  >>> from hypothesis.strategies import integers, lists
-  >>> from hypothesis import find
-  >>> rectangle_lists = integers(min_value=0, max_value=10).flatmap(lambda n:
-  ... lists(lists(integers(), min_size=n, max_size=n)))
+  >>> rectangle_lists = integers(min_value=0, max_value=10).flatmap(
+  ... lambda n: lists(lists(integers(), min_size=n, max_size=n)))
   >>> find(rectangle_lists, lambda x: True)
   []
   >>> find(rectangle_lists, lambda x: len(x) >= 10)
   [[], [], [], [], [], [], [], [], [], []]
-  >>> find(rectangle_lists, lambda t: len(t) >= 3 and len(t[0])  >= 3)
+  >>> find(rectangle_lists, lambda t: len(t) >= 3 and len(t[0]) >= 3)
   [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
   >>> find(rectangle_lists, lambda t: sum(len(s) for s in t) >= 10)
   [[0], [0], [0], [0], [0], [0], [0], [0], [0], [0]]
@@ -263,27 +257,36 @@ wanted to generate JSON data, valid JSON is:
 3. Any dictionary mapping unicode strings to valid JSON data.
 
 The problem is that you cannot call a strategy recursively and expect it to not just
-blow up and eat all your memory.
+blow up and eat all your memory.  The other problem here is that not all unicode strings
+display consistently on different machines, so we'll restrict them in our doctest.
 
-The way Hypothesis handles this is with the 'recursive' function in hypothesis.strategies
+The way Hypothesis handles this is with the ':py:func:`recursive` function
 which you pass in a base case and a function that given a strategy for your data type
 returns a new strategy for it. So for example:
 
-.. code-block:: pycon
+.. doctest::
 
-  >>> import hypothesis.strategies as st
-  >>> json = st.recursive(st.floats() | st.booleans() | st.text() | st.none(),
-  ... lambda children: st.lists(children) | st.dictionaries(st.text(), children))
-  >>> json.example()
-  {'': None, '\U000b3407\U000b3407\U000b3407': {
-      '': '"é""é\x11', '\x13': 1.6153068016570349e-282,
-      '\x00': '\x11\x11\x11"\x11"é"éé\x11""éé"\x11"éé\x11éé\x11é\x11',
-    '\x80': 'é\x11\x11\x11\x11\x11\x11', '\x13\x13\x00\x80\x80\x00': 4.643602465868519e-144
-    }, '\U000b3407': None}
-  >>> json.example()
+  >>> from string import printable; from pprint import pprint
+  >>> json = recursive(none() | booleans() | floats() | text(printable),
+  ... lambda children: lists(children) | dictionaries(text(printable), children))
+  >>> pprint(json.example())
+  {'': 'Me$',
+   "\r5qPZ%etF:vL'9gC": False,
+   '$KsT(( J/(wQ': [],
+   '0)G&31': False,
+   '7': [],
+   'C.i]A-I': {':?Xh>[;': None,
+               'YHT\r!\x0b': -6.801160220000663e+18,
+  ...
+  >>> pprint(json.example())
+  [{"7_8'qyb": None,
+    ':': -0.3641507440748771,
+    'TI_^\n>L{T\x0c': -0.0,
+    'ZiOqQ\t': 'RKT*a]IjI/Zx2HB4ODiSUN)LsZ',
+    'n;E^^6|9=@g@@BmAi': '7j5\\'},
+   True]
+  >>> pprint(json.example())
   []
-  >>> json.example()
-  '\x06ě\U000d25e4H\U000d25e4\x06ě'
 
 That is, we start with our leaf data and then we augment it by allowing lists and dictionaries of anything we can generate as JSON data.
 
@@ -291,17 +294,15 @@ The size control of this works by limiting the maximum number of values that can
 we wanted to only generate really small JSON we could do this as:
 
 
-.. code-block:: pycon
+.. doctest::
 
-  >>> small_lists = st.recursive(st.booleans(), st.lists, max_leaves=5)
+  >>> small_lists = recursive(booleans(), lists, max_leaves=5)
   >>> small_lists.example()
-  False
+  True
   >>> small_lists.example()
-  [[False], [], [], [], [], []]
+  [True, False]
   >>> small_lists.example()
-  False
-  >>> small_lists.example()
-  []
+  True
 
 ~~~~~~~~~~~~~~~~~~~~
 Composite strategies
@@ -315,30 +316,30 @@ The composite decorator works by giving you a function as the first argument
 that you can use to draw examples from other strategies. For example, the
 following gives you a list and an index into it:
 
-.. code-block:: python
+.. doctest::
 
-    @composite
-    def list_and_index(draw, elements=integers()):
-        xs = draw(lists(elements, min_size=1))
-        i = draw(integers(min_value=0, max_value=len(xs) - 1))
-        return (xs, i)
+    >>> @composite
+    ... def list_and_index(draw, elements=integers()):
+    ...     xs = draw(lists(elements, min_size=1))
+    ...     i = draw(integers(min_value=0, max_value=len(xs) - 1))
+    ...     return (xs, i)
 
 'draw(s)' is a function that should be thought of as returning s.example(),
 except that the result is reproducible and will minimize correctly. The
 decorated function has the initial argument removed from the list, but will
 accept all the others in the expected order. Defaults are preserved.
 
-.. code-block:: pycon
+.. doctest::
 
     >>> list_and_index()
     list_and_index()
     >>> list_and_index().example()
-    ([5585, 4073], 1)
+    ([215, 112], 0)
 
     >>> list_and_index(booleans())
     list_and_index(elements=booleans())
     >>> list_and_index(booleans()).example()
-    ([False, False, True], 1)
+    ([False, False], 1)
 
 Note that the repr will work exactly like it does for all the built-in
 strategies: It will be a function that you can call to get the strategy in
@@ -380,13 +381,11 @@ strategies interactively. Rather than having to specify everything up front in
 If the test fails, each draw will be printed with the falsifying example. e.g.
 the above is wrong (it has a boundary condition error), so will print:
 
-
-::
+.. code-block:: pycon
 
     Falsifying example: test_draw_sequentially(data=data(...))
     Draw 1: 0
     Draw 2: 0
-
 
 As you can see, data drawn this way is simplified as usual.
 
@@ -406,7 +405,7 @@ For instance:
 
 will produce the output:
 
-::
+.. code-block:: pycon
 
     Falsifying example: test_draw_sequentially(data=data(...))
     Draw 1 (First number): 0

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -965,6 +965,7 @@ def shared(base, key=None):
     base. Any two shared instances with the same key will share the same value,
     otherwise the identity of this strategy will be used. That is:
 
+    >>> s = integers()  # or any other strategy
     >>> x = shared(s)
     >>> y = shared(s)
 

--- a/src/hypothesis/version.py
+++ b/src/hypothesis/version.py
@@ -17,5 +17,5 @@
 
 from __future__ import division, print_function, absolute_import
 
-__version_info__ = (3, 8, 0)
+__version_info__ = (3, 8, 1)
 __version__ = '.'.join(map(str, __version_info__))


### PR DESCRIPTION
Closes #533, closes #320.

This pull skips doctests for functionality under `extra`, because they often depend on package versions or require much more setup than is worthwhile in doctests.  I'm OK with this, because the motivation was things like people attempting `streaming(integers()).example()` - per the docs - and discovering that it raises an exception.  Also skips rectangle lists per #581, as the shrink is flaky as well as suboptimal.

I'm using Sphinx's doctest runner because it has the best control of discovery that I've found, and allows us to reseed the random module before each doctest group.  This prevents the problems with other runners where execution order means different output, or changing one group invalidated all other output too.

@DRMacIver, I'd appreciate it if you could work out how best to include this in the build on CI (`cd docs && sphinx-build -b doctest . _build/html`).  Output *may* be stable, but generated under Python 3.6.1 if it turns out to matter.