### PR TITLE
Reduce dependency churn

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,10 +1,7 @@
 requirements:
   - requirements/tools.txt
-      updates: all
-      pin: True
   - requirements/test.txt
-      updates: all
-      pin: True
   - requirements/benchmark.txt
-      updates: all
-      pin: True
+updates: all
+pin: True
+schedule: "every day"


### PR DESCRIPTION
A solid majority of our pull requests are simple dependency updates, which is placing undue strain on reviewers and our CI queues - especially when a single package updates several times in one day, as requests and isort have done recently.

Weekly batch updates seem like a good balance - ensuring we have very recent versions without the current churn.