### PR TITLE
Compare version numbers as Tuple[int], not strings

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -23,7 +23,7 @@ information to the contrary.
 
 
 ------------------
-3.8.4 - 2017-05-15
+3.8.4 - 2017-05-16
 ------------------
 
 This is a compatibility bugfix release.  ``sampled_from`` no longer raises


### PR DESCRIPTION
Because that only works when they all have the same number of digits between each dot.  Whoops.

Also a better error message for unsorted entries.