### PR TITLE
More efficient tests for datetimes

### DIFF
--- a/tests/cover/test_datetimes.py
+++ b/tests/cover/test_datetimes.py
@@ -45,11 +45,11 @@ def test_can_find_negative_delta():
 
 
 def test_can_find_on_the_second():
-    minimal(timedeltas(), lambda x: x.seconds == 0)
+    timedeltas().filter(lambda x: x.seconds == 0).example()
 
 
 def test_can_find_off_the_second():
-    minimal(timedeltas(), lambda x: x.seconds != 0)
+    timedeltas().filter(lambda x: x.seconds != 0).example()
 
 
 def test_simplifies_towards_zero_delta():
@@ -122,8 +122,8 @@ def test_can_find_before_the_year_2000():
 
 
 def test_can_find_each_month():
-    for i in hrange(1, 12):
-        minimal(dates(), lambda x: x.month == i)
+    for month in hrange(1, 13):
+        dates().filter(lambda x: x.month == month).example()
 
 
 def test_min_year_is_respected():
@@ -143,7 +143,7 @@ TestStandardDescriptorFeatures_times1 = strategy_test_suite(times())
 
 
 def test_can_find_midnight():
-    minimal(times(), lambda x: x.hour == x.minute == x.second == 0)
+    times().filter(lambda x: x.hour == x.minute == x.second == 0).example()
 
 
 def test_can_find_non_midnight():
@@ -151,11 +151,11 @@ def test_can_find_non_midnight():
 
 
 def test_can_find_on_the_minute():
-    minimal(times(), lambda x: x.second == 0)
+    times().filter(lambda x: x.second == 0).example()
 
 
 def test_can_find_off_the_minute():
-    minimal(times(), lambda x: x.second != 0)
+    times().filter(lambda x: x.second != 0).example()
 
 
 def test_simplifies_towards_midnight():
@@ -164,7 +164,7 @@ def test_simplifies_towards_midnight():
 
 
 def test_can_generate_naive_time():
-    minimal(times(), lambda d: not d.tzinfo)
+    times().filter(lambda d: not d.tzinfo).example()
 
 
 @given(times())

--- a/tests/datetime/test_dates.py
+++ b/tests/datetime/test_dates.py
@@ -35,8 +35,8 @@ def test_can_find_before_the_year_2000():
 
 @checks_deprecated_behaviour
 def test_can_find_each_month():
-    for i in hrange(1, 12):
-        minimal(dates(), lambda x: x.month == i)
+    for month in hrange(1, 13):
+        dates().filter(lambda x: x.month == month).example()
 
 
 @checks_deprecated_behaviour

--- a/tests/datetime/test_datetime.py
+++ b/tests/datetime/test_datetime.py
@@ -44,16 +44,15 @@ def test_can_find_before_the_year_2000():
 
 @checks_deprecated_behaviour
 def test_can_find_each_month():
-    for i in hrange(1, 12):
-        minimal(datetimes(), lambda x: x.month == i)
+    for month in hrange(1, 13):
+        datetimes().filter(lambda x: x.month == month).example()
 
 
 @checks_deprecated_behaviour
 def test_can_find_midnight():
-    minimal(
-        datetimes(),
-        lambda x: (x.hour == 0 and x.minute == 0 and x.second == 0),
-    )
+    datetimes().filter(
+        lambda x: x.hour == x.minute == x.second == 0
+    ).example()
 
 
 @checks_deprecated_behaviour
@@ -63,12 +62,12 @@ def test_can_find_non_midnight():
 
 @checks_deprecated_behaviour
 def test_can_find_off_the_minute():
-    minimal(datetimes(), lambda x: x.second == 0)
+    datetimes().filter(lambda x: x.second != 0).example()
 
 
 @checks_deprecated_behaviour
 def test_can_find_on_the_minute():
-    minimal(datetimes(), lambda x: x.second != 0)
+    datetimes().filter(lambda x: x.second == 0).example()
 
 
 @checks_deprecated_behaviour
@@ -82,7 +81,7 @@ def test_simplifies_towards_midnight():
 
 @checks_deprecated_behaviour
 def test_can_generate_naive_datetime():
-    minimal(datetimes(allow_naive=True), lambda d: not d.tzinfo)
+    datetimes(allow_naive=True).filter(lambda d: d.tzinfo is None).example()
 
 
 @checks_deprecated_behaviour
@@ -93,9 +92,9 @@ def test_can_generate_non_naive_datetime():
 
 @checks_deprecated_behaviour
 def test_can_generate_non_utc():
-    minimal(
-        datetimes(),
-        lambda d: assume(d.tzinfo) and d.tzinfo.zone != u'UTC')
+    datetimes().filter(
+        lambda d: assume(d.tzinfo) and d.tzinfo.zone != u'UTC'
+    ).example()
 
 
 with hs.settings(strict=False):

--- a/tests/datetime/test_times.py
+++ b/tests/datetime/test_times.py
@@ -28,10 +28,7 @@ from hypothesis.extra.datetime import times
 
 @checks_deprecated_behaviour
 def test_can_find_midnight():
-    minimal(
-        times(),
-        lambda x: (x.hour == 0 and x.minute == 0 and x.second == 0),
-    )
+    times().filter(lambda x: x.hour == x.minute == x.second == 0).example()
 
 
 @checks_deprecated_behaviour
@@ -41,12 +38,12 @@ def test_can_find_non_midnight():
 
 @checks_deprecated_behaviour
 def test_can_find_off_the_minute():
-    minimal(times(), lambda x: x.second == 0)
+    times().filter(lambda x: x.second != 0).example()
 
 
 @checks_deprecated_behaviour
 def test_can_find_on_the_minute():
-    minimal(times(), lambda x: x.second != 0)
+    times().filter(lambda x: x.second == 0).example()
 
 
 @checks_deprecated_behaviour
@@ -60,7 +57,7 @@ def test_simplifies_towards_midnight():
 
 @checks_deprecated_behaviour
 def test_can_generate_naive_time():
-    minimal(times(allow_naive=True), lambda d: not d.tzinfo)
+    times(allow_naive=True).filter(lambda d: d.tzinfo is not None).example()
 
 
 @checks_deprecated_behaviour
@@ -71,9 +68,9 @@ def test_can_generate_non_naive_time():
 
 @checks_deprecated_behaviour
 def test_can_generate_non_utc():
-    minimal(
-        times(),
-        lambda d: assume(d.tzinfo) and d.tzinfo.zone != u'UTC')
+    times().filter(
+        lambda d: assume(d.tzinfo) and d.tzinfo.zone != u'UTC'
+    ).example()
 
 
 with hs.settings(strict=False):

--- a/tests/datetime/test_timezones.py
+++ b/tests/datetime/test_timezones.py
@@ -88,8 +88,9 @@ def test_timezone_aware_times_are_timezone_aware(dt):
 
 
 def test_can_generate_non_utc():
-    minimal(times(timezones=timezones()),
-            lambda d: assume(d.tzinfo) and d.tzinfo.zone != u'UTC')
+    times(timezones=timezones()).filter(
+        lambda d: assume(d.tzinfo) and d.tzinfo.zone != u'UTC'
+    ).example()
 
 
 @given(sampled_from(['min_time', 'max_time']), times(timezones=timezones()))


### PR DESCRIPTION
Several tests used `find` or `minimal` without asserting anything about the result, solely to demonstrate that such examples exist.  Using `s.filter(predicate).example()` is much more efficient, and should eliminate a common source of timeouts, especially for pypy.