### PR TITLE
Infer argument types based on type annotations 

### DIFF
--- a/src/hypothesis/extra/types.py
+++ b/src/hypothesis/extra/types.py
@@ -6,6 +6,7 @@ Infer types of test function arguments using type annotations
 
 import hypothesis
 import hypothesis.strategies as st
+import inspect
 
 __author__      = "Marco Sirabella"
 __credits__     = ["Marco Sirabella"]  # Authors and bug reporters
@@ -14,10 +15,20 @@ __module__      = "Hypothesis"
 
 
 type2strat = {}
-ez_strategies = (st.integers(), st.floats(), st.text(), st.binary(),
-st.booleans())
-for strat in ez_strategies:
-    type2strat[type(strat.example())] = strat
+for strat_name in dir(st):
+    strat = getattr(st, strat_name)
+    del strat_name
+    if inspect.isfunction(strat):
+        try:
+            strat = strat()
+            if isinstance(
+                    strat,
+                    hypothesis.searchstrategy.strategies.SearchStrategy
+                    ):
+                type2strat[type(strat.example())] = strat
+        except (TypeError, hypothesis.errors.NoExamples):
+            pass
+
 
 def infer(func):
     types = func.__annotations__

--- a/src/hypothesis/extra/types.py
+++ b/src/hypothesis/extra/types.py
@@ -9,10 +9,10 @@ import hypothesis.strategies as st
 import inspect
 import typing
 
-__author__      = "Marco Sirabella"
-__credits__     = ["Marco Sirabella"]  # Authors and bug reporters
-__email__       = "msirabel@gmail.com"
-__module__      = "Hypothesis"
+__author__      = "Marco Sirabella"     # noqa E221
+__credits__     = ["Marco Sirabella"]   # noqa E221
+__email__       = "msirabel@gmail.com"  # noqa E221
+__module__      = "Hypothesis"          # noqa E221
 
 
 class Type2Strat(dict):

--- a/src/hypothesis/extra/types.py
+++ b/src/hypothesis/extra/types.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Infer types of test function arguments using type annotations
+"""
+
+import hypothesis
+import hypothesis.strategies as st
+
+__author__      = "Marco Sirabella"
+__credits__     = ["Marco Sirabella"]  # Authors and bug reporters
+__email__       = "msirabel@gmail.com"
+__module__      = "Hypothesis"
+
+
+type2strat = {
+        int: st.integers(),
+        float: st.floats(),
+        str: st.text(),
+        bytes: st.binary(),
+        bool: st.booleans(),
+}
+
+def infer(func):
+    types = func.__annotations__
+    kwargs = {}
+    for key, value in types.items():
+        kwargs[key] = type2strat[value]
+    func = hypothesis.given(**kwargs)(func)
+    return func
+
+
+# Testing quickly
+
+@infer
+def test(i: int):
+    print(i)
+
+test()

--- a/src/hypothesis/extra/types.py
+++ b/src/hypothesis/extra/types.py
@@ -27,7 +27,7 @@ class Type2Strat(dict):
                             strat,
                             hypothesis.searchstrategy.strategies.SearchStrategy
                     ):
-                        self[type(strat.example())] = strat
+                        self.append(strat)
                 except (TypeError, hypothesis.errors.NoExamples):
                     pass
 
@@ -36,6 +36,9 @@ class Type2Strat(dict):
             both = item.__args__
             return self[both[0]] | self[both[1]]
         return super().__getitem__(item)
+
+    def append(self, strategy):
+        self[type(strategy.example())] = strategy
 
 
 type2strat = Type2Strat()

--- a/src/hypothesis/extra/types.py
+++ b/src/hypothesis/extra/types.py
@@ -17,27 +17,31 @@ __module__      = "Hypothesis"
 
 class Type2Strat(dict):
     def __init__(self):
-        for strat_name in dir(st):
-            strat = getattr(st, strat_name)
-            del strat_name
-            if inspect.isfunction(strat):
+        for strat_name in dir(st):  # Iterate through all attributes in module
+            strat = getattr(st, strat_name)  # get attribute of name
+            del strat_name  # No need for the strategy name anymore,
+            if inspect.isfunction(strat):  # If attribute is callable function
                 try:
-                    strat = strat()
+                    strat = strat()  # Call wrapping function
                     if isinstance(
-                            strat,
+                            strat,  # If it is a search strategy
                             hypothesis.searchstrategy.strategies.SearchStrategy
                     ):
-                        self.append(strat)
+                        self.append(strat)  # Add strategy to self
                 except (TypeError, hypothesis.errors.NoExamples):
+                    # If not enough args or not able to get examples
                     pass
 
     def __getitem__(self, item):
-        if isinstance(item, typing._Union):
-            both = item.__args__
-            return self[both[0]] | self[both[1]]
-        return super().__getitem__(item)
+        if isinstance(item, typing._Union):  # If is union of multiple types
+            both = item.__args__  # assign each item of args to both
+            return self[both[0]] | self[both[1]]  # Call __getitem__ for each
+        return super().__getitem__(item)  # If not union just return normally
 
     def append(self, strategy):
+        """
+        Add strategy and respective type as key
+        """
         self[type(strategy.example())] = strategy
 
 
@@ -45,6 +49,15 @@ type2strat = Type2Strat()
 
 
 def infer(func):
+    """
+    a decorator for turning a test function that accepts argument into a
+    randomized test
+
+    This is a offshoot of the given function, rather than accept arguments of
+    what strategies the tests should use, tries to infer based on type
+    annotations of wrapped function
+    """
+
     types = func.__annotations__
     kwargs = {}
     for key, value in types.items():

--- a/src/hypothesis/extra/types.py
+++ b/src/hypothesis/extra/types.py
@@ -58,7 +58,8 @@ def infer(func):
     annotations of wrapped function
     """
 
-    types = func.__annotations__
+    # types = func.__annotations__
+    types = typing.get_type_hints(func)  # It's longer but I guess?
     kwargs = {}
     for key, value in types.items():
         kwargs[key] = type2strat[value]

--- a/src/hypothesis/extra/types.py
+++ b/src/hypothesis/extra/types.py
@@ -51,22 +51,3 @@ def infer(func):
         kwargs[key] = type2strat[value]
     func = hypothesis.given(**kwargs)(func)
     return func
-
-
-# Testing quickly
-
-@infer
-def test_int(i: int):
-    assert abs(i) >= 0
-
-
-@infer
-def oneorother(i: typing.Union[int, float]):
-    if isinstance(i, int):
-        assert type(i) == int
-    else:
-        assert isinstance(i, float)
-
-
-test_int()
-oneorother()

--- a/src/hypothesis/extra/types.py
+++ b/src/hypothesis/extra/types.py
@@ -13,13 +13,11 @@ __email__       = "msirabel@gmail.com"
 __module__      = "Hypothesis"
 
 
-type2strat = {
-        int: st.integers(),
-        float: st.floats(),
-        str: st.text(),
-        bytes: st.binary(),
-        bool: st.booleans(),
-}
+type2strat = {}
+ez_strategies = (st.integers(), st.floats(), st.text(), st.binary(),
+st.booleans())
+for strat in ez_strategies:
+    type2strat[type(strat.example())] = strat
 
 def infer(func):
     types = func.__annotations__

--- a/src/hypothesis/extra/types.py
+++ b/src/hypothesis/extra/types.py
@@ -7,6 +7,7 @@ Infer types of test function arguments using type annotations
 import hypothesis
 import hypothesis.strategies as st
 import inspect
+import typing
 
 __author__      = "Marco Sirabella"
 __credits__     = ["Marco Sirabella"]  # Authors and bug reporters
@@ -42,7 +43,15 @@ def infer(func):
 # Testing quickly
 
 @infer
-def test(i: int):
-    print(i)
+def test_int(i: int):
+    assert abs(i) >= 0
 
-test()
+@hypothesis.given(st.integers() | st.floats())
+def oneorother(i: typing.Union[int, float]):
+    if isinstance(i, int):
+        assert type(i) == int
+    else:
+        assert isinstance(i, float)
+
+test_int()
+oneorother()

--- a/src/hypothesis/extra/types.py
+++ b/src/hypothesis/extra/types.py
@@ -26,15 +26,17 @@ class Type2Strat(dict):
                     if isinstance(
                             strat,
                             hypothesis.searchstrategy.strategies.SearchStrategy
-                            ):
+                    ):
                         self[type(strat.example())] = strat
                 except (TypeError, hypothesis.errors.NoExamples):
                     pass
+
     def __getitem__(self, item):
         if isinstance(item, typing._Union):
             both = item.__args__
             return self[both[0]] | self[both[1]]
         return super().__getitem__(item)
+
 
 type2strat = Type2Strat()
 
@@ -54,12 +56,14 @@ def infer(func):
 def test_int(i: int):
     assert abs(i) >= 0
 
+
 @infer
 def oneorother(i: typing.Union[int, float]):
     if isinstance(i, int):
         assert type(i) == int
     else:
         assert isinstance(i, float)
+
 
 test_int()
 oneorother()

--- a/src/hypothesis/extra/types.py
+++ b/src/hypothesis/extra/types.py
@@ -15,7 +15,14 @@ __email__       = "msirabel@gmail.com"
 __module__      = "Hypothesis"
 
 
-type2strat = {}
+class Type2Strat(dict):
+    def __getitem__(self, item):
+        if isinstance(item, typing._Union):
+            both = item.__args__
+            return self[both[0]] | self[both[1]]
+        return super().__getitem__(item)
+
+type2strat = Type2Strat()
 for strat_name in dir(st):
     strat = getattr(st, strat_name)
     del strat_name
@@ -46,7 +53,7 @@ def infer(func):
 def test_int(i: int):
     assert abs(i) >= 0
 
-@hypothesis.given(st.integers() | st.floats())
+@infer
 def oneorother(i: typing.Union[int, float]):
     if isinstance(i, int):
         assert type(i) == int

--- a/src/hypothesis/extra/types.py
+++ b/src/hypothesis/extra/types.py
@@ -16,6 +16,20 @@ __module__      = "Hypothesis"
 
 
 class Type2Strat(dict):
+    def __init__(self):
+        for strat_name in dir(st):
+            strat = getattr(st, strat_name)
+            del strat_name
+            if inspect.isfunction(strat):
+                try:
+                    strat = strat()
+                    if isinstance(
+                            strat,
+                            hypothesis.searchstrategy.strategies.SearchStrategy
+                            ):
+                        self[type(strat.example())] = strat
+                except (TypeError, hypothesis.errors.NoExamples):
+                    pass
     def __getitem__(self, item):
         if isinstance(item, typing._Union):
             both = item.__args__
@@ -23,19 +37,6 @@ class Type2Strat(dict):
         return super().__getitem__(item)
 
 type2strat = Type2Strat()
-for strat_name in dir(st):
-    strat = getattr(st, strat_name)
-    del strat_name
-    if inspect.isfunction(strat):
-        try:
-            strat = strat()
-            if isinstance(
-                    strat,
-                    hypothesis.searchstrategy.strategies.SearchStrategy
-                    ):
-                type2strat[type(strat.example())] = strat
-        except (TypeError, hypothesis.errors.NoExamples):
-            pass
 
 
 def infer(func):


### PR DESCRIPTION
Working off of  #200 and #293. Simply has a subclassed dictionary object that maps types to strategies, and a decorator to map type annotations to strategies and forwards strategies to the given function and works from there.

```python
@infer
def test_abs(number: int):
    assert abs(number) >= 0
```

Works with type unions and all core strategies, but lacking handling of many fringe cases.

Will not break anything, as the file did not exist before. 

This will make test functions slightly easier to write since the type annotations will be documented and accessible through the help function but also usable by the testing framework.