### PR TITLE
Build wheels on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -76,7 +76,7 @@ install:
   - "%CMD_IN_ENV% python -W setup.py -q bdist_wheel --dist-dir dist"
 
 deploy_script:
-  - ps: "if ($env:APPVEYOR_REPO_TAG -eq $TRUE) { %CMD_IN_ENV% python -m twine upload dist/* }"
+  - ps: if ($env:APPVEYOR_REPO_TAG -eq $TRUE) { %CMD_IN_ENV% python -m twine upload dist/* }
 
 build: false  # Not a C# project, build stuff at the test step instead.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -76,7 +76,7 @@ install:
   - "%CMD_IN_ENV% python -W setup.py -q bdist_wheel --dist-dir dist"
 
 deploy_script:
-  - ps: if ($env:APPVEYOR_REPO_TAG -eq $TRUE) { %CMD_IN_ENV% python -m twine upload dist/* }
+  - ps: "if ($env:APPVEYOR_REPO_TAG -eq $TRUE) { %CMD_IN_ENV% python -m twine upload dist/* }"
 
 build: false  # Not a C# project, build stuff at the test step instead.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,10 @@ environment:
     # See: http://stackoverflow.com/a/13751649/163740
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\scripts\\run_with_env.cmd"
 
+    TWINE_USERNAME: DRMacIver
+    TWINE_PASSWORD:
+      secure: TpmpMHwgS4xxcbbzROle2xyb3i+VPP8cT5ZL4dF/UrA=
+
   matrix:
     - PYTHON: "C:\\Python27"
       PYTHON_VERSION: "2.7.8"
@@ -15,11 +19,19 @@ environment:
       PYTHON_ARCH: "64"
 
     - PYTHON: "C:\\Python34"
-      PYTHON_VERSION: "3.4.1"
+      PYTHON_VERSION: "3.5.3"
       PYTHON_ARCH: "32"
 
     - PYTHON: "C:\\Python34-x64"
-      PYTHON_VERSION: "3.4.1"
+      PYTHON_VERSION: "3.5.3"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python34"
+      PYTHON_VERSION: "3.6.1"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python34-x64"
+      PYTHON_VERSION: "3.6.1"
       PYTHON_ARCH: "64"
 
 branches:
@@ -27,6 +39,9 @@ branches:
     - master
     - /\d+\.\d+\.\d+/
 
+artifacts:
+  - path: 'dist\*.whl'
+    name: wheel
 
 install:
   - ECHO "Filesystem root:"
@@ -47,9 +62,13 @@ install:
   # Check that we have the expected version and architecture for Python
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
-  - "%CMD_IN_ENV% python -m pip.__main__ install --upgrade setuptools pip"
+  - "%CMD_IN_ENV% python -m pip.__main__ install --upgrade setuptools pip wheel twine"
   - "%CMD_IN_ENV% python -m pip.__main__ install setuptools -rrequirements/test.txt"
   - "%CMD_IN_ENV% python -m pip.__main__ install .[all]"
+  - "%CMD_IN_ENV% python -W setup.py -q bdist_wheel --dist-dir dist
+
+deploy_script:
+  - ps: if ($env:APPVEYOR_REPO_TAG -eq $TRUE) { "%CMD_IN_ENV% python -m twine upload dist/* }
 
 build: false  # Not a C# project, build stuff at the test step instead.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -73,10 +73,10 @@ install:
   - "%CMD_IN_ENV% python -m pip.__main__ install --upgrade setuptools pip wheel twine"
   - "%CMD_IN_ENV% python -m pip.__main__ install setuptools -rrequirements/test.txt"
   - "%CMD_IN_ENV% python -m pip.__main__ install .[all]"
-  - "%CMD_IN_ENV% python -W setup.py -q bdist_wheel --dist-dir dist
+  - "%CMD_IN_ENV% python -W setup.py -q bdist_wheel --dist-dir dist"
 
 deploy_script:
-  - ps: if ($env:APPVEYOR_REPO_TAG -eq $TRUE) { "%CMD_IN_ENV% python -m twine upload dist/* }
+  - ps: if ($env:APPVEYOR_REPO_TAG -eq $TRUE) { %CMD_IN_ENV% python -m twine upload dist/* }
 
 build: false  # Not a C# project, build stuff at the test step instead.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,19 +26,19 @@ environment:
       PYTHON_VERSION: "3.4.1"
       PYTHON_ARCH: "64"
 
-    - PYTHON: "C:\\Python34"
+    - PYTHON: "C:\\Python35"
       PYTHON_VERSION: "3.5.3"
       PYTHON_ARCH: "32"
 
-    - PYTHON: "C:\\Python34-x64"
+    - PYTHON: "C:\\Python35-x64"
       PYTHON_VERSION: "3.5.3"
       PYTHON_ARCH: "64"
 
-    - PYTHON: "C:\\Python34"
+    - PYTHON: "C:\\Python36"
       PYTHON_VERSION: "3.6.1"
       PYTHON_ARCH: "32"
 
-    - PYTHON: "C:\\Python34-x64"
+    - PYTHON: "C:\\Python36-x64"
       PYTHON_VERSION: "3.6.1"
       PYTHON_ARCH: "64"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -73,7 +73,7 @@ install:
   - "%CMD_IN_ENV% python -m pip.__main__ install --upgrade setuptools pip wheel twine"
   - "%CMD_IN_ENV% python -m pip.__main__ install setuptools -rrequirements/test.txt"
   - "%CMD_IN_ENV% python -m pip.__main__ install .[all]"
-  - "%CMD_IN_ENV% python -W setup.py -q bdist_wheel --dist-dir dist"
+  - "%CMD_IN_ENV% python -W setup.py bdist_wheel --dist-dir dist"
 
 deploy_script:
   - ps: if ($env:APPVEYOR_REPO_TAG -eq $TRUE) { %CMD_IN_ENV% python -m twine upload dist/* }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,11 +11,19 @@ environment:
 
   matrix:
     - PYTHON: "C:\\Python27"
-      PYTHON_VERSION: "2.7.8"
+      PYTHON_VERSION: "2.7.13"
       PYTHON_ARCH: "32"
 
     - PYTHON: "C:\\Python27-x64"
-      PYTHON_VERSION: "2.7.8"
+      PYTHON_VERSION: "2.7.13"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python34"
+      PYTHON_VERSION: "3.4.1"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python34-x64"
+      PYTHON_VERSION: "3.4.1"
       PYTHON_ARCH: "64"
 
     - PYTHON: "C:\\Python34"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,8 @@ environment:
 branches:
   only:
     - master
+    - /\d+\.\d+\.\d+/
+
 
 install:
   - ECHO "Filesystem root:"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,14 +18,6 @@ environment:
       PYTHON_VERSION: "2.7.13"
       PYTHON_ARCH: "64"
 
-    - PYTHON: "C:\\Python34"
-      PYTHON_VERSION: "3.4.1"
-      PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python34-x64"
-      PYTHON_VERSION: "3.4.1"
-      PYTHON_ARCH: "64"
-
     - PYTHON: "C:\\Python35"
       PYTHON_VERSION: "3.5.3"
       PYTHON_ARCH: "32"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -73,7 +73,7 @@ install:
   - "%CMD_IN_ENV% python -m pip.__main__ install --upgrade setuptools pip wheel twine"
   - "%CMD_IN_ENV% python -m pip.__main__ install setuptools -rrequirements/test.txt"
   - "%CMD_IN_ENV% python -m pip.__main__ install .[all]"
-  - "%CMD_IN_ENV% python -W setup.py bdist_wheel --dist-dir dist"
+  - "%CMD_IN_ENV% python setup.py bdist_wheel --dist-dir dist"
 
 deploy_script:
   - ps: if ($env:APPVEYOR_REPO_TAG -eq $TRUE) { %CMD_IN_ENV% python -m twine upload dist/* }

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -22,6 +22,13 @@ You should generally assume that an API is internal unless you have specific
 information to the contrary.
 
 -------------------
+3.11.6 - 2017-06-19
+-------------------
+
+This release involves no functionality changes, but is the first to ship wheels
+as well as an sdist.
+
+-------------------
 3.11.5 - 2017-06-18
 -------------------
 

--- a/src/hypothesis/version.py
+++ b/src/hypothesis/version.py
@@ -17,5 +17,5 @@
 
 from __future__ import division, print_function, absolute_import
 
-__version_info__ = (3, 11, 5)
+__version_info__ = (3, 11, 6)
 __version__ = '.'.join(map(str, __version_info__))


### PR DESCRIPTION
This improves our deploy process by having appveyor build wheels and upload them to pypi when it's building a tag.

Context: In the future I will want us to start shipping C extensions. This is unfortunate for Windows users who may not have a C compiler installed, so we're going to need to build wheels for them.

This is the first stage of that. We're still Python source only, but we can at least start building wheels. I doubt this will improve anyone's lives much, but it will at least make install from pypi very fractionally faster.

This also:

* makes appveyor build on tags as well as on master.
* updates and expands the range of versions we test on appveyor.