### PR TITLE
Sampling fix

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -23,6 +23,14 @@ information to the contrary.
 
 
 ------------------
+3.8.4 - 2017-05-14
+------------------
+
+This is a compatibility bugfix release.  ``sampled_from`` no longer raises
+a deprecation warning when sampling from an ``Enum``, as all enums have a
+reliable iteration order.
+
+------------------
 3.8.3 - 2017-05-09
 ------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,6 +22,7 @@ from __future__ import division, print_function, absolute_import
 # on_rtd is whether we are on readthedocs.org
 import os
 import sys
+import datetime
 
 from hypothesis import __version__
 
@@ -51,7 +52,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Hypothesis'
-copyright = u'2015, David R. MacIver'
+copyright = u'2013-%s, David R. MacIver' % datetime.datetime.utcnow().year
 author = u'David R. MacIver'
 
 version = __version__

--- a/src/hypothesis/internal/conjecture/utils.py
+++ b/src/hypothesis/internal/conjecture/utils.py
@@ -17,6 +17,7 @@
 
 from __future__ import division, print_function, absolute_import
 
+import enum
 import math
 from collections import Sequence
 
@@ -104,7 +105,7 @@ def centered_integer_range(data, lower, upper, center):
 
 
 def check_sample(values):
-    if not isinstance(values, Sequence):
+    if not isinstance(values, (Sequence, enum.EnumMeta)):
         note_deprecation(
             ('Cannot sample from %r, not a sequence.  ' % (values,)) +
             'Hypothesis goes to some length to ensure that sampling an '

--- a/src/hypothesis/version.py
+++ b/src/hypothesis/version.py
@@ -17,5 +17,5 @@
 
 from __future__ import division, print_function, absolute_import
 
-__version_info__ = (3, 8, 3)
+__version_info__ = (3, 8, 4)
 __version__ = '.'.join(map(str, __version_info__))

--- a/tests/cover/test_sampled_from.py
+++ b/tests/cover/test_sampled_from.py
@@ -17,10 +17,14 @@
 
 from __future__ import division, print_function, absolute_import
 
+import enum
+
 from hypothesis import given, settings
 from hypothesis.errors import HypothesisDeprecationWarning
 from tests.common.utils import fails_with
 from hypothesis.strategies import sampled_from
+
+an_enum = enum.Enum('A', 'a b c')
 
 
 @given(sampled_from((1, 2)))
@@ -38,3 +42,9 @@ def test_cannot_sample_sets_in_strict_mode():
 def test_can_sample_sets_while_deprecated():
     with settings(strict=False):
         assert sampled_from(set('abc')).example() in 'abc'
+
+
+@given(sampled_from(an_enum))
+def test_can_sample_enums(member):
+    with settings(strict=True):
+        assert isinstance(member, an_enum)


### PR DESCRIPTION
A tiny compatibility fix for `sampled_from`, allowing Enums without a deprecation warning.  Closes #595.

Uses the current year (in UTC) for the sphinx copyright notice.