### PR TITLE
Strategies from type hints, and inference of missing arguments to builds() and @given()

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -22,6 +22,29 @@ You should generally assume that an API is internal unless you have specific
 information to the contrary.
 
 -------------------
+3.14.0 - 2017-07-23
+-------------------
+
+Hypothesis now understands inline type annotations (:issue:`293`):
+
+- If the target of :func:`~hypothesis.strategies.builds` has type annotations,
+  a default strategy for missing required arguments is selected based on the
+  type.  Type-based strategy selection will only override a default if you
+  pass :const:`hypothesis.infer` as a keyword argument.
+
+- If :func:`@given <hypothesis.given>` wraps a function with type annotations,
+  you can pass :const:`~hypothesis.infer` as a keyword argument and the
+  appropriate strategy will be substituted.
+
+- You can check what strategy will be inferred for a type with the new
+  :func:`~hypothesis.strategies.from_type` function.
+
+- :func:`~hypothesis.strategies.register_type_strategy` teaches Hypothesis
+  which strategy to infer for custom or unknown types.  You can provide a
+  strategy, or for more complex cases a function which takes the type and
+  returns a strategy.
+
+-------------------
 3.13.1 - 2017-07-20
 -------------------
 

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -2,11 +2,11 @@
 What you can generate and how
 =============================
 
-The general philosophy of Hypothesis data generation is that everything
-should be possible to generate and most things should be easy. Most things in
-the standard library
-is more aspirational than achieved, the state of the art is already pretty
-good.
+*Most things should be easy to generate and everything should be possible.*
+
+To support this principle Hypothesis provides strategies for most of built-in
+types with arguments to constrain or adjust the output, as well as higher-order
+strategies that can be composed to generate more complex types.
 
 This document is a guide to what strategies are available for generating data
 and how to build them. Strategies have a variety of other important internal
@@ -84,7 +84,7 @@ Think of a Stream as an infinite list where we've only evaluated as much as
 we need to. As per above, you can index into it and the stream will be evaluated up to
 that index and no further.
 
-You can iterate over it too (warning: iter on a stream given to you
+You can iterate over it too (warning: :func:`python:iter` on a stream given to you
 by Hypothesis in this way will never terminate):
 
 .. doctest::
@@ -133,7 +133,7 @@ map creates a new stream where each element of the stream is the function
 applied to the corresponding element of the original stream. Evaluating the
 new stream will force evaluating the original stream up to that index.
 
-(Warning: This isn't the map builtin. In Python 3 the builtin map should do
+(Warning: This isn't the map builtin. In Python 3 the builtin :func:`python:map` should do
 more or less the right thing, but in Python 2 it will never terminate and
 will just eat up all your memory as it tries to build an infinitely long list)
 
@@ -167,7 +167,7 @@ e.g.:
   [-224, -222, 16, 159, 120699286316048]
 
 Note that many things that you might use mapping for can also be done with
-:func:`hypothesis.strategies.builds`.
+:func:`~hypothesis.strategies.builds`.
 
 ---------
 Filtering
@@ -329,7 +329,7 @@ following gives you a list and an index into it:
     ...     i = draw(integers(min_value=0, max_value=len(xs) - 1))
     ...     return (xs, i)
 
-'draw(s)' is a function that should be thought of as returning s.example(),
+``draw(s)`` is a function that should be thought of as returning ``s.example()``,
 except that the result is reproducible and will minimize correctly. The
 decorated function has the initial argument removed from the list, but will
 accept all the others in the expected order. Defaults are preserved.
@@ -361,7 +361,7 @@ You can use :func:`assume <hypothesis.assume>` inside composite functions:
         assume(x != y)
         return (x, y)
 
-This works as assume normally would, filtering out any examples for which the
+This works as :func:`assume <hypothesis.assume>` normally would, filtering out any examples for which the
 passed in argument is falsey.
 
 
@@ -371,7 +371,7 @@ passed in argument is falsey.
 Drawing interactively in tests
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-There is also the ``data()`` strategy, which gives you a means of using
+There is also the :func:`~hypothesis.strategies.data` strategy, which gives you a means of using
 strategies interactively. Rather than having to specify everything up front in
 :func:`@given <hypothesis.given>` you can draw from strategies in the body of your test:
 
@@ -394,7 +394,7 @@ the above is wrong (it has a boundary condition error), so will print:
 
 As you can see, data drawn this way is simplified as usual.
 
-Test functions using the ``data()`` strategy do not support explicit
+Test functions using the :func:`~hypothesis.strategies.data` strategy do not support explicit
 :func:`@example(...) <hypothesis.example>`\ s.  In this case, the best option is usually to construct
 your data with :func:`@composite <hypothesis.strategies.composite>` or the explicit example, and unpack this within
 the body of the test.

--- a/docs/details.rst
+++ b/docs/details.rst
@@ -365,16 +365,16 @@ The rules for determining what are valid uses of given are as follows:
 1. You may pass any keyword argument to given.
 2. Positional arguments to given are equivalent to the rightmost named
    arguments for the test function.
-3. positional arguments may not be used if the underlying test function has
-   varargs or arbitrary keywords.
+3. Positional arguments may not be used if the underlying test function has
+   varargs, arbitrary keywords, or keyword-only arguments.
 4. Functions tested with given may not have any defaults.
 
 The reason for the "rightmost named arguments" behaviour is so that
 using :func:`@given <hypothesis.given>` with instance methods works: ``self``
 will be passed to the function as normal and not be parametrized over.
 
-The function returned by given has all the arguments that the original test did
-, minus the ones that are being filled in by given.
+The function returned by given has all the same arguments as the original
+test, minus those that are filled in by given.
 
 -------------------------
 Custom function execution

--- a/guides/documentation.rst
+++ b/guides/documentation.rst
@@ -7,7 +7,7 @@ and Hypothesis is written to be used, as widely as possible.
 
 This is a working document-in-progress with some tips for how we try to write
 our docs, with a little of the what and a bigger chunk of the how.
-If you have ideas about how to improve these suggests, meta issues or pull
+If you have ideas about how to improve these suggestions, meta issues or pull
 requests are just as welcome as for docs or code :D
 
 ----------------------------
@@ -36,7 +36,7 @@ cross-references.  Without repeating the docs for Sphinx, here are some tips:
   (eg) ``:func:`hypothesis.given`\ ``, which will appear as
   ``hypothesis.given()`` with a hyperlink to the apropriate docs.  You can
   show only the last part (unqualified name) by adding a tilde at the start,
-  like ``:func:`hypothesis.given`\ `` -> ``given()``.  Finally, you can give
+  like ``:func:`~hypothesis.given`\ `` -> ``given()``.  Finally, you can give
   it alternative link text in the usual way:
   ``:func:`other text <hypothesis.given>`\ `` -> ``other text``.
 

--- a/src/hypothesis/__init__.py
+++ b/src/hypothesis/__init__.py
@@ -28,6 +28,7 @@ from hypothesis._settings import settings, Verbosity, Phase, HealthCheck
 from hypothesis.version import __version_info__, __version__
 from hypothesis.control import assume, note, reject, event
 from hypothesis.core import given, find, example, seed
+from hypothesis.utils.conventions import infer
 
 
 __all__ = [
@@ -43,6 +44,7 @@ __all__ = [
     'example',
     'note',
     'event',
+    'infer',
     '__version__',
     '__version_info__',
 ]

--- a/src/hypothesis/errors.py
+++ b/src/hypothesis/errors.py
@@ -142,6 +142,17 @@ class InvalidArgument(HypothesisException, TypeError):
     some manner incorrect."""
 
 
+class ResolutionFailed(InvalidArgument):
+
+    """Hypothesis had to resolve a type to a strategy, but this failed.
+
+    Type inference is best-effort, so this only happens when an
+    annotation exists but could not be resolved for a required argument
+    to the target of ``builds()``, or where the user passed ``infer``.
+
+    """
+
+
 class InvalidState(HypothesisException):
 
     """The system is not in a state where you were allowed to do that."""

--- a/src/hypothesis/errors.py
+++ b/src/hypothesis/errors.py
@@ -23,7 +23,6 @@ import warnings
 class HypothesisException(Exception):
 
     """Generic parent class for exceptions thrown by Hypothesis."""
-    pass
 
 
 class CleanupFailed(HypothesisException):
@@ -83,7 +82,6 @@ class NoExamples(HypothesisException):
     """Raised when example() is called on a strategy but we cannot find any
     examples after enough tries that we really should have been able to if this
     was ever going to work."""
-    pass
 
 
 class Unsatisfiable(HypothesisException):

--- a/src/hypothesis/internal/compat.py
+++ b/src/hypothesis/internal/compat.py
@@ -268,7 +268,8 @@ if PY2:
     def getfullargspec(func):
         import inspect
         args, varargs, varkw, defaults = inspect.getargspec(func)
-        return FullArgSpec(args, varargs, varkw, defaults, [], None, {})
+        return FullArgSpec(args, varargs, varkw, defaults, [], None,
+                           getattr(func, '__annotations__', {}))
 else:
     from inspect import getfullargspec, FullArgSpec
 

--- a/src/hypothesis/internal/compat.py
+++ b/src/hypothesis/internal/compat.py
@@ -290,6 +290,26 @@ else:
         getfullargspec = silence_warnings(getfullargspec)
 
 
+def get_type_hints(thing):
+    """Try to return any type hints for ``thing``."""
+    try:
+        import typing
+        return typing.get_type_hints(thing)
+    except TypeError:
+        # `thing` is not a module, class, method, or function
+        return {}
+    except (ImportError, AttributeError):  # pragma: no cover
+        # This is a fallback for Python <3.6, where get_type_hints may fail
+        try:
+            spec = getfullargspec(thing)
+            return {
+                k: v for k, v in spec.annotations.items()
+                if k in (spec.args + spec.kwonlyargs) and isinstance(v, type)
+            }
+        except TypeError:
+            return {}
+
+
 importlib_invalidate_caches = getattr(
     importlib, 'invalidate_caches', lambda: ())
 

--- a/src/hypothesis/internal/reflection.py
+++ b/src/hypothesis/internal/reflection.py
@@ -74,6 +74,20 @@ def function_digest(function):
     return hasher.digest()
 
 
+def required_args(target, args=(), kwargs=()):
+    """Return a set of required args to target."""
+    try:
+        spec = getfullargspec(
+            target.__init__ if inspect.isclass(target) else target)
+    except TypeError:  # pragma: no cover
+        return None
+    # For classes, self is present in the argspec but not really required
+    posargs = spec.args[1:] if inspect.isclass(target) else spec.args
+    return set(posargs + spec.kwonlyargs) \
+        - set(spec.args[len(spec.args) - len(spec.defaults or ()):]) \
+        - set(spec.kwonlydefaults or ()) - set(args) - set(kwargs)
+
+
 def convert_keyword_arguments(function, args, kwargs):
     """Returns a pair of a tuple and a dictionary which would be equivalent
     passed as positional and keyword args to the function. Unless function has.

--- a/src/hypothesis/searchstrategy/types.py
+++ b/src/hypothesis/searchstrategy/types.py
@@ -1,0 +1,253 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2017 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import io
+import sys
+import functools
+import collections
+
+import hypothesis.strategies as st
+from hypothesis.errors import ResolutionFailed
+from hypothesis.internal.compat import text_type, integer_types
+
+_global_type_to_strategy_lookup = {}
+
+
+@st.cacheable
+def type_strategy_mapping():
+    """Return a dict mapping from types to corresponding search strategies.
+
+    Most resolutions will terminate here or in the special handling for
+    generics from the typing module.
+
+    """
+    import uuid
+    import decimal
+    import datetime as dt
+    import fractions
+
+    known_type_strats = {
+        # Types with core Hypothesis strategies
+        type(None): st.none(),
+        bool: st.booleans(),
+        float: st.floats(),
+        complex: st.complex_numbers(),
+        fractions.Fraction: st.fractions(),
+        decimal.Decimal: st.decimals(),
+        text_type: st.text(),
+        bytes: st.binary(),
+        dt.datetime: st.datetimes(),
+        dt.date: st.dates(),
+        dt.time: st.times(),
+        dt.timedelta: st.timedeltas(),
+        uuid.UUID: st.uuids(),
+        # Built-in types
+        type: st.sampled_from([type(None), bool, int, str, list, set, dict]),
+        type(Ellipsis): st.just(Ellipsis),
+        type(NotImplemented): st.just(NotImplemented),
+        bytearray: st.binary().map(bytearray),
+        memoryview: st.binary().map(memoryview),
+        # Pull requests with more types welcome!
+    }
+    for t in integer_types:
+        known_type_strats[t] = st.integers()
+    # build empty collections, as only generics know their contents
+    known_type_strats.update({
+        t: st.builds(t) for t in (tuple, list, set, frozenset, dict)
+    })
+    try:
+        from hypothesis.extra.pytz import timezones
+        known_type_strats[dt.tzinfo] = timezones()
+    except ImportError:  # pragma: no cover
+        pass
+    try:  # pragma: no cover
+        import numpy as np
+        from hypothesis.extra.numpy import \
+            arrays, array_shapes, scalar_dtypes, nested_dtypes
+        known_type_strats.update({
+            np.dtype: nested_dtypes(),
+            np.ndarray: arrays(scalar_dtypes(), array_shapes(max_dims=2)),
+        })
+    except ImportError:
+        pass
+    return known_type_strats
+
+
+def type_sorting_key(t):
+    """Minimise to None, then non-container types, then container types."""
+    if t is None or t is type(None):
+        return -1
+    return issubclass(t, collections.abc.Container)
+
+
+def check_by_origin(thing, super_):
+    return thing is super_ or getattr(thing, '__origin__', None) is super_
+
+
+def try_issubclass(thing, maybe_superclass):
+    try:
+        return issubclass(thing, maybe_superclass)
+    except (AttributeError, TypeError):
+        # Some types can't be the subject or object of an instance or
+        # subclass check, including _TypeAlias and Union
+        return False
+
+
+def from_typing_type(thing):
+    import typing
+    # `Any` and `Type` mess up our subclass lookups, so handle them first
+    if thing is typing.Any:
+        raise ResolutionFailed('Cannot resolve typing.Any to any strategy.')
+    if check_by_origin(thing, getattr(typing, 'Type', object())):
+        if thing.__args__ in (None, typing.Any):
+            return st.just(type)
+        return st.from_type(thing.__args__[0]).map(type)
+    if check_by_origin(thing, typing.Union) or \
+            (sys.version_info[:2] == (3, 5) and thing.__name__ == 'Union'):
+        params = getattr(thing, '__union_params__', None) or ()
+        args = getattr(thing, '__args__', None) or ()
+        possible = sorted(params + args, key=type_sorting_key)
+        if not possible:
+            raise ResolutionFailed('Cannot resolve Union of no types.')
+        return st.one_of([st.from_type(t) for t in possible])
+    if isinstance(thing, typing.TypeVar):
+        if getattr(thing, '__contravariant__', False):
+            raise ResolutionFailed('Cannot resolve contravariant %s' % thing)
+        constraints = getattr(thing, '__constraints__', ())
+        if not constraints:
+            return st.builds(object)
+        # Pick a single constraint per run, and resolve it to a strategy
+        return st.shared(st.sampled_from(constraints), key=thing
+                         ).flatmap(st.from_type)
+    to_match = getattr(thing, '__origin__', None) or thing
+    # Of all types with a strategy, select the supertypes of this thing that
+    # whose subtypes have no strategy, and return their strategic union
+    mapping = dict(generic_type_strategy_mapping())
+    mapping.update({k: v for k, v in _global_type_to_strategy_lookup.items()
+                    if k.__module__ == 'typing'})
+    mapping = {k: v for k, v in mapping.items() if try_issubclass(k, to_match)}
+    if typing.Dict in mapping:
+        # View types are weird - the metaclasses are subclasses of (eg)
+        # Collection, but a concrete instance isn't an instance of Collection!
+        for t in (typing.KeysView, typing.ValuesView, typing.ItemsView):
+            mapping.pop(t, None)
+    return st.one_of([v if isinstance(v, st.SearchStrategy) else v(thing)
+                      for k, v in mapping.items()
+                      if sum(try_issubclass(k, T) for T in mapping) == 1])
+
+
+@st.cacheable
+def generic_type_strategy_mapping():
+    """Cache most of our generic type resolution logic.
+
+    Requires the ``typing`` module to be importable.
+
+    """
+    try:
+        import typing
+    except ImportError:  # pragma: no cover
+        return {}
+
+    registry = {
+        typing.ByteString: st.binary(),
+        typing.io.BinaryIO: st.builds(io.BytesIO, st.binary()),
+        typing.io.TextIO: st.builds(io.StringIO, st.text()),
+        typing.Reversible: st.lists(st.integers()),
+        typing.SupportsBytes: st.binary(),
+        typing.SupportsAbs: st.complex_numbers(),
+        typing.SupportsComplex: st.complex_numbers(),
+        typing.SupportsFloat: st.complex_numbers(),
+        typing.SupportsInt: st.complex_numbers(),
+        typing.SupportsRound: st.complex_numbers(),
+    }
+
+    def register(type_, fallback=None):
+        if isinstance(type_, str):
+            # Use the name of generic types which are not available on all
+            # versions, and the function just won't be added to the registry
+            type_ = getattr(typing, type_, None)
+            if type_ is None:  # pragma: no cover
+                return lambda f: f
+
+        def inner(func):
+            if fallback is None:
+                registry[type_] = func
+                return func
+
+            @functools.wraps(func)
+            def really_inner(thing):
+                if getattr(thing, '__args__', None) is None:
+                    return fallback
+                return func(thing)
+            registry[type_] = really_inner
+            return really_inner
+        return inner
+
+    @register(typing.Tuple)
+    def resolve_Tuple(thing):
+        # NamedTuple has special handling above due to user-defined __module__
+        elem_types = getattr(thing, '__tuple_params__', None) or ()
+        elem_types += getattr(thing, '__args__', None) or ()
+        if getattr(thing, '__tuple_use_ellipsis__', False) or \
+                len(elem_types) == 2 and elem_types[-1] is Ellipsis:
+            return st.lists(st.from_type(elem_types[0])).map(tuple)
+        return st.tuples(*map(st.from_type, elem_types))
+
+    @register(typing.List, st.builds(list))
+    def resolve_List(thing):
+        return st.lists(st.from_type(thing.__args__[0]))
+
+    @register(typing.Set, st.builds(set))
+    def resolve_Set(thing):
+        return st.sets(st.from_type(thing.__args__[0]))
+
+    @register(typing.FrozenSet, st.builds(frozenset))
+    def resolve_FrozenSet(thing):
+        return st.frozensets(st.from_type(thing.__args__[0]))
+
+    @register(typing.Dict, st.builds(dict))
+    def resolve_Dict(thing):
+        # If thing is a Collection instance, we need to fill in the values
+        keys_vals = [st.from_type(t) for t in thing.__args__] * 2
+        return st.dictionaries(keys_vals[0], keys_vals[1])
+
+    @register('DefaultDict', st.builds(collections.defaultdict))
+    def resolve_DefaultDict(thing):
+        return resolve_Dict(thing).map(
+            lambda d: collections.defaultdict(None, d))
+
+    @register(typing.ItemsView, st.builds(dict).map(dict.items))
+    def resolve_ItemsView(thing):
+        return resolve_Dict(thing).map(dict.items)
+
+    @register(typing.KeysView, st.builds(dict).map(dict.keys))
+    def resolve_KeysView(thing):
+        return st.dictionaries(st.from_type(thing.__args__[0]), st.none()
+                               ).map(dict.keys)
+
+    @register(typing.ValuesView, st.builds(dict).map(dict.values))
+    def resolve_ValuesView(thing):
+        return st.dictionaries(st.integers(), st.from_type(thing.__args__[0])
+                               ).map(dict.values)
+
+    @register(typing.Iterator, st.iterables(st.nothing()))
+    def resolve_Iterator(thing):
+        return st.iterables(st.from_type(thing.__args__[0]))
+
+    return registry

--- a/src/hypothesis/searchstrategy/types.py
+++ b/src/hypothesis/searchstrategy/types.py
@@ -18,75 +18,16 @@
 from __future__ import division, print_function, absolute_import
 
 import io
-import sys
+import uuid
+import decimal
+import datetime
+import fractions
 import functools
 import collections
 
 import hypothesis.strategies as st
 from hypothesis.errors import ResolutionFailed
 from hypothesis.internal.compat import text_type, integer_types
-
-_global_type_to_strategy_lookup = {}
-
-
-@st.cacheable
-def type_strategy_mapping():
-    """Return a dict mapping from types to corresponding search strategies.
-
-    Most resolutions will terminate here or in the special handling for
-    generics from the typing module.
-
-    """
-    import uuid
-    import decimal
-    import datetime as dt
-    import fractions
-
-    known_type_strats = {
-        # Types with core Hypothesis strategies
-        type(None): st.none(),
-        bool: st.booleans(),
-        float: st.floats(),
-        complex: st.complex_numbers(),
-        fractions.Fraction: st.fractions(),
-        decimal.Decimal: st.decimals(),
-        text_type: st.text(),
-        bytes: st.binary(),
-        dt.datetime: st.datetimes(),
-        dt.date: st.dates(),
-        dt.time: st.times(),
-        dt.timedelta: st.timedeltas(),
-        uuid.UUID: st.uuids(),
-        # Built-in types
-        type: st.sampled_from([type(None), bool, int, str, list, set, dict]),
-        type(Ellipsis): st.just(Ellipsis),
-        type(NotImplemented): st.just(NotImplemented),
-        bytearray: st.binary().map(bytearray),
-        memoryview: st.binary().map(memoryview),
-        # Pull requests with more types welcome!
-    }
-    for t in integer_types:
-        known_type_strats[t] = st.integers()
-    # build empty collections, as only generics know their contents
-    known_type_strats.update({
-        t: st.builds(t) for t in (tuple, list, set, frozenset, dict)
-    })
-    try:
-        from hypothesis.extra.pytz import timezones
-        known_type_strats[dt.tzinfo] = timezones()
-    except ImportError:  # pragma: no cover
-        pass
-    try:  # pragma: no cover
-        import numpy as np
-        from hypothesis.extra.numpy import \
-            arrays, array_shapes, scalar_dtypes, nested_dtypes
-        known_type_strats.update({
-            np.dtype: nested_dtypes(),
-            np.ndarray: arrays(scalar_dtypes(), array_shapes(max_dims=2)),
-        })
-    except ImportError:
-        pass
-    return known_type_strats
 
 
 def type_sorting_key(t):
@@ -96,75 +37,120 @@ def type_sorting_key(t):
     return issubclass(t, collections.abc.Container)
 
 
-def check_by_origin(thing, super_):
-    return thing is super_ or getattr(thing, '__origin__', None) is super_
-
-
 def try_issubclass(thing, maybe_superclass):
     try:
         return issubclass(thing, maybe_superclass)
-    except (AttributeError, TypeError):
+    except (AttributeError, TypeError):  # pragma: no cover
         # Some types can't be the subject or object of an instance or
-        # subclass check, including _TypeAlias and Union
+        # subclass check under Python 3.5
         return False
 
 
 def from_typing_type(thing):
+    # We start with special-case support for Union and Tuple - the latter
+    # isn't actually a generic type.  Support for Callable may be added to
+    # this section later.
+    # We then explicitly error on non-Generic types, which don't carry enough
+    # information to sensibly resolve to strategies at runtime.
+    # Finally, we run a variation of the subclass lookup in st.from_type
+    # among generic types in the lookup.
     import typing
-    # `Any` and `Type` mess up our subclass lookups, so handle them first
-    if thing is typing.Any:
-        raise ResolutionFailed('Cannot resolve typing.Any to any strategy.')
-    if check_by_origin(thing, getattr(typing, 'Type', object())):
-        if thing.__args__ in (None, typing.Any):
-            return st.just(type)
-        return st.from_type(thing.__args__[0]).map(type)
-    if check_by_origin(thing, typing.Union) or \
-            (sys.version_info[:2] == (3, 5) and thing.__name__ == 'Union'):
-        params = getattr(thing, '__union_params__', None) or ()
-        args = getattr(thing, '__args__', None) or ()
-        possible = sorted(params + args, key=type_sorting_key)
-        if not possible:
+    # Under 3.6 Union is handled directly in st.from_type, as the argument is
+    # not an instance of `type`. However, under Python 3.5 Union *is* a type
+    # and we have to handle it here, including failing if it has no parameters.
+    if hasattr(thing, '__union_params__'):  # pragma: no cover
+        args = sorted(thing.__union_params__ or (), key=type_sorting_key)
+        if not args:
             raise ResolutionFailed('Cannot resolve Union of no types.')
-        return st.one_of([st.from_type(t) for t in possible])
-    if isinstance(thing, typing.TypeVar):
-        if getattr(thing, '__contravariant__', False):
-            raise ResolutionFailed('Cannot resolve contravariant %s' % thing)
-        constraints = getattr(thing, '__constraints__', ())
-        if not constraints:
-            return st.builds(object)
-        # Pick a single constraint per run, and resolve it to a strategy
-        return st.shared(st.sampled_from(constraints), key=thing
-                         ).flatmap(st.from_type)
-    to_match = getattr(thing, '__origin__', None) or thing
-    # Of all types with a strategy, select the supertypes of this thing that
-    # whose subtypes have no strategy, and return their strategic union
-    mapping = dict(generic_type_strategy_mapping())
-    mapping.update({k: v for k, v in _global_type_to_strategy_lookup.items()
-                    if k.__module__ == 'typing'})
-    mapping = {k: v for k, v in mapping.items() if try_issubclass(k, to_match)}
+        return st.one_of([st.from_type(t) for t in args])
+    if isinstance(thing, typing.TupleMeta):
+        elem_types = getattr(thing, '__tuple_params__', None) or ()
+        elem_types += getattr(thing, '__args__', None) or ()
+        if getattr(thing, '__tuple_use_ellipsis__', False) or \
+                len(elem_types) == 2 and elem_types[-1] is Ellipsis:
+            return st.lists(st.from_type(elem_types[0])).map(tuple)
+        return st.tuples(*map(st.from_type, elem_types))
+    # Now, confirm that we're dealing with a generic type as we expected
+    if not isinstance(thing, typing.GenericMeta):  # pragma: no cover
+        raise ResolutionFailed('Cannot resolve %s to a strategy' % (thing,))
+    # Parametrised generic types have their __origin__ attribute set to the
+    # un-parametrised version, which we need to use in the subclass checks.
+    # e.g.:     typing.List[int].__origin__ == typing.List
+    mapping = {k: v for k, v in _global_type_lookup.items()
+               if isinstance(k, typing.GenericMeta) and
+               try_issubclass(k, getattr(thing, '__origin__', None) or thing)}
     if typing.Dict in mapping:
-        # View types are weird - the metaclasses are subclasses of (eg)
-        # Collection, but a concrete instance isn't an instance of Collection!
+        # The subtype relationships between generic and concrete View types
+        # are sometimes inconsistent under Python 3.5, so we pop them out to
+        # preserve our invariant that all examples of from_type(T) are
+        # instances of type T - and simplify the strategy for abstract types
+        # such as Container
         for t in (typing.KeysView, typing.ValuesView, typing.ItemsView):
             mapping.pop(t, None)
-    return st.one_of([v if isinstance(v, st.SearchStrategy) else v(thing)
-                      for k, v in mapping.items()
-                      if sum(try_issubclass(k, T) for T in mapping) == 1])
+    strategies = [v if isinstance(v, st.SearchStrategy) else v(thing)
+                  for k, v in mapping.items()
+                  if sum(try_issubclass(k, T) for T in mapping) == 1]
+    empty = ', '.join(repr(s) for s in strategies if s.is_empty)
+    if empty or not strategies:  # pragma: no cover
+        raise ResolutionFailed(
+            'Could not resolve %s to a strategy; consider using '
+            'register_type_strategy' % (empty or thing,))
+    return st.one_of(strategies)
 
 
-@st.cacheable
-def generic_type_strategy_mapping():
-    """Cache most of our generic type resolution logic.
+_global_type_lookup = {
+    # Types with core Hypothesis strategies
+    type(None): st.none(),
+    bool: st.booleans(),
+    float: st.floats(),
+    complex: st.complex_numbers(),
+    fractions.Fraction: st.fractions(),
+    decimal.Decimal: st.decimals(),
+    text_type: st.text(),
+    bytes: st.binary(),
+    datetime.datetime: st.datetimes(),
+    datetime.date: st.dates(),
+    datetime.time: st.times(),
+    datetime.timedelta: st.timedeltas(),
+    uuid.UUID: st.uuids(),
+    tuple: st.builds(tuple),
+    list: st.builds(list),
+    set: st.builds(set),
+    frozenset: st.builds(frozenset),
+    dict: st.builds(dict),
+    # Built-in types
+    type: st.sampled_from([type(None), bool, int, str, list, set, dict]),
+    type(Ellipsis): st.just(Ellipsis),
+    type(NotImplemented): st.just(NotImplemented),
+    bytearray: st.binary().map(bytearray),
+    memoryview: st.binary().map(memoryview),
+    # Pull requests with more types welcome!
+}
+for t in integer_types:
+    _global_type_lookup[t] = st.integers()
 
-    Requires the ``typing`` module to be importable.
+try:
+    from hypothesis.extra.pytz import timezones
+    _global_type_lookup[datetime.tzinfo] = timezones()
+except ImportError:  # pragma: no cover
+    pass
+try:  # pragma: no cover
+    import numpy as np
+    from hypothesis.extra.numpy import \
+        arrays, array_shapes, scalar_dtypes, nested_dtypes
+    _global_type_lookup.update({
+        np.dtype: nested_dtypes(),
+        np.ndarray: arrays(scalar_dtypes(), array_shapes(max_dims=2)),
+    })
+except ImportError:
+    pass
 
-    """
-    try:
-        import typing
-    except ImportError:  # pragma: no cover
-        return {}
-
-    registry = {
+try:
+    import typing
+except ImportError:  # pragma: no cover
+    pass
+else:
+    _global_type_lookup.update({
         typing.ByteString: st.binary(),
         typing.io.BinaryIO: st.builds(io.BytesIO, st.binary()),
         typing.io.TextIO: st.builds(io.StringIO, st.text()),
@@ -175,7 +161,7 @@ def generic_type_strategy_mapping():
         typing.SupportsFloat: st.complex_numbers(),
         typing.SupportsInt: st.complex_numbers(),
         typing.SupportsRound: st.complex_numbers(),
-    }
+    })
 
     def register(type_, fallback=None):
         if isinstance(type_, str):
@@ -187,7 +173,7 @@ def generic_type_strategy_mapping():
 
         def inner(func):
             if fallback is None:
-                registry[type_] = func
+                _global_type_lookup[type_] = func
                 return func
 
             @functools.wraps(func)
@@ -195,19 +181,20 @@ def generic_type_strategy_mapping():
                 if getattr(thing, '__args__', None) is None:
                     return fallback
                 return func(thing)
-            registry[type_] = really_inner
+            _global_type_lookup[type_] = really_inner
             return really_inner
         return inner
 
-    @register(typing.Tuple)
-    def resolve_Tuple(thing):
-        # NamedTuple has special handling above due to user-defined __module__
-        elem_types = getattr(thing, '__tuple_params__', None) or ()
-        elem_types += getattr(thing, '__args__', None) or ()
-        if getattr(thing, '__tuple_use_ellipsis__', False) or \
-                len(elem_types) == 2 and elem_types[-1] is Ellipsis:
-            return st.lists(st.from_type(elem_types[0])).map(tuple)
-        return st.tuples(*map(st.from_type, elem_types))
+    @register('Type')
+    def resolve_Type(thing):
+        if thing.__args__ is None:
+            return st.just(type)
+        inner = thing.__args__[0]
+        if getattr(inner, '__origin__', None) is typing.Union:
+            return st.sampled_from(inner.__args__)
+        elif hasattr(inner, '__union_params__'):  # pragma: no cover
+            return st.sampled_from(inner.__union_params__)
+        return st.just(inner)
 
     @register(typing.List, st.builds(list))
     def resolve_List(thing):
@@ -249,5 +236,3 @@ def generic_type_strategy_mapping():
     @register(typing.Iterator, st.iterables(st.nothing()))
     def resolve_Iterator(thing):
         return st.iterables(st.from_type(thing.__args__[0]))
-
-    return registry

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -21,17 +21,18 @@ import math
 import datetime as dt
 import operator
 from decimal import Decimal, InvalidOperation
+from inspect import isclass
 from numbers import Rational
 from fractions import Fraction
 
-from hypothesis.errors import InvalidArgument
+from hypothesis.errors import InvalidArgument, ResolutionFailed
 from hypothesis.control import assume
 from hypothesis.searchstrategy import SearchStrategy
 from hypothesis.internal.compat import hrange, text_type, integer_types, \
-    getfullargspec, implements_iterator
+    get_type_hints, getfullargspec, implements_iterator
 from hypothesis.internal.floats import is_negative, float_to_int, \
     int_to_float, count_between_floats
-from hypothesis.utils.conventions import not_set
+from hypothesis.utils.conventions import infer, not_set
 from hypothesis.internal.reflection import proxies
 from hypothesis.searchstrategy.reprwrapper import ReprWrapperStrategy
 
@@ -52,6 +53,7 @@ __all__ = [
     'recursive', 'composite',
     'shared', 'runner', 'data',
     'deferred',
+    'from_type', 'register_type_strategy',
 ]
 
 _strategies = set()
@@ -101,6 +103,7 @@ def cacheable(fn):
             result = fn(*args, **kwargs)
             cache[cache_key] = result
             return result
+    cached_strategy.__clear_cache = cache.clear
     return cached_strategy
 
 
@@ -780,6 +783,83 @@ def builds(target, *args, **kwargs):
 
 
 @cacheable
+def from_type(thing):
+    """Looks up the appropriate search strategy for the given type.
+
+    ``from_type`` is used internally to fill in missing arguments to
+    :func:`~hypothesis.strategies.builds` and can be used interactively
+    to explore what strategies are available or to debug type resolution.
+
+    You can use :func:`~hypothesis.strategies.register_type_strategy` to
+    handle your custom types, or to globally redefine certain strategies -
+    for example excluding NaN from floats, or use timezone-aware instead of
+    naive time and datetime strategies.
+
+    The resolution logic may be changed in a future version, but currently
+    tries these four options:
+
+    1. If ``thing`` is in the default lookup mapping or user-registered lookup,
+       return the corresponding strategy.  The default lookup covers all types
+       with Hypothesis strategies, including extras where possible.
+    2. If ``thing`` is from the :mod:`python:typing` module, return the
+       corresponding strategy (special logic).
+    3. If ``thing`` has one or more subtypes in the merged lookup, return
+       the union of the strategies for those types that are not subtypes of
+       other elements in the lookup.
+    4. Finally, if ``thing`` has type annotations for all required arguments,
+       it is resolved via :func:`~hypothesis.strategies.builds`.
+
+    """
+    from hypothesis.searchstrategy import types
+    # Look for a known concrete type or user-defined mapping
+    lookup = dict(types.type_strategy_mapping())
+    lookup.update(types.generic_type_strategy_mapping())
+    lookup.update(types._global_type_to_strategy_lookup)
+    if thing in lookup:
+        strategy = lookup[thing]
+        if not isinstance(lookup[thing], SearchStrategy):
+            strategy = lookup[thing](thing)
+        if strategy.is_empty:
+            raise ResolutionFailed(
+                'Error: %r resolved to an empty strategy' % (thing,))
+        return strategy
+    # I tried many more elegant checks, but `typing` tends to treat the type
+    # system as a loose guideline at best so they were all unreliable.
+    if getattr(thing, '__module__', None) == 'typing':
+        return types.from_typing_type(thing)
+    # If there's no exact match above, use similar subtype resolution logic
+    strategies = [  # pragma: no cover
+        v if isinstance(v, SearchStrategy) else v(thing)
+        for k, v in lookup.items()
+        if isclass(k) and isclass(thing) and types.try_issubclass(k, thing) and
+        sum(types.try_issubclass(k, T) for T in lookup) == 1
+    ]
+    empty = ', '.join(repr(s) for s in strategies if s.is_empty)
+    if empty:
+        raise ResolutionFailed(
+            'Could not resolve %s to a strategy; consider using '
+            'register_type_strategy' % empty)
+    elif strategies:
+        return one_of(strategies)
+    # If we don't have a strategy registered for this type or any subtype, we
+    # may be able to fall back on type annotations.
+    # Types created via typing.NamedTuple use a custom attribute instead -
+    # but we can still use builds(), if we work out the right kwargs.
+    if issubclass(thing, tuple) and hasattr(thing, '_fields') \
+            and hasattr(thing, '_field_types'):
+        kwargs = {k: from_type(thing._field_types[k]) for k in thing._fields}
+        return builds(thing, **kwargs)
+    # If the constructor has an annotation for every required argument,
+    # we can (and do) use builds() without supplying additional arguments.
+    required = required_args(thing)
+    if not required or required.issubset(get_type_hints(thing.__init__)):
+        return builds(thing)
+    # We have utterly failed, and might as well say so now.
+    raise ResolutionFailed('Could not resolve %r to a strategy; consider '
+                           'using register_type_strategy' % (thing,))
+
+
+@cacheable
 @defines_strategy
 def fractions(min_value=None, max_value=None, max_denominator=None):
     """Returns a strategy which generates Fractions.
@@ -1270,6 +1350,35 @@ def data():
                 "using @composite for whatever it is you're trying to do."
             ) % (name,))
     return DataStrategy()
+
+
+def register_type_strategy(custom_type, strategy):
+    """Add an entry to the global type-to-strategy lookup.
+
+    This lookup is used in :func:`~hypothesis.strategies.builds` and
+    :func:`@given <hypothesis.given>`.
+
+    :func:`~hypothesis.strategies.builds` will be used automatically for
+    classes with type annotations on ``__init__`` , so you only need to
+    register a strategy if one or more arguments need to be more tightly
+    defined than their type-based default, or if you want to supply a strategy
+    for an argument with a default value.
+
+    ``strategy`` may be a search strategy, or a function that takes a type and
+    returns a strategy (useful for generic types).
+
+    """
+    from hypothesis.searchstrategy import types
+    if not isinstance(custom_type, type):
+        raise InvalidArgument('custom_type=%r must be a type')
+    elif not (isinstance(strategy, SearchStrategy) or callable(strategy)):
+        raise InvalidArgument(
+            'strategy=%r must be a SearchStrategy, or a function that takes '
+            'a generic type and returns a specific SearchStrategy')
+    elif isinstance(strategy, SearchStrategy) and strategy.is_empty:
+        raise InvalidArgument('strategy=%r must not be empty')
+    types._global_type_lookup[custom_type] = strategy
+    from_type.__clear_cache()
 
 # Private API below here
 

--- a/src/hypothesis/utils/conventions.py
+++ b/src/hypothesis/utils/conventions.py
@@ -27,4 +27,5 @@ class UniqueIdentifier(object):
         return self.identifier
 
 
+infer = UniqueIdentifier(u'infer')
 not_set = UniqueIdentifier(u'not_set')

--- a/src/hypothesis/version.py
+++ b/src/hypothesis/version.py
@@ -17,5 +17,5 @@
 
 from __future__ import division, print_function, absolute_import
 
-__version_info__ = (3, 13, 1)
+__version_info__ = (3, 14, 0)
 __version__ = '.'.join(map(str, __version_info__))

--- a/tests/cover/test_given_error_conditions.py
+++ b/tests/cover/test_given_error_conditions.py
@@ -21,8 +21,8 @@ import time
 
 import pytest
 
-from hypothesis import given, assume, reject, settings
-from hypothesis.errors import Timeout, Unsatisfiable
+from hypothesis import given, infer, assume, reject, settings
+from hypothesis.errors import Timeout, Unsatisfiable, InvalidArgument
 from hypothesis.strategies import booleans, integers
 
 
@@ -61,3 +61,19 @@ def test_does_not_raise_unsatisfiable_if_some_false_in_finite_set():
         assume(x)
 
     test_assume_x()
+
+
+def test_error_if_has_no_hints():
+    @given(a=infer)
+    def inner(a):
+        pass
+    with pytest.raises(InvalidArgument):
+        inner()
+
+
+def test_error_if_infer_is_posarg():
+    @given(infer)
+    def inner(ex):
+        pass
+    with pytest.raises(InvalidArgument):
+        inner()

--- a/tests/cover/test_type_lookup.py
+++ b/tests/cover/test_type_lookup.py
@@ -1,0 +1,142 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2017 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import pytest
+
+import hypothesis.strategies as st
+from hypothesis import given, infer
+from hypothesis.errors import InvalidArgument, ResolutionFailed
+from hypothesis.searchstrategy import types
+from hypothesis.internal.compat import PY2, integer_types
+
+# Build a set of all types output by core strategies
+blacklist = [
+    'builds', 'iterables', 'permutations', 'random_module', 'randoms',
+    'runner', 'sampled_from', 'streaming',
+]
+types_with_core_strat = set(integer_types)
+for thing in (getattr(st, name) for name in sorted(st._strategies)
+              if name in dir(st) and name not in blacklist):
+    for n in range(3):
+        try:
+            ex = thing(*([st.nothing()] * n)).example()
+            types_with_core_strat.add(type(ex))
+            break
+        except (TypeError, InvalidArgument):
+            continue
+
+
+@pytest.mark.parametrize('typ', sorted(types_with_core_strat, key=str))
+def test_resolve_core_strategies(typ):
+    @given(st.from_type(typ))
+    def inner(ex):
+        if PY2 and issubclass(typ, integer_types):
+            assert isinstance(ex, integer_types)
+        else:
+            assert isinstance(ex, typ)
+
+    inner()
+
+
+def test_lookup_knows_about_all_core_strategies():
+    cannot_lookup = types_with_core_strat - set(types._global_type_lookup)
+    assert not cannot_lookup
+
+
+def test_lookup_keys_are_types():
+    with pytest.raises(InvalidArgument):
+        st.register_type_strategy('int', st.integers())
+    assert 'int' not in types._global_type_lookup
+
+
+def test_lookup_values_are_strategies():
+    with pytest.raises(InvalidArgument):
+        st.register_type_strategy(int, 42)
+    assert 42 not in types._global_type_lookup.values()
+
+
+@pytest.mark.parametrize('typ', sorted(types_with_core_strat, key=str))
+def test_lookup_overrides_defaults(typ):
+    sentinel = object()
+    try:
+        strat = types._global_type_lookup[typ]
+        st.register_type_strategy(typ, st.just(sentinel))
+        assert st.from_type(typ).example() is sentinel
+    finally:
+        st.register_type_strategy(typ, strat)
+        st.from_type.__clear_cache()
+    assert st.from_type(typ).example() is not sentinel
+
+
+class ParentUnknownType(object):
+    pass
+
+
+class UnknownType(ParentUnknownType):
+    def __init__(self, arg):
+        pass
+
+
+def test_custom_type_resolution():
+    fails = st.from_type(UnknownType)
+    with pytest.raises(ResolutionFailed):
+        fails.example()
+    sentinel = object()
+    try:
+        st.register_type_strategy(UnknownType, st.just(sentinel))
+        assert st.from_type(UnknownType).example() is sentinel
+        # Also covered by registration of child class
+        assert st.from_type(ParentUnknownType).example() is sentinel
+    finally:
+        types._global_type_lookup.pop(UnknownType)
+        st.from_type.__clear_cache()
+    fails = st.from_type(UnknownType)
+    with pytest.raises(ResolutionFailed):
+        fails.example()
+
+
+def test_errors_if_generic_resolves_empty():
+    try:
+        st.register_type_strategy(UnknownType, lambda _: st.nothing())
+        fails_1 = st.from_type(UnknownType)
+        with pytest.raises(ResolutionFailed):
+            fails_1.example()
+        fails_2 = st.from_type(ParentUnknownType)
+        with pytest.raises(ResolutionFailed):
+            fails_2.example()
+    finally:
+        types._global_type_lookup.pop(UnknownType)
+        st.from_type.__clear_cache()
+
+
+def test_cannot_register_empty():
+    # Cannot register and did not register
+    with pytest.raises(InvalidArgument):
+        st.register_type_strategy(UnknownType, st.nothing())
+    fails = st.from_type(UnknownType)
+    with pytest.raises(ResolutionFailed):
+        fails.example()
+    assert UnknownType not in types._global_type_lookup
+
+
+def test_pulic_interface_works():
+    st.from_type(int).example()
+    fails = st.from_type('not a type or annotated function')
+    with pytest.raises(InvalidArgument):
+        fails.example()

--- a/tests/cover/test_type_lookup.py
+++ b/tests/cover/test_type_lookup.py
@@ -140,3 +140,11 @@ def test_pulic_interface_works():
     fails = st.from_type('not a type or annotated function')
     with pytest.raises(InvalidArgument):
         fails.example()
+
+
+def test_given_can_infer_on_py2():
+    # Editing annotations before decorating is hilariously awkward, but works!
+    def inner(a):
+        pass
+    inner.__annotations__ = {'a': int}
+    given(a=infer)(inner)()

--- a/tests/py3/test_lookup.py
+++ b/tests/py3/test_lookup.py
@@ -1,0 +1,288 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2017 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import io
+import sys
+import collections
+
+import pytest
+
+import hypothesis.strategies as st
+from hypothesis import find, given, infer, assume
+from hypothesis.errors import NoExamples, InvalidArgument, ResolutionFailed
+from hypothesis.strategies import from_type
+from hypothesis.searchstrategy import types
+from hypothesis.internal.compat import get_type_hints
+
+typing = pytest.importorskip('typing')
+sentinel = object()
+generics = sorted((t for t in types._global_type_lookup
+                   if isinstance(t, typing.GenericMeta)), key=str)
+
+
+@pytest.mark.parametrize('typ', generics)
+def test_resolve_typing_module(typ):
+    @given(from_type(typ))
+    def inner(ex):
+        if typ in (typing.BinaryIO, typing.TextIO):
+            assert isinstance(ex, io.IOBase)
+        elif typ is typing.Tuple:
+            # isinstance is incompatible with Tuple on early 3.5
+            assert ex == ()
+        elif isinstance(typ, typing._ProtocolMeta):
+            pass
+        else:
+            try:
+                assert isinstance(ex, typ)
+            except TypeError:
+                if sys.version_info[:2] < (3, 6):
+                    pytest.skip()
+                raise
+
+    inner()
+
+
+@pytest.mark.parametrize('typ', [typing.Any, typing.Union])
+def test_does_not_resolve_special_cases(typ):
+    with pytest.raises(InvalidArgument):
+        from_type(typ).example()
+
+
+@pytest.mark.parametrize('typ,instance_of', [
+    (typing.Union[int, str], (int, str)),
+    (typing.Optional[int], (int, type(None))),
+])
+def test_specialised_scalar_types(typ, instance_of):
+    @given(from_type(typ))
+    def inner(ex):
+        assert isinstance(ex, instance_of)
+
+    inner()
+
+
+@pytest.mark.skipif(not hasattr(typing, 'Type'), reason='requires this attr')
+def test_typing_Type_int():
+    assert from_type(typing.Type[int]).example() is int
+
+
+@pytest.mark.skipif(not hasattr(typing, 'Type'), reason='requires this attr')
+def test_typing_Type_Union():
+    @given(from_type(typing.Type[typing.Union[str, list]]))
+    def inner(ex):
+        assert ex in (str, list)
+
+    inner()
+
+
+@pytest.mark.parametrize('typ,coll_type,instance_of', [
+    (typing.Set[int], set, int),
+    (typing.FrozenSet[int], frozenset, int),
+    (typing.Dict[int, int], dict, int),
+    (typing.KeysView[int], type({}.keys()), int),
+    (typing.ValuesView[int], type({}.values()), int),
+    (typing.List[int], list, int),
+    (typing.Tuple[int], tuple, int),
+    (typing.Tuple[int, ...], tuple, int),
+    (typing.Iterator[int], typing.Iterator, int),
+    (typing.Sequence[int], typing.Sequence, int),
+    (typing.Iterable[int], typing.Iterable, int),
+    (typing.Mapping[int, None], typing.Mapping, int),
+    (typing.Container[int], typing.Container, int),
+    (typing.NamedTuple('A_NamedTuple', (('elem', int),)), tuple, int),
+])
+def test_specialised_collection_types(typ, coll_type, instance_of):
+    @given(from_type(typ))
+    def inner(ex):
+        if sys.version_info[:2] >= (3, 6):
+            assume(ex)
+        assert isinstance(ex, coll_type)
+        assert all(isinstance(elem, instance_of) for elem in ex)
+
+    try:
+        inner()
+    except (ResolutionFailed, AssertionError):
+        if sys.version_info[:2] < (3, 6):
+            pytest.skip('Hard-to-reproduce bug (early version of typing?)')
+        raise
+
+
+@pytest.mark.skipif(sys.version_info[:2] < (3, 6), reason='new addition')
+def test_36_specialised_collection_types():
+    @given(from_type(typing.DefaultDict[int, int]))
+    def inner(ex):
+        if sys.version_info[:2] >= (3, 6):
+            assume(ex)
+        assert isinstance(ex, collections.defaultdict)
+        assert all(isinstance(elem, int) for elem in ex)
+        assert all(isinstance(elem, int) for elem in ex.values())
+
+    inner()
+
+
+@pytest.mark.skipif(sys.version_info[:3] <= (3, 5, 1), reason='broken')
+def test_ItemsView():
+    @given(from_type(typing.ItemsView[int, int]))
+    def inner(ex):
+        # See https://github.com/python/typing/issues/177
+        if sys.version_info[:2] >= (3, 6):
+            assume(ex)
+        assert isinstance(ex, type({}.items()))
+        assert all(isinstance(elem, tuple) and len(elem) == 2 for elem in ex)
+        assert all(all(isinstance(e, int) for e in elem) for elem in ex)
+
+    inner()
+
+
+def test_Optional_minimises_to_None():
+    assert find(from_type(typing.Optional[int]), lambda ex: True) is None
+
+
+@pytest.mark.parametrize('n', range(10))
+def test_variable_length_tuples(n):
+    type_ = typing.Tuple[int, ...]
+    try:
+        from_type(type_).filter(lambda ex: len(ex) == n).example()
+    except NoExamples:
+        if sys.version_info[:2] < (3, 6):
+            pytest.skip()
+        raise
+
+
+@pytest.mark.skipif(sys.version_info[:3] <= (3, 5, 1), reason='broken')
+def test_lookup_overrides_defaults():
+    sentinel = object()
+    try:
+        st.register_type_strategy(int, st.just(sentinel))
+
+        @given(from_type(typing.List[int]))
+        def inner_1(ex):
+            assert all(elem is sentinel for elem in ex)
+
+        inner_1()
+    finally:
+        st.register_type_strategy(int, st.integers())
+        st.from_type.__clear_cache()
+
+    @given(from_type(typing.List[int]))
+    def inner_2(ex):
+        assert all(isinstance(elem, int) for elem in ex)
+
+    inner_2()
+
+
+def test_register_generic_typing_strats():
+    # I don't expect anyone to do this, but good to check it works as expected
+    try:
+        # We register sets for the abstract sequence type, which masks subtypes
+        # from supertype resolution but not direct resolution
+        st.register_type_strategy(
+            typing.Sequence,
+            types._global_type_lookup[typing.Set]
+        )
+
+        @given(from_type(typing.Sequence[int]))
+        def inner_1(ex):
+            assert isinstance(ex, set)
+
+        @given(from_type(typing.Container[int]))
+        def inner_2(ex):
+            assert not isinstance(ex, typing.Sequence)
+
+        @given(from_type(typing.List[int]))
+        def inner_3(ex):
+            assert isinstance(ex, list)
+
+        inner_1()
+        inner_2()
+        inner_3()
+    finally:
+        types._global_type_lookup.pop(typing.Sequence)
+        st.from_type.__clear_cache()
+
+
+@pytest.mark.parametrize('typ', [
+    typing.Sequence, typing.Container, typing.Mapping, typing.Reversible,
+    typing.SupportsBytes, typing.SupportsAbs, typing.SupportsComplex,
+    typing.SupportsFloat, typing.SupportsInt, typing.SupportsRound,
+])
+def test_resolves_weird_types(typ):
+    from_type(typ).example()
+
+
+def annotated_func(a: int, b: int=2, *, c: int, d: int=4):
+    return a + b + c + d
+
+
+@pytest.mark.parametrize('thing', [
+    annotated_func,  # Works via typing.get_type_hints
+    typing.NamedTuple('N', [('a', int)]),  # Falls back to inspection
+    int,  # Fails; returns empty dict
+])
+def test_can_get_type_hints(thing):
+    assert isinstance(get_type_hints(thing), dict)
+
+
+def test_force_builds_to_infer_strategies_for_default_args():
+    # By default, leaves args with defaults and minimises to 2+4=6
+    assert find(st.builds(annotated_func), lambda ex: True) == 6
+    # Inferring integers() for args makes it minimise to zero
+    assert find(st.builds(annotated_func, b=infer, d=infer),
+                lambda ex: True) == 0
+
+
+def non_annotated_func(a, b=2, *, c, d=4):
+    pass
+
+
+def test_cannot_pass_infer_as_posarg():
+    with pytest.raises(InvalidArgument):
+        st.builds(annotated_func, infer).example()
+
+
+def test_cannot_force_inference_for_unannotated_arg():
+    with pytest.raises(InvalidArgument):
+        st.builds(non_annotated_func, a=infer, c=st.none()).example()
+    with pytest.raises(InvalidArgument):
+        st.builds(non_annotated_func, a=st.none(), c=infer).example()
+
+
+class UnknownType(object):
+    def __init__(self, arg):
+        pass
+
+
+class UnknownAnnotatedType(object):
+    def __init__(self, arg: int):
+        pass
+
+
+@given(st.from_type(UnknownAnnotatedType))
+def test_builds_for_unknown_annotated_type(ex):
+    assert isinstance(ex, UnknownAnnotatedType)
+
+
+def unknown_annotated_func(a: UnknownType, b=2, *, c: UnknownType, d=4):
+    pass
+
+
+def test_raises_for_arg_with_unresolvable_annotation():
+    with pytest.raises(ResolutionFailed):
+        st.builds(unknown_annotated_func).example()
+    with pytest.raises(ResolutionFailed):
+        st.builds(unknown_annotated_func, a=st.none(), c=infer).example()

--- a/tests/py3/test_lookup.py
+++ b/tests/py3/test_lookup.py
@@ -286,3 +286,16 @@ def test_raises_for_arg_with_unresolvable_annotation():
         st.builds(unknown_annotated_func).example()
     with pytest.raises(ResolutionFailed):
         st.builds(unknown_annotated_func, a=st.none(), c=infer).example()
+
+
+@given(a=infer, b=infer)
+def test_can_use_type_hints(a: int, b: float):
+    assert isinstance(a, int) and isinstance(b, float)
+
+
+def test_error_if_has_unresolvable_hints():
+    @given(a=infer)
+    def inner(a: UnknownType):
+        pass
+    with pytest.raises(InvalidArgument):
+        inner()


### PR DESCRIPTION
Closes #293.  This pull:

- adds a new function `from_type` to look up a strategy that can generate instances of the given type
- upgrades `builds()` to infer missing arguments based on type hints
- upgrades `@given` to infer missing arguments from type hints
- adds a new function `register_type_strategy` to register custom types that can't be automatically derived (based on a known child class or type hints, using `builds`)

It's been a long time coming, but I think I'm done.  (again 😉)