### PR TITLE
Ensure we can sample from an OrderedDict without a warning

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -22,6 +22,13 @@ You should generally assume that an API is internal unless you have specific
 information to the contrary.
 
 -------------------
+3.11.3 - 2017-06-11
+-------------------
+
+This is a bugfix release: Hypothesis no longer emits a warning if you try to
+use ``sampled_from`` with ``collections.OrderedDict``.  (:issue:`688`)
+
+-------------------
 3.11.2 - 2017-06-10
 -------------------
 

--- a/src/hypothesis/internal/conjecture/utils.py
+++ b/src/hypothesis/internal/conjecture/utils.py
@@ -19,7 +19,7 @@ from __future__ import division, print_function, absolute_import
 
 import enum
 import math
-from collections import Sequence
+from collections import OrderedDict, Sequence
 
 from hypothesis._settings import note_deprecation
 from hypothesis.internal.compat import hbytes, bit_length, int_to_bytes, \
@@ -105,7 +105,7 @@ def centered_integer_range(data, lower, upper, center):
 
 
 def check_sample(values):
-    if not isinstance(values, (Sequence, enum.EnumMeta)):
+    if not isinstance(values, (OrderedDict, Sequence, enum.EnumMeta)):
         note_deprecation(
             ('Cannot sample from %r, not a sequence.  ' % (values,)) +
             'Hypothesis goes to some length to ensure that sampling an '

--- a/src/hypothesis/internal/conjecture/utils.py
+++ b/src/hypothesis/internal/conjecture/utils.py
@@ -19,7 +19,7 @@ from __future__ import division, print_function, absolute_import
 
 import enum
 import math
-from collections import OrderedDict, Sequence
+from collections import Sequence, OrderedDict
 
 from hypothesis._settings import note_deprecation
 from hypothesis.internal.compat import hbytes, bit_length, int_to_bytes, \

--- a/src/hypothesis/version.py
+++ b/src/hypothesis/version.py
@@ -17,5 +17,5 @@
 
 from __future__ import division, print_function, absolute_import
 
-__version_info__ = (3, 11, 2)
+__version_info__ = (3, 11, 3)
 __version__ = '.'.join(map(str, __version_info__))

--- a/tests/cover/test_sampled_from.py
+++ b/tests/cover/test_sampled_from.py
@@ -17,6 +17,7 @@
 
 from __future__ import division, print_function, absolute_import
 
+import collections
 import enum
 
 from hypothesis import given, settings
@@ -25,6 +26,8 @@ from tests.common.utils import fails_with
 from hypothesis.strategies import sampled_from
 
 an_enum = enum.Enum('A', 'a b c')
+
+an_ordereddict = collections.OrderedDict([('a', 1), ('b', 2), ('c', 3)])
 
 
 @given(sampled_from((1, 2)))
@@ -42,6 +45,16 @@ def test_cannot_sample_sets_in_strict_mode():
 def test_can_sample_sets_while_deprecated():
     with settings(strict=False):
         assert sampled_from(set('abc')).example() in 'abc'
+
+
+def test_can_sample_sequence_without_warning():
+    with settings(strict=True):
+        sampled_from([1, 2, 3]).example()
+
+
+def test_can_sample_ordereddict_without_warning():
+    with settings(strict=True):
+        sampled_from(an_ordereddict).example()
 
 
 @given(sampled_from(an_enum))

--- a/tests/cover/test_sampled_from.py
+++ b/tests/cover/test_sampled_from.py
@@ -17,8 +17,8 @@
 
 from __future__ import division, print_function, absolute_import
 
-import collections
 import enum
+import collections
 
 from hypothesis import given, settings
 from hypothesis.errors import HypothesisDeprecationWarning


### PR DESCRIPTION
Fairly simple patch – just extend the list of types we exclude from the warning about un-replayable collections.

Resolves #688.