### PR TITLE
Upgrade introspection to use getfullargspec

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -21,6 +21,18 @@ Hypothesis APIs come in three flavours:
 You should generally assume that an API is internal unless you have specific
 information to the contrary.
 
+-------------------
+3.10.0 - 2017-05-22
+-------------------
+
+Hypothesis now uses ``inspect.getfullargspec`` internally.
+On Python 2, there are no visible changes.
+
+On Python 3 ``@given`` and ``@composite`` now preserve annotations on the
+decorated function.  Keyword-only arguments are now either handled correctly
+(e.g. ``@composite``), or caught in validation instead of silently discarded
+or raising an unrelated error later (e.g. ``@given``).
+
 ------------------
 3.9.1 - 2017-05-22
 ------------------

--- a/src/hypothesis/searchstrategy/deferred.py
+++ b/src/hypothesis/searchstrategy/deferred.py
@@ -18,7 +18,7 @@
 from __future__ import division, print_function, absolute_import
 
 from hypothesis import settings
-from hypothesis.internal.compat import hrange, getargspec
+from hypothesis.internal.compat import hrange, getfullargspec
 from hypothesis.internal.reflection import arg_string, \
     convert_keyword_arguments, convert_positional_arguments
 from hypothesis.searchstrategy.strategies import SearchStrategy
@@ -91,8 +91,8 @@ class DeferredStrategy(SearchStrategy):
         if self.__representation is None:
             _args = self.__args
             _kwargs = self.__kwargs
-            argspec = getargspec(self.__function)
-            defaults = {}
+            argspec = getfullargspec(self.__function)
+            defaults = dict(argspec.kwonlydefaults or {})
             if argspec.defaults is not None:
                 for k in hrange(1, len(argspec.defaults) + 1):
                     defaults[argspec.args[-k]] = argspec.defaults[-k]

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -25,8 +25,8 @@ from fractions import Fraction
 from hypothesis.errors import InvalidArgument
 from hypothesis.control import assume
 from hypothesis.searchstrategy import SearchStrategy
-from hypothesis.internal.compat import ArgSpec, hrange, text_type, \
-    getargspec, integer_types, implements_iterator
+from hypothesis.internal.compat import hrange, text_type, integer_types, \
+    getfullargspec, implements_iterator
 from hypothesis.internal.floats import is_negative, float_to_int, \
     int_to_float, count_between_floats
 from hypothesis.utils.conventions import not_set
@@ -975,7 +975,7 @@ def composite(f):
     """
 
     from hypothesis.internal.reflection import define_function_signature
-    argspec = getargspec(f)
+    argspec = getfullargspec(f)
 
     if (
         argspec.defaults is not None and
@@ -989,10 +989,9 @@ def composite(f):
             'positional argument.'
         )
 
-    new_argspec = ArgSpec(
-        args=argspec.args[1:], varargs=argspec.varargs,
-        keywords=argspec.keywords, defaults=argspec.defaults
-    )
+    annots = {k: v for k, v in argspec.annotations.items()
+              if k in (argspec.args + argspec.kwonlyargs + ['return'])}
+    new_argspec = argspec._replace(args=argspec.args[1:], annotations=annots)
 
     @defines_strategy
     @define_function_signature(f.__name__, f.__doc__, new_argspec)

--- a/src/hypothesis/version.py
+++ b/src/hypothesis/version.py
@@ -17,5 +17,5 @@
 
 from __future__ import division, print_function, absolute_import
 
-__version_info__ = (3, 9, 1)
+__version_info__ = (3, 10, 0)
 __version__ = '.'.join(map(str, __version_info__))

--- a/tests/py3/test_annotations.py
+++ b/tests/py3/test_annotations.py
@@ -17,10 +17,107 @@
 
 from __future__ import division, print_function, absolute_import
 
+import pytest
+
 import hypothesis.strategies as st
 from hypothesis import given
+from hypothesis.errors import InvalidArgument
+from hypothesis.internal.compat import getfullargspec
+from hypothesis.internal.reflection import define_function_signature, \
+    convert_positional_arguments, get_pretty_function_description
 
 
 @given(st.integers())
 def test_has_an_annotation(i: int):
     pass
+
+
+def universal_acceptor(*args, **kwargs):
+    return args, kwargs
+
+
+def has_annotation(a: int, *b, c=2) -> None:
+    pass
+
+
+@pytest.mark.parametrize('f', [
+    has_annotation,
+    lambda *, a: a,
+    lambda *, a=1: a,
+])
+def test_copying_preserves_argspec(f):
+    af = getfullargspec(f)
+    t = define_function_signature('foo', 'docstring', af)(universal_acceptor)
+    at = getfullargspec(t)
+    assert af.args == at.args[:len(af.args)]
+    assert af.varargs == at.varargs
+    assert af.varkw == at.varkw
+    assert len(af.defaults or ()) == len(at.defaults or ())
+    assert af.kwonlyargs == at.kwonlyargs
+    assert af.kwonlydefaults == at.kwonlydefaults
+    assert af.annotations == at.annotations
+
+
+@pytest.mark.parametrize('lam,source', [
+    ((lambda *z, a: a),
+     'lambda *z, a: a'),
+    ((lambda *z, a=1: a),
+     'lambda *z, a=1: a'),
+    ((lambda *, a: a),
+     'lambda *, a: a'),
+    ((lambda *, a=1: a),
+     'lambda *, a=1: a'),
+])
+def test_py3only_lambda_formatting(lam, source):
+    # Testing kwonly lambdas, with and without varargs and default values
+    assert get_pretty_function_description(lam) == source
+
+
+def test_given_notices_missing_kwonly_args():
+    with pytest.raises(InvalidArgument):
+        @given(a=st.none())
+        def reqs_kwonly(*, a, b):
+            pass
+
+
+def test_converter_handles_kwonly_args():
+    def f(*, a, b=2):
+        pass
+
+    out = convert_positional_arguments(f, (), dict(a=1))
+    assert out == ((), dict(a=1, b=2))
+
+
+def test_converter_notices_missing_kwonly_args():
+    def f(*, a, b=2):
+        pass
+
+    with pytest.raises(TypeError):
+        assert convert_positional_arguments(f, (), dict())
+
+
+def pointless_composite(draw: None, strat: bool, nothing: list) -> int:
+    return 3
+
+
+def return_annot() -> int:
+    return 4  # per RFC 1149.5 / xckd 221
+
+
+def first_annot(draw: None):
+    pass
+
+
+def test_composite_edits_annotations():
+    spec_comp = getfullargspec(st.composite(pointless_composite))
+    assert spec_comp.annotations['return'] == int
+    assert 'nothing' in spec_comp.annotations
+    assert 'draw' not in spec_comp.annotations
+
+
+@pytest.mark.parametrize('nargs', [1, 2, 3])
+def test_given_edits_annotations(nargs):
+    spec_given = getfullargspec(
+        given(*(nargs * [st.none()]))(pointless_composite))
+    assert spec_given.annotations.pop('return') is None
+    assert len(spec_given.annotations) == 3 - nargs


### PR DESCRIPTION
This allows us to support keyword-only arguments and defaults in various places, as well as passing through function annotations.  Closes #290.  It's also part of the foundation for 167 and eventually 293.

Needs review by @DRMacIver, because it's scary internals stuff.  I also need to move most of the tests to a new file for Py3 reflection tests.