### PR TITLE
Fix wheel building

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -68,7 +68,7 @@ install:
   - "%CMD_IN_ENV% python setup.py bdist_wheel --dist-dir dist"
 
 deploy_script:
-  - ps: if ($env:APPVEYOR_REPO_TAG -eq $TRUE) { %CMD_IN_ENV% python -m twine upload dist/* }
+  - ps: "if ($env:APPVEYOR_REPO_TAG -eq $TRUE) { python -m twine upload dist/* }"
 
 build: false  # Not a C# project, build stuff at the test step instead.
 


### PR DESCRIPTION
[Apparently CMD_IN_ENV doesn't work in powershell](https://ci.appveyor.com/project/DRMacIver/hypothesis-python/build/1.0.1287/job/bl1cum9h4t143fpj#L1960).

This is somewhat speculative but should work. I have hand cranked wheels out for the release that failed, so nothing is currently on fire. I guess we'll find out if this works properly next release?

(The major concern here is I'm not really sure that Python  is on the path there, but I think it should be)