### PR TITLE
Don't run doctests until #711 is resolved

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -270,3 +270,6 @@ clean:
 
 documentation: $(SPHINX_BUILD) docs/*.rst
 	PYTHONPATH=src $(SPHINX_BUILD) -W -b html -d docs/_build/doctrees docs docs/_build/html
+
+doctest: $(SPHINX_BUILD) docs/*.rst
+	PYTHONPATH=src $(SPHINX_BUILD) -W -b doctest -d docs/_build/doctrees docs docs/_build/html

--- a/Makefile
+++ b/Makefile
@@ -270,4 +270,3 @@ clean:
 
 documentation: $(SPHINX_BUILD) docs/*.rst
 	PYTHONPATH=src $(SPHINX_BUILD) -W -b html -d docs/_build/doctrees docs docs/_build/html
-	PYTHONPATH=src $(SPHINX_BUILD) -W -b doctest -d docs/_build/doctrees docs docs/_build/html


### PR DESCRIPTION
See #710 for details. Basically right now doctests force a large amount of manual work that should be completely automatable on almost every change I make to data generation, or the documentation thereof.

I care about being able to actually do work on Hypothesis more than I care about having our examples be perfectly up to date (especially for things that are really just changes in which random path you happened to take), so until we come up with a fully automated solution for updating these examples, I don't want this in the build.

I am more than happy to revert this when we figure out a solution to #711, and am quite sad to remove it, but until we come up with a proper solution I think this is the best way forward.