### PR TITLE
Better management of the example database

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -22,6 +22,26 @@ You should generally assume that an API is internal unless you have specific
 information to the contrary.
 
 -------------------
+3.17.0 - 2017-08-07
+-------------------
+
+This release documents :ref:`the previously undocumented phases feature <phases>`",
+making it part of the official public API. It also updates how the example
+database is used. Principally:
+
+* A ``Phases.reuse`` argument will now correctly control whether examples
+  from the database are run (it previously did exactly the wrong thing and
+  controlled whether examples would be *saved*).
+* Hypothesis will no longer try to rerun *all* previously failing examples.
+  Instead it will replay the smallest previously failing example and a
+  selection of other examples that are likely to trigger any other bugs that
+  will found. This prevents a previous failure from dominating your tests
+  unnecessarily.
+* As a result of the previous change, Hypothesis will be slower about clearing
+  out old examples from the database that are no longer failing (because it can
+  only clear out ones that it actually runs).
+
+-------------------
 3.16.1 - 2017-08-07
 -------------------
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -43,7 +43,36 @@ Available settings
 .. autoclass:: settings
     :members: max_examples, max_iterations, min_satisfying_examples,
         max_shrinks, timeout, strict, database_file, stateful_step_count,
-        database, perform_health_check, suppress_health_check, buffer_size
+        database, perform_health_check, suppress_health_check, buffer_size,
+        phases
+
+.. _phases:
+
+~~~~~~~~~~~~~~~~~~~~~
+Controlling What Runs
+~~~~~~~~~~~~~~~~~~~~~
+
+Hypothesis divides tests into four logically distinct phases:
+
+1. Running explicit examples :ref:`provided with the @example decorator <providing-explicit-examples>`.
+2. Rerunning a selection of previously failing examples to reproduce a previously seen error
+3. Generating new examples.
+4. Attempting to shrink an example found in phases 2 or 3 to a more manageable
+   one (explicit examples cannot be shrunk).
+
+The phases setting provides you fine grained control over which of these run,
+with each phase corresponding to a value on the Phase enum:
+
+1. ``Phase.explicit`` controls whether explicit examples are run.
+2. ``Phase.reuse`` controls whether previous examples will be reused.
+3. ``Phase.generate`` controls whether new examples will be generated.
+4. ``Phase.shrink`` controls whether examples will be shrunk.
+
+The phases argument accepts a collection with any subset of these. e.g.
+``settings(phases=[Phase.generate, Phase.shrink])`` will generate new examples
+and shrink them, but will not run explicit examples or reuse previous failures,
+while ``settings(phases=[Phase.explicit])`` will only run the explicit
+examples.
 
 .. _verbose-output:
 

--- a/src/hypothesis/_settings.py
+++ b/src/hypothesis/_settings.py
@@ -576,7 +576,10 @@ def _validate_phases(phases):
 settings.define_setting(
     'phases',
     default=tuple(Phase),
-    description='Control which phases should be run',
+    description=(
+        'Control which phases should be run. ' +
+        'See :ref:`the full documentation for more details <phases>`'
+    ),
     validator=_validate_phases,
 )
 

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -560,10 +560,6 @@ class StateForActualGivenExecution(object):
             return
         if runner.last_data.status == Status.INTERESTING:
             self.falsifying_example = runner.last_data.buffer
-            if self.settings.database is not None:
-                self.settings.database.save(
-                    database_key, self.falsifying_example
-                )
         else:
             if timed_out:
                 note_deprecation((

--- a/src/hypothesis/internal/compat.py
+++ b/src/hypothesis/internal/compat.py
@@ -503,8 +503,12 @@ else:
 if PY2:
     def floor(x):
         return int(math.floor(x))
+
+    def ceil(x):
+        return int(math.ceil(x))
 else:
     floor = math.floor
+    ceil = math.ceil
 
 
 if PY2:

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -17,7 +17,6 @@
 
 from __future__ import division, print_function, absolute_import
 
-import math
 import time
 from enum import Enum
 from random import Random, getrandbits
@@ -26,8 +25,8 @@ from weakref import WeakKeyDictionary
 from hypothesis import settings as Settings
 from hypothesis import Phase
 from hypothesis.reporting import debug_report
-from hypothesis.internal.compat import EMPTY_BYTES, Counter, hbytes, \
-    hrange, text_type, bytes_from_list, to_bytes_sequence, \
+from hypothesis.internal.compat import EMPTY_BYTES, Counter, ceil, \
+    hbytes, hrange, text_type, bytes_from_list, to_bytes_sequence, \
     unicode_safe_repr
 from hypothesis.internal.conjecture.data import MAX_DEPTH, Status, \
     StopTest, ConjectureData
@@ -449,7 +448,7 @@ class ConjectureRunner(object):
                 key=sort_key
             )
 
-            desired_size = max(2, math.ceil(0.1 * self.settings.max_examples))
+            desired_size = max(2, ceil(0.1 * self.settings.max_examples))
 
             if desired_size < len(corpus):
                 new_corpus = [corpus[0], corpus[-1]]

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -172,8 +172,7 @@ class ConjectureRunner(object):
     def save_buffer(self, buffer):
         if (
             self.settings.database is not None and
-            self.database_key is not None and
-            Phase.reuse in self.settings.phases
+            self.database_key is not None
         ):
             self.settings.database.save(
                 self.database_key, hbytes(buffer)
@@ -433,7 +432,8 @@ class ConjectureRunner(object):
 
         if (
             self.settings.database is not None and
-            self.database_key is not None
+            self.database_key is not None and
+            Phase.reuse in self.settings.phases
         ):
             corpus = sorted(
                 self.settings.database.fetch(self.database_key),

--- a/src/hypothesis/version.py
+++ b/src/hypothesis/version.py
@@ -17,5 +17,5 @@
 
 from __future__ import division, print_function, absolute_import
 
-__version_info__ = (3, 16, 1)
+__version_info__ = (3, 17, 0)
 __version__ = '.'.join(map(str, __version_info__))

--- a/tests/cover/test_database_usage.py
+++ b/tests/cover/test_database_usage.py
@@ -72,7 +72,7 @@ def test_clears_out_database_as_things_get_boring():
         assert False
 
 
-def test_trashes_all_invalid_examples():
+def test_trashes_invalid_examples():
     key = b"a database key"
     database = SQLiteExampleDatabase(':memory:')
     finicky = False
@@ -91,10 +91,11 @@ def test_trashes_all_invalid_examples():
         except Unsatisfiable:
             pass
     stuff()
-    assert len(set(database.fetch(key))) > 1
+    original = len(set(database.fetch(key)))
+    assert original > 1
     finicky = True
     stuff()
-    assert len(set(database.fetch(key))) == 0
+    assert len(set(database.fetch(key))) < original
 
 
 def test_respects_max_examples_in_database_usage():

--- a/tests/cover/test_database_usage.py
+++ b/tests/cover/test_database_usage.py
@@ -17,10 +17,13 @@
 
 from __future__ import division, print_function, absolute_import
 
+import pytest
+
 import hypothesis.strategies as st
-from hypothesis import find, assume, settings
+from hypothesis import Verbosity, find, given, assume, settings
 from hypothesis.errors import NoSuchExample, Unsatisfiable
-from hypothesis.database import SQLiteExampleDatabase
+from hypothesis.database import SQLiteExampleDatabase, \
+    InMemoryExampleDatabase
 from hypothesis.internal.compat import hbytes
 
 
@@ -119,3 +122,51 @@ def test_respects_max_examples_in_database_usage():
     counter[0] = 0
     stuff()
     assert counter == [10]
+
+
+def test_clears_out_everything_smaller_than_the_interesting_example():
+    in_clearing = False
+    target = [None]
+
+    for _ in range(5):
+        # We retry the test run a few times to get a large enough initial
+        # set of examples that we're not going to explore them all in the
+        # initial run.
+        cache = {}
+        seen = set()
+
+        database = InMemoryExampleDatabase()
+
+        @settings(
+            database=database, verbosity=Verbosity.quiet, max_examples=100)
+        @given(st.binary(min_size=10, max_size=10))
+        def test(i):
+            if not in_clearing:
+                if len([b for b in i if b > 1]) >= 8:
+                    assert cache.setdefault(i, len(cache) % 10 != 9)
+            elif len(seen) <= 20:
+                seen.add(i)
+            else:
+                if target[0] is None:
+                    remainder = sorted([s for s in saved if s not in seen])
+                    target[0] = remainder[len(remainder) // 2]
+                assert i in seen or i < target[0]
+
+        with pytest.raises(AssertionError):
+            test()
+
+        saved, = database.data.values()
+        if len(saved) > 30:
+            break
+    else:
+        assert False, 'Never generated enough examples while shrinking'
+
+    in_clearing = True
+
+    with pytest.raises(AssertionError):
+        test()
+
+    saved, = database.data.values()
+
+    for s in saved:
+        assert s >= target[0]


### PR DESCRIPTION
This pull request contains three distinct changes, so I could split it up if you want, but they're all quite closely related and really what it contains is the one change I wanted to make and the two that got in the way of it:

1. The principle thing it does is make some major changes to how we replay examples from the database. I'll go into that below.
2. In the course of doing that I realised that the way that we handled `Phase.reuse` was completely backwards and fixed that.
3. In the course of doing *that* I realised that the phases setting was completely undocumented, so I fixed that too.

The main idea of the database changes is that currently we have a problem that saved examples can overwhelm your testing. If you e.g have more than 200 shrinks of a previous failure (which can happen relatively easily when shrinking to boundary values), your entire tests will be replaying the (very similar) shrunk examples!

This changes the logic so that way only ever spend 10% of our testing budget on replay, or a minimum of two if the test budget is very small. We try the smallest saved example (which is our previous shrink), our largest saved example (which is usually the starting point for the previous failure), and a random selection of the other examples.

This preserves the invariant that Hypothesis always starts from the last failure, and gives us a decent selection of other bugs that might have been found during the shrinking process, but leaves us room to actually run a sensible number of tests.

This required two other changes:

1. We now discard *all* valid but uninteresting examples when we read them from the database. This means we have similar "incremental garbage collection" to what we had before, because we're only retrying a subset.
2. When shrinking we first try any previously saved examples that are smaller than the current example and delete them if they're not interesting. This is useful because a) It preserves the invariant that the smallest example in the DB is always a previous failure and b) Hey, who knows, we might get a good shrink out of it.