### PR TITLE
Only build Appveyor pushes to master, not PR branches

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,7 +37,7 @@ environment:
 branches:
   only:
     - master
-    - /\d+\.\d+\.\d+/
+    - /^\d+\.\d+\.\d+$/
 
 artifacts:
   - path: 'dist\*.whl'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,6 +34,9 @@ environment:
       PYTHON_VERSION: "3.6.1"
       PYTHON_ARCH: "64"
 
+# This matches both branches and tags (no, I don't know why either).
+# We need a match both for pushes to master, and our release tags which
+# trigger wheel builds.
 branches:
   only:
     - master


### PR DESCRIPTION
This just disables Appveyor builds on every branch that isn’t master – we don’t actually have any official version branches (unless they’re hiding?), but this regex was doing builds for pushes to pyup branches, which have the form

```
pyup-update-dependency-x.y.z-to-a.b.c
```

and I think the version number was matching the regex.

No effect on Hypothesis itself, just a benefit for maintainers that we’ll have slightly less contention for Appveyor builds.