### PR TITLE
Remove pytest version check

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -21,6 +21,21 @@ Hypothesis APIs come in three flavours:
 You should generally assume that an API is internal unless you have specific
 information to the contrary.
 
+
+------------------
+3.8.3 - 2017-05-09
+------------------
+
+This release removes a version check for older versions of pytest when using
+the Hypothesis pytest plugin. The pytest plugin will now run unconditionally
+on all versions of pytest. This breaks compatibility with any version of pytest
+prior to 2.7.0 (which is more than two years old).
+
+The primary reason for this change is that the version check was a frequent
+source of breakage when pytest change their versioning scheme. If you are not
+working on pytest itself and are not running a very old version of it, this
+release probably doesn't affect you.
+
 ------------------
 3.8.2 - 2017-04-26
 ------------------

--- a/src/hypothesis/extra/pytestplugin.py
+++ b/src/hypothesis/extra/pytestplugin.py
@@ -17,8 +17,6 @@
 
 from __future__ import division, print_function, absolute_import
 
-import re
-
 import pytest
 
 from hypothesis.reporting import default as default_reporter
@@ -27,116 +25,119 @@ from hypothesis.statistics import collector
 from hypothesis.internal.compat import OrderedDict, text_type
 from hypothesis.internal.detection import is_hypothesis_test
 
-PYTEST_VERSION = tuple(map(
-    int,
-    re.sub('-.+', '', pytest.__version__).split('.')[:3]
-))
-
 LOAD_PROFILE_OPTION = '--hypothesis-profile'
 PRINT_STATISTICS_OPTION = '--hypothesis-show-statistics'
 
-if PYTEST_VERSION >= (2, 7, 0):
-    class StoringReporter(object):
 
-        def __init__(self, config):
-            self.config = config
-            self.results = []
+class StoringReporter(object):
 
-        def __call__(self, msg):
-            if self.config.getoption('capture', 'fd') == 'no':
-                default_reporter(msg)
-            if not isinstance(msg, text_type):
-                msg = repr(msg)
-            self.results.append(msg)
+    def __init__(self, config):
+        self.config = config
+        self.results = []
 
-    def pytest_addoption(parser):
-        group = parser.getgroup('hypothesis', 'Hypothesis')
-        group.addoption(
-            LOAD_PROFILE_OPTION,
-            action='store',
-            help='Load in a registered hypothesis.settings profile'
+    def __call__(self, msg):
+        if self.config.getoption('capture', 'fd') == 'no':
+            default_reporter(msg)
+        if not isinstance(msg, text_type):
+            msg = repr(msg)
+        self.results.append(msg)
+
+
+def pytest_addoption(parser):
+    group = parser.getgroup('hypothesis', 'Hypothesis')
+    group.addoption(
+        LOAD_PROFILE_OPTION,
+        action='store',
+        help='Load in a registered hypothesis.settings profile'
+    )
+    group.addoption(
+        PRINT_STATISTICS_OPTION,
+        action='store_true',
+        help='Configure when statistics are printed',
+        default=False
+    )
+
+
+def pytest_configure(config):
+    from hypothesis import settings
+    profile = config.getoption(LOAD_PROFILE_OPTION)
+    if profile:
+        settings.load_profile(profile)
+    config.addinivalue_line(
+        'markers',
+        'hypothesis: Tests which use hypothesis.')
+
+
+gathered_statistics = OrderedDict()
+
+
+@pytest.mark.hookwrapper
+def pytest_runtest_call(item):
+    if not (hasattr(item, 'obj') and is_hypothesis_test(item.obj)):
+        yield
+    else:
+        store = StoringReporter(item.config)
+
+        def note_statistics(stats):
+            gathered_statistics[item.nodeid] = stats
+
+        with collector.with_value(note_statistics):
+            with with_reporter(store):
+                yield
+        if store.results:
+            item.hypothesis_report_information = list(store.results)
+
+
+@pytest.mark.hookwrapper
+def pytest_runtest_makereport(item, call):
+    report = (yield).get_result()
+    if hasattr(item, 'hypothesis_report_information'):
+        report.sections.append((
+            'Hypothesis',
+            '\n'.join(item.hypothesis_report_information)
+        ))
+
+
+def pytest_terminal_summary(terminalreporter):
+    if not terminalreporter.config.getoption(PRINT_STATISTICS_OPTION):
+        return
+    terminalreporter.section('Hypothesis Statistics')
+    for name, statistics in gathered_statistics.items():
+        terminalreporter.write_line(name + ':')
+        terminalreporter.write_line('')
+
+        if not statistics.has_runs:
+            terminalreporter.write_line('  - Test was never run')
+            continue
+
+        terminalreporter.write_line((
+            '  - %d passing examples, %d failing examples,'
+            ' %d invalid examples') % (
+            statistics.passing_examples, statistics.failing_examples,
+            statistics.invalid_examples,
+        ))
+        terminalreporter.write_line(
+            '  - Typical runtimes: %s' % (statistics.runtimes,)
         )
-        group.addoption(
-            PRINT_STATISTICS_OPTION,
-            action='store_true',
-            help='Configure when statistics are printed',
-            default=False
+        terminalreporter.write_line(
+            '  - Stopped because %s' % (statistics.exit_reason,)
         )
+        if statistics.events:
+            terminalreporter.write_line('  - Events:')
+            for event in statistics.events:
+                terminalreporter.write_line(
+                    '    * %s' % (event,)
+                )
+        terminalreporter.write_line('')
 
-    def pytest_configure(config):
-        from hypothesis import settings
-        profile = config.getoption(LOAD_PROFILE_OPTION)
-        if profile:
-            settings.load_profile(profile)
-        config.addinivalue_line(
-            'markers',
-            'hypothesis: Tests which use hypothesis.')
 
-    gathered_statistics = OrderedDict()
+def pytest_collection_modifyitems(items):
+    for item in items:
+        if not isinstance(item, pytest.Function):
+            continue
+        if getattr(item.function, 'is_hypothesis_test', False):
+            item.add_marker('hypothesis')
 
-    @pytest.mark.hookwrapper
-    def pytest_runtest_call(item):
-        if not (hasattr(item, 'obj') and is_hypothesis_test(item.obj)):
-            yield
-        else:
-            store = StoringReporter(item.config)
 
-            def note_statistics(stats):
-                gathered_statistics[item.nodeid] = stats
-
-            with collector.with_value(note_statistics):
-                with with_reporter(store):
-                    yield
-            if store.results:
-                item.hypothesis_report_information = list(store.results)
-
-    @pytest.mark.hookwrapper
-    def pytest_runtest_makereport(item, call):
-        report = (yield).get_result()
-        if hasattr(item, 'hypothesis_report_information'):
-            report.sections.append((
-                'Hypothesis',
-                '\n'.join(item.hypothesis_report_information)
-            ))
-
-    def pytest_terminal_summary(terminalreporter):
-        if not terminalreporter.config.getoption(PRINT_STATISTICS_OPTION):
-            return
-        terminalreporter.section('Hypothesis Statistics')
-        for name, statistics in gathered_statistics.items():
-            terminalreporter.write_line(name + ':')
-            terminalreporter.write_line('')
-
-            if not statistics.has_runs:
-                terminalreporter.write_line('  - Test was never run')
-                continue
-
-            terminalreporter.write_line((
-                '  - %d passing examples, %d failing examples,'
-                ' %d invalid examples') % (
-                statistics.passing_examples, statistics.failing_examples,
-                statistics.invalid_examples,
-            ))
-            terminalreporter.write_line(
-                '  - Typical runtimes: %s' % (statistics.runtimes,)
-            )
-            terminalreporter.write_line(
-                '  - Stopped because %s' % (statistics.exit_reason,)
-            )
-            if statistics.events:
-                terminalreporter.write_line('  - Events:')
-                for event in statistics.events:
-                    terminalreporter.write_line(
-                        '    * %s' % (event,)
-                    )
-            terminalreporter.write_line('')
-
-    def pytest_collection_modifyitems(items):
-        for item in items:
-            if not isinstance(item, pytest.Function):
-                continue
-            if getattr(item.function, 'is_hypothesis_test', False):
-                item.add_marker('hypothesis')
-
-    def load():
-        pass
+def load():
+    pass

--- a/src/hypothesis/version.py
+++ b/src/hypothesis/version.py
@@ -17,5 +17,5 @@
 
 from __future__ import division, print_function, absolute_import
 
-__version_info__ = (3, 8, 2)
+__version_info__ = (3, 8, 3)
 __version__ = '.'.join(map(str, __version_info__))


### PR DESCRIPTION
Fixes #611

This version check tests for a version of pytest that is > 2 years old, and the check has been a frequent source of breakage for pytest's use of Hypothesis. Lets just remove it.