### PR TITLE
Import sqlite3 only if used; minor bugfixes

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -21,6 +21,13 @@ Hypothesis APIs come in three flavours:
 You should generally assume that an API is internal unless you have specific
 information to the contrary.
 
+------------------
+3.8.5 - 2017-05-16
+------------------
+
+Hypothesis now imports ``sqlite3`` when a SQLite database is used, rather
+than at module load, improving compatibility with Python implementations
+compiled without SQLite support (such as BSD or Jython).
 
 ------------------
 3.8.4 - 2017-05-16

--- a/docs/supported.rst
+++ b/docs/supported.rst
@@ -14,10 +14,10 @@ Python versions
 Hypothesis is supported and tested on CPython 2.7 and CPython 3.4+.
 
 Hypothesis also supports PyPy2, and will support PyPy3 when there is a stable
-release supporting Python 3.4+.  Hypothesis does not currently work on Jython
-(it requires sqlite), though could feasibly be made to do so. IronPython might
-work but hasn't been tested.  32-bit and narrow builds should work, though
-this is currently only tested on Windows.
+release supporting Python 3.4+.  Hypothesis does not currently work on Jython,
+though could feasibly be made to do so. IronPython might work but hasn't been
+tested.  32-bit and narrow builds should work, though this is currently only
+tested on Windows.
 
 In general Hypothesis does not officially support anything except the latest
 patch release of any version of Python it supports. Earlier releases should work
@@ -30,9 +30,7 @@ Operating systems
 
 In theory Hypothesis should work anywhere that Python does. In practice it is
 only known to work and regularly tested on OS X, Windows and Linux, and you may
-experience issues running it elsewhere. For example a known issue is that FreeBSD
-splits out the python-sqlite package from the main python package, and you will
-need to install that in order for it to work.
+experience issues running it elsewhere.
 
 If you're using something else and it doesn't work, do get in touch and I'll try
 to help, but unless you can come up with a way for me to run a CI server on that

--- a/src/hypothesis/_settings.py
+++ b/src/hypothesis/_settings.py
@@ -246,8 +246,8 @@ class settings(settingsMeta('settings', (object,), {})):
         If this was explicitly set at settings instantiation then that
         value will be used (even if it was None). If not and the
         database_file setting is not None this will be lazily loaded as
-        an SQLite backed ExampleDatabase using that file the first time
-        this property is accessed on a particular thread.
+        an ExampleDatabase using that file the first time this property
+        is accessed on a particular thread.
 
         """
         if self._database is not_set and self.database_file is not None:

--- a/src/hypothesis/database.py
+++ b/src/hypothesis/database.py
@@ -19,7 +19,6 @@ from __future__ import division, print_function, absolute_import
 
 import os
 import re
-import sqlite3
 import binascii
 import threading
 from contextlib import contextmanager
@@ -27,6 +26,7 @@ from contextlib import contextmanager
 from hypothesis.internal.compat import FileNotFoundError, sha1, \
     b64decode, b64encode
 
+sqlite3 = None
 SQLITE_PATH = re.compile(r"\.\(db|sqlite|sqlite3\)$")
 
 
@@ -115,6 +115,8 @@ class SQLiteExampleDatabase(ExampleDatabase):
         self.path = path
         self.db_created = False
         self.current_connection = threading.local()
+        global sqlite3
+        import sqlite3
 
     def connection(self):
         if not hasattr(self.current_connection, 'connection'):

--- a/src/hypothesis/version.py
+++ b/src/hypothesis/version.py
@@ -17,5 +17,5 @@
 
 from __future__ import division, print_function, absolute_import
 
-__version_info__ = (3, 8, 4)
+__version_info__ = (3, 8, 5)
 __version__ = '.'.join(map(str, __version_info__))


### PR DESCRIPTION
Still a single import, but this way it's only attempted if you're actually using a sqlite example database.  IMO it is better to raise an import error if you attempt to use sqlite than to change the database selection logic depending on whether it is installed.  Closes #173.