### PR TITLE
Fix and document misuse of find() to check for examples; fix various typos

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -22,6 +22,14 @@ You should generally assume that an API is internal unless you have specific
 information to the contrary.
 
 -------------------
+3.14.1 - 2017-07-31
+-------------------
+
+This is a documentation update, recommending ``strategy.filter(predicate).example()``
+as a more efficient way to check that such an example exists than
+:func:`find(strategy, predicate) <hypothesis.find>` and fixing a few typos.
+
+-------------------
 3.14.0 - 2017-07-23
 -------------------
 

--- a/docs/details.rst
+++ b/docs/details.rst
@@ -452,6 +452,12 @@ some predicate.  This is generally useful for exploring custom strategies
 defined with :func:`@composite <hypothesis.strategies.composite>`, or
 experimenting with conditions for filtering data.
 
+To get an arbitary example value matching a predicate from the strategy, or
+raise :class:`~hypothesis.errors.NoExamples` if no such value exists, use
+``strategy.filter(predicate).example()``.  This avoids the expensive shrinking
+logic used by :func:`~hypothesis.find` to return the *minimal* value matching
+the predicate.
+
 .. autofunction:: hypothesis.find
 
 .. doctest::

--- a/src/hypothesis/internal/conjecture/utils.py
+++ b/src/hypothesis/internal/conjecture/utils.py
@@ -188,8 +188,7 @@ def biased_coin(data, p):
                 # Every other partition is truthy, so the result is true
                 result = True
             elif truthy == 0:
-                # Every other partition is falsey, so the result is true
-                result = True
+                # Every other partition is falsey, so the result is false
                 result = False
             elif i <= 1:
                 # We special case so that zero is always false and 1 is always

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -974,7 +974,7 @@ def decimals(min_value=None, max_value=None,
 
     - A finite rational number, between ``min_value`` and ``max_value``.
     - Not a Number, if ``allow_nan`` is True.  None means "allow NaN, unless
-      ``min__value`` and ``max_value`` are not None".
+      ``min_value`` and ``max_value`` are not None".
     - Positive or negative infinity, if ``max_value`` and ``min_value``
       respectively are None, and ``allow_infinity`` is not False.  None means
       "allow infinity, unless excluded by the min and max values".

--- a/src/hypothesis/version.py
+++ b/src/hypothesis/version.py
@@ -17,5 +17,5 @@
 
 from __future__ import division, print_function, absolute_import
 
-__version_info__ = (3, 14, 0)
+__version_info__ = (3, 14, 1)
 __version__ = '.'.join(map(str, __version_info__))

--- a/tests/cover/test_arbitrary_data.py
+++ b/tests/cover/test_arbitrary_data.py
@@ -86,7 +86,7 @@ def test_given_twice_is_same():
 
 def test_errors_when_used_in_find():
     with raises(InvalidArgument):
-        find(st.data(), lambda x: x.draw(st.booleans()))
+        find(st.data(), lambda _: True)
 
 
 @pytest.mark.parametrize('f', [

--- a/tests/cover/test_database_usage.py
+++ b/tests/cover/test_database_usage.py
@@ -27,7 +27,7 @@ def test_saves_incremental_steps_in_database():
     key = b"a database key"
     database = SQLiteExampleDatabase(':memory:')
     find(
-        st.binary(min_size=10), lambda x: any(x),
+        st.binary(min_size=10), any,
         settings=settings(database=database), database_key=key
     )
     assert len(set(database.fetch(key))) > 1

--- a/tests/cover/test_direct_strategies.py
+++ b/tests/cover/test_direct_strategies.py
@@ -233,10 +233,9 @@ def test_float_can_find_max_value_inf():
 
 
 def test_float_can_find_min_value_inf():
-    find(ds.floats(), lambda x: x < 0 and math.isinf(x))
-    find(
-        ds.floats(min_value=float('-inf'), max_value=0.0),
-        lambda x: math.isinf(x))
+    ds.floats().filter(lambda x: x < 0 and math.isinf(x)).example()
+    ds.floats(min_value=float('-inf'), max_value=0.0).filter(
+        lambda x: math.isinf(x)).example()
 
 
 def test_can_find_none_list():
@@ -252,7 +251,8 @@ def test_decimals():
 
 
 def test_non_float_decimal():
-    find(ds.decimals(), lambda d: float_to_decimal(float(d)) != d)
+    ds.decimals(allow_nan=False).filter(
+        lambda d: float_to_decimal(float(d)) != d).example()
 
 
 def test_produces_dictionaries_of_at_least_minimum_size():

--- a/tests/cover/test_sharing.py
+++ b/tests/cover/test_sharing.py
@@ -35,28 +35,24 @@ def test_different_instances_with_the_same_key_are_shared(a, b):
 
 
 def test_different_instances_are_not_shared():
-    find(
-        st.tuples(st.shared(st.integers()), st.shared(st.integers())),
-        lambda x: x[0] != x[1]
-    )
+    st.tuples(
+        st.shared(st.integers()),
+        st.shared(st.integers())
+    ).filter(lambda x: x[0] != x[1]).example()
 
 
 def test_different_keys_are_not_shared():
-    find(
-        st.tuples(
-            st.shared(st.integers(), key=1),
-            st.shared(st.integers(), key=2)),
-        lambda x: x[0] != x[1]
-    )
+    st.tuples(
+        st.shared(st.integers(), key=1),
+        st.shared(st.integers(), key=2)
+    ).filter(lambda x: x[0] != x[1]).example()
 
 
 def test_keys_and_default_are_not_shared():
-    find(
-        st.tuples(
-            st.shared(st.integers(), key=1),
-            st.shared(st.integers())),
-        lambda x: x[0] != x[1]
-    )
+    st.tuples(
+        st.shared(st.integers(), key=1),
+        st.shared(st.integers())
+    ).filter(lambda x: x[0] != x[1]).example()
 
 
 def test_can_simplify_shared_lists():

--- a/tests/cover/test_simple_characters.py
+++ b/tests/cover/test_simple_characters.py
@@ -22,7 +22,7 @@ import unicodedata
 import pytest
 
 from hypothesis import find
-from hypothesis.errors import NoSuchExample, InvalidArgument
+from hypothesis.errors import NoExamples, InvalidArgument
 from hypothesis.strategies import characters
 
 
@@ -53,21 +53,22 @@ def test_when_nothing_could_be_produced():
 def test_characters_of_specific_groups():
     st = characters(whitelist_categories=('Lu', 'Nd'))
 
-    find(st, lambda c: unicodedata.category(c) == 'Lu')
-    find(st, lambda c: unicodedata.category(c) == 'Nd')
+    st.filter(lambda c: unicodedata.category(c) == 'Lu').example()
+    st.filter(lambda c: unicodedata.category(c) == 'Nd').example()
 
-    with pytest.raises(NoSuchExample):
-        find(st, lambda c: unicodedata.category(c) not in ('Lu', 'Nd'))
+    with pytest.raises(NoExamples):
+        st.filter(lambda c: unicodedata.category(c) not in ('Lu', 'Nd')
+                  ).example()
 
 
 def test_exclude_characters_of_specific_groups():
     st = characters(blacklist_categories=('Lu', 'Nd'))
 
-    find(st, lambda c: unicodedata.category(c) != 'Lu')
-    find(st, lambda c: unicodedata.category(c) != 'Nd')
+    st.filter(lambda c: unicodedata.category(c) != 'Lu').example()
+    st.filter(lambda c: unicodedata.category(c) != 'Nd').example()
 
-    with pytest.raises(NoSuchExample):
-        find(st, lambda c: unicodedata.category(c) in ('Lu', 'Nd'))
+    with pytest.raises(NoExamples):
+        st.filter(lambda c: unicodedata.category(c) in ('Lu', 'Nd')).example()
 
 
 def test_find_one():
@@ -78,10 +79,10 @@ def test_find_one():
 def test_find_something_rare():
     st = characters(whitelist_categories=['Zs'], min_codepoint=12288)
 
-    find(st, lambda c: unicodedata.category(c) == 'Zs')
+    st.filter(lambda c: unicodedata.category(c) == 'Zs').example()
 
-    with pytest.raises(NoSuchExample):
-        find(st, lambda c: unicodedata.category(c) != 'Zs')
+    with pytest.raises(NoExamples):
+        st.filter(lambda c: unicodedata.category(c) != 'Zs').example()
 
 
 def test_blacklisted_characters():
@@ -91,5 +92,5 @@ def test_blacklisted_characters():
 
     assert '1' == find(st, lambda c: True)
 
-    with pytest.raises(NoSuchExample):
-        find(st, lambda c: c in bad_chars)
+    with pytest.raises(NoExamples):
+        st.filter(lambda c: c in bad_chars).example()


### PR DESCRIPTION
Closes #734, fixes typos I discovered in grepping through out tests and fixes #724.  Review should be straightforward.

(With better timing we could have released version 3.14.1 on 22/7...  ah well.)