### PR TITLE
Some small benchmarking fixes

### DIFF
--- a/scripts/benchmarks.py
+++ b/scripts/benchmarks.py
@@ -36,7 +36,6 @@ import hypothesis.strategies as st
 from hypothesis import settings
 from scipy.stats import ttest_ind
 from hypothesis.errors import UnsatisfiedAssumption
-from hypothesis.internal.conjecture.data import StopTest
 from hypothesis.internal.conjecture.engine import ConjectureRunner
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -136,9 +135,8 @@ def run_benchmark_for_sizes(benchmark, n_runs):
                             interesting_seed, data, value
                         ):
                             data.mark_interesting()
-                except StopTest:
-                    pass
-                sizes.append(len(data.buffer))
+                finally:
+                    sizes.append(len(data.buffer))
             engine = ConjectureRunner(
                 test_function, settings=BENCHMARK_SETTINGS, random=random
             )


### PR DESCRIPTION
Two small fixes:

* Some benchmarks can produce constant data (this doesn't happen in any of the current ones with the current implementation, but I've seen it in some experiments). This currently produces a p-value of NaN. This updates it to check those benchmarks manually as having identical constant values and skipping them.
* The code was catching StopTest. I'm not sure why I thought that was a good idea, but it's certainly not necessary and is kinda naughty (I think harmless though). This removes that and adds the data in a finally block.

These are entirely independent but I'm being lazy and bundling the two line change for StopTest in with the other more interesting one. Feel free to yell at me if this bothers you and I'll split it out.