### PR TITLE
Raise MAX_DEPTH to fix Issue #751

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -22,6 +22,17 @@ You should generally assume that an API is internal unless you have specific
 information to the contrary.
 
 -------------------
+3.14.1 - 2017-08-01
+-------------------
+
+This raises the maximum depth at which Hypothesis starts cutting off data
+generation to a more reasonable value which it is harder to hit by accident.
+
+This resolves (:issue:`751`), in which some examples which previously worked
+would start timing out, but it will also likely improve the data generation
+quality for complex data types.
+
+-------------------
 3.14.0 - 2017-07-23
 -------------------
 

--- a/src/hypothesis/internal/conjecture/data.py
+++ b/src/hypothesis/internal/conjecture/data.py
@@ -45,7 +45,7 @@ class StopTest(BaseException):
 global_test_counter = 0
 
 
-MAX_DEPTH = 50
+MAX_DEPTH = 100
 
 
 class ConjectureData(object):

--- a/src/hypothesis/version.py
+++ b/src/hypothesis/version.py
@@ -17,5 +17,5 @@
 
 from __future__ import division, print_function, absolute_import
 
-__version_info__ = (3, 14, 0)
+__version_info__ = (3, 14, 1)
 __version__ = '.'.join(map(str, __version_info__))

--- a/tests/cover/test_regressions.py
+++ b/tests/cover/test_regressions.py
@@ -1,0 +1,40 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2017 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+from hypothesis import strategies as st
+from hypothesis import given
+
+
+def strat():
+    return st.builds(dict, one=strat_one())
+
+
+@st.composite
+def strat_one(draw):
+    return draw(st.builds(dict, val=st.builds(dict, two=strat_two())))
+
+
+@st.composite
+def strat_two(draw):
+    return draw(st.builds(dict, some_text=st.text(min_size=1)))
+
+
+@given(strat())
+def test_issue751(v):
+    pass

--- a/tests/cover/test_regressions.py
+++ b/tests/cover/test_regressions.py
@@ -17,8 +17,10 @@
 
 from __future__ import division, print_function, absolute_import
 
+import pytest
+
 from hypothesis import strategies as st
-from hypothesis import given
+from hypothesis import Verbosity, given, settings
 
 
 def strat():
@@ -38,3 +40,18 @@ def strat_two(draw):
 @given(strat())
 def test_issue751(v):
     pass
+
+
+def test_can_find_non_zero():
+    # This future proofs against a possible failure mode where the depth bound
+    # is triggered but we've fixed the behaviour of min_size so that it can
+    # handle that: We want to make sure that we're really not depth bounding
+    # the text in the leaf nodes.
+
+    @settings(verbosity=Verbosity.quiet)
+    @given(strat())
+    def test(v):
+        assert '0' in v['one']['val']['two']['some_text']
+
+    with pytest.raises(AssertionError):
+        test()


### PR DESCRIPTION
As per title, fixes #751 

What's going on here:

In implementing the recursion support I basically picked an arbitrary number as the greatest depth it was likely to be "reasonable" to hit. Apparently I underestimated how much @mithrandi liked using `@composite`, which ends up wrapping things a lot and pushing up the depth, making it hit that `MAX_DEPTH`.

Compounding that is the fact that `min_size=1` does not currently play well with the max depth constraints, which is why it was producing an overflow in that case. I have a branch which fixes that, but it's more work and in that case we would *still* want to avoid the depth bounding case (which is what the additional test in `test_regressions` is for).

It might be good to do some better error handling in the case where the minimal example hits the depth bound, but I'm not sure what the best thing to do here is, and until then I think it's reasonable to just keep raising the bound until people stop hitting problems with it.