### PR TITLE
Relax some of the weirder constraints on Hypothesis shrinking

### DIFF
--- a/tests/quality/test_shrink_quality.py
+++ b/tests/quality/test_shrink_quality.py
@@ -53,20 +53,6 @@ def test_minimal_fractions_3():
         lists(fractions()), lambda s: len(s) >= 20) == [Fraction(0)] * 20
 
 
-def test_minimize_list_of_floats_on_large_structure():
-    def test_list_in_range(xs):
-        return len([
-            x for x in xs
-            if x >= 3
-        ]) >= 30
-
-    result = minimal(
-        lists(floats(), min_size=50, average_size=100),
-        test_list_in_range, timeout_after=120)
-    result.sort()
-    assert result == [0.0] * 20 + [3.0] * 30
-
-
 def test_minimize_string_to_empty():
     assert minimal(text()) == u''
 

--- a/tests/quality/test_shrink_quality.py
+++ b/tests/quality/test_shrink_quality.py
@@ -421,13 +421,3 @@ def test_can_simplify_hard_recursive_data_into_boolean_alternative(rnd):
     lvs = leaves(r)
     assert lvs == [False] * 3
     assert all(isinstance(v, bool) for v in lvs), repr(lvs)
-
-
-@given(random_module(), integers(min_value=0))
-@example(None, 62677)
-@settings(max_examples=100, max_shrinks=0)
-def test_minimize_down_to(rnd, i):
-    j = find(
-        integers(), lambda x: x >= i,
-        settings=settings(max_examples=1000, database=None, max_shrinks=1000))
-    assert i == j

--- a/tests/quality/test_shrink_quality.py
+++ b/tests/quality/test_shrink_quality.py
@@ -367,20 +367,6 @@ def test_anti_sorted_ordered_pair():
     assert len(result) == 30
 
 
-def test_constant_lists_of_diverse_length():
-    n_elements = 10
-
-    result = minimal(
-        lists(constant_list(integers()), min_size=n_elements),
-        lambda x: len(set(map(len, x))) >= n_elements,
-        timeout_after=30,
-    )
-    assert len(result) == n_elements
-    for v in result:
-        assert v == [0] * len(v)
-    assert sorted(map(len, result)) == list(hrange(n_elements))
-
-
 @pytest.mark.parametrize('n', [0, 1, 10, 100, 1000])
 def test_containment(n):
     iv = minimal(

--- a/tests/quality/test_shrink_quality.py
+++ b/tests/quality/test_shrink_quality.py
@@ -423,14 +423,6 @@ def test_can_simplify_hard_recursive_data_into_boolean_alternative(rnd):
     assert all(isinstance(v, bool) for v in lvs), repr(lvs)
 
 
-def test_can_clone_same_length_items():
-    ls = find(
-        lists(frozensets(integers(), min_size=10, max_size=10)),
-        lambda x: len(x) >= 20
-    )
-    assert len(set(ls)) == 1
-
-
 @given(random_module(), integers(min_value=0))
 @example(None, 62677)
 @settings(max_examples=100, max_shrinks=0)

--- a/tests/quality/test_shrink_quality.py
+++ b/tests/quality/test_shrink_quality.py
@@ -216,16 +216,6 @@ def test_minimize_long():
 
 
 
-def test_small_sum_lists():
-    xs = minimal(
-        lists(floats(), min_size=100, average_size=200),
-        lambda x:
-            sum(t for t in x if float(u'inf') > t >= 0) >= 1,
-        timeout_after=60,
-    )
-    assert 1.0 <= sum(t for t in xs if t >= 0) <= 1.5
-
-
 def test_find_large_union_list():
     def large_mostly_non_overlapping(xs):
         assume(xs)

--- a/tests/quality/test_shrink_quality.py
+++ b/tests/quality/test_shrink_quality.py
@@ -29,6 +29,8 @@ from tests.common.debug import minimal
 from tests.common import parametrize
 from hypothesis.strategies import just, sets, text, lists, binary, \
     floats, tuples, randoms, booleans, integers, fractions, \
+from hypothesis.strategies import just, sets, text, lists, \
+    floats, tuples, randoms, booleans, decimals, integers, fractions, \
     recursive, frozensets, dictionaries, sampled_from
 from hypothesis.internal.compat import PY3, OrderedDict, hrange, \
     reduce, integer_types
@@ -205,18 +207,6 @@ def test_minimize_multiple_elements_in_silly_large_int_range_min_is_not_dupe():
         timeout_after=60,
     )
     assert x == target
-
-
-def test_minimize_one_of_distinct_types():
-    y = booleans() | binary()
-    x = minimal(
-        tuples(y, y),
-        lambda x: type(x[0]) != type(x[1])
-    )
-    assert x in (
-        (False, b''),
-        (b'', False)
-    )
 
 
 @pytest.mark.skipif(PY3, reason=u'Python 3 has better integers')

--- a/tests/quality/test_shrink_quality.py
+++ b/tests/quality/test_shrink_quality.py
@@ -30,7 +30,7 @@ from tests.common import parametrize
 from hypothesis.strategies import just, sets, text, lists, binary, \
     floats, tuples, randoms, booleans, integers, fractions, \
 from hypothesis.strategies import just, sets, text, lists, \
-    floats, tuples, randoms, booleans, decimals, integers, fractions, \
+    tuples, randoms, booleans, decimals, integers, fractions, \
     recursive, frozensets, dictionaries, sampled_from
 from hypothesis.internal.compat import PY3, OrderedDict, hrange, \
     reduce, integer_types

--- a/tests/quality/test_shrink_quality.py
+++ b/tests/quality/test_shrink_quality.py
@@ -18,7 +18,6 @@
 from __future__ import division, print_function, absolute_import
 
 import sys
-import math
 import operator
 from random import Random
 from fractions import Fraction
@@ -26,11 +25,11 @@ from fractions import Fraction
 import pytest
 
 from hypothesis import find, given, assume, example, settings
-from tests.common import parametrize, ordered_pair, constant_list
 from tests.common.debug import minimal
+from tests.common import parametrize
 from hypothesis.strategies import just, sets, text, lists, binary, \
     floats, tuples, randoms, booleans, integers, fractions, \
-    recursive, frozensets, dictionaries, sampled_from, random_module
+    recursive, frozensets, dictionaries, sampled_from
 from hypothesis.internal.compat import PY3, OrderedDict, hrange, \
     reduce, integer_types
 
@@ -117,6 +116,7 @@ def test_minimize_sets_of_sets():
                 s != t and t.issubset(s)
                 for t in set_of_sets
             )
+
 
 def test_can_simplify_flatmap_with_bounded_left_hand_size():
     assert minimal(


### PR DESCRIPTION
You know that thing where you get frustrated with your test suite and want to delete all of it? This is that PR.

The purpose of this PR is a *really* brutal cull of tests/quality/test_shrink_quality.py

A justification of my actions follows:

I've been doing a lot of benchmarking related work recently. It goes roughly like this:

1. I find some *really* suboptimal behaviour where Hypothesis is doing way more work than it needs to.
2. I replace it with something simple and faster and the benchmark suite thanksk me.
3. Some weird test case that I dreamed up four years ago to showcase how clever I was being fails
4. I get annoyed and try to fix it.
5. Oh god there are worms everywhere why did I even open this can?

The fact is, most of the shrinking tests in this file don't come from *anywhere* sensible. They're just the results of me being a dick to Hypothesis's shrinker and seeing how far I can push it.

This is the wrong way to go about it.

Further, I hear a bunch of user complaints about Hypothesis performance and almost zero user complaints about Hypothesis shrink quality. Most of the time (issues like #581 aside) Hypothesis's shrink quality is more than good enough, and often it's *unreasonably* good. The rest of the time, its problems aren't found by this sort of weird adversarial testing and are found by real user problems.

So I propose getting rid of a lot of the old baggage and a moratorium on new shrink examples unless they satisfy one of the following:

1. They are *really* simple (#581 just about qualifies)
2. They are derived from an actual user problem.

Discuss.