### PR TITLE
Add a python_requires to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(
     zip_safe=False,
     extras_require=extras,
     install_requires=install_requires,
+    python_requires='>=2.7',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
I didn't know this was a thing, but apparently it is!

If you try to `pip install` a package with this flag present, you get an error message:

```console
$ pip install -e .
DEPRECATION: Python 2.6 is no longer supported by the Python core team, please upgrade your Python. A future version of pip will drop support for Python 2.6
Obtaining file:///Users/alexwlchan/repos/hypothesis-python
hypothesis requires Python '>=2.7' but the running Python is 2.6.9
```

It doesn't stop somebody from running `python setup.py install`, but it saves them from installing it from PyPI (which is likely the vast majority of installations).