### PR TITLE
Hopefully fix deployment

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -22,7 +22,7 @@ You should generally assume that an API is internal unless you have specific
 information to the contrary.
 
 ------------------
-3.8.1 - 2017-04-25
+3.8.1 - 2017-04-26
 ------------------
 
 This is a documentation release.  Almost all code examples are now doctests

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -76,7 +76,12 @@ if __name__ == '__main__':
         sys.executable, 'setup.py', 'sdist', '--dist-dir', DIST,
     ])
 
-    if not tools.on_master():
+    HEAD = tools.hash_for_name('HEAD')
+    MASTER = tools.hash_for_name('origin/master')
+    print('Current head:', HEAD)
+    print('Current master:', MASTER)
+
+    if not tools.is_ancestor(HEAD, MASTER):
         print('Not deploying due to not being on master')
         sys.exit(0)
 

--- a/scripts/hypothesistooling.py
+++ b/scripts/hypothesistooling.py
@@ -88,10 +88,6 @@ def is_ancestor(a, b):
     ]) == 0
 
 
-def on_master():
-    return hash_for_name('HEAD') == merge_base('HEAD', 'origin/master')
-
-
 def changelog():
     with open(os.path.join(ROOT, 'docs', 'changes.rst')) as i:
         return i.read()

--- a/scripts/hypothesistooling.py
+++ b/scripts/hypothesistooling.py
@@ -82,6 +82,12 @@ def hash_for_name(name):
     ]).decode('ascii').strip()
 
 
+def is_ancestor(a, b):
+    return subprocess.call([
+        'git', '--is-ancestor', a, b
+    ]) == 0
+
+
 def on_master():
     return hash_for_name('HEAD') == merge_base('HEAD', 'origin/master')
 

--- a/scripts/hypothesistooling.py
+++ b/scripts/hypothesistooling.py
@@ -83,9 +83,11 @@ def hash_for_name(name):
 
 
 def is_ancestor(a, b):
-    return subprocess.call([
-        'git', '--is-ancestor', a, b
-    ]) == 0
+    check = subprocess.call([
+        'git', 'merge-base', '--is-ancestor', a, b
+    ])
+    assert 0 <= check <= 1
+    return check == 0
 
 
 def changelog():


### PR DESCRIPTION
See #589 - deploys currently think they're not on master when they are.

This updates the master check to use "git merge-base --is-ancestor", which is hopefully more correct.

It's obviously a little hard to test this without actually deploying, but this should work.