### PR TITLE
Change data.write() to modify the data stream

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -22,7 +22,7 @@ You should generally assume that an API is internal unless you have specific
 information to the contrary.
 
 -------------------
-3.16.1 - 2017-08-05
+3.16.1 - 2017-08-07
 -------------------
 
 This release makes an implementation change to how Hypothesis handles certain

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -22,6 +22,18 @@ You should generally assume that an API is internal unless you have specific
 information to the contrary.
 
 -------------------
+3.16.1 - 2017-08-05
+-------------------
+
+This release makes an implementation change to how Hypothesis handles certain
+internal constructs.
+
+The main effect you should see is improvement to the behaviour and performance
+of collection types, especially ones with a ``min_size`` parameter. Many cases
+that would previously fail due to being unable to generate enough valid
+examples will now succeed, and other cases should run slightly faster.
+
+-------------------
 3.16.0 - 2017-08-04
 -------------------
 

--- a/src/hypothesis/database.py
+++ b/src/hypothesis/database.py
@@ -23,7 +23,7 @@ import binascii
 import threading
 from contextlib import contextmanager
 
-from hypothesis.internal.compat import FileNotFoundError, sha1, \
+from hypothesis.internal.compat import FileNotFoundError, sha1, hbytes, \
     b64decode, b64encode
 
 sqlite3 = None
@@ -100,10 +100,10 @@ class InMemoryExampleDatabase(ExampleDatabase):
             yield v
 
     def save(self, key, value):
-        self.data.setdefault(key, set()).add(value)
+        self.data.setdefault(key, set()).add(hbytes(value))
 
     def delete(self, key, value):
-        self.data.get(key, set()).discard(value)
+        self.data.get(key, set()).discard(hbytes(value))
 
     def close(self):
         pass
@@ -239,7 +239,7 @@ class DirectoryBasedExampleDatabase(ExampleDatabase):
         for path in os.listdir(kp):
             try:
                 with open(os.path.join(kp, path), 'rb') as i:
-                    yield i.read()
+                    yield hbytes(i.read())
             except FileNotFoundError:
                 pass
 

--- a/src/hypothesis/internal/compat.py
+++ b/src/hypothesis/internal/compat.py
@@ -27,7 +27,7 @@ import codecs
 import platform
 import importlib
 from gzip import GzipFile
-from base64 import b64decode, b64encode
+from base64 import b64encode
 from decimal import Context, Decimal, Inexact
 from hashlib import sha1
 from collections import namedtuple
@@ -505,3 +505,11 @@ if PY2:
         return int(math.floor(x))
 else:
     floor = math.floor
+
+
+if PY2:
+    def b64decode(s):
+        from base64 import b64decode as base
+        return hbytes(base(s))
+else:
+    from base64 import b64decode

--- a/src/hypothesis/internal/conjecture/data.py
+++ b/src/hypothesis/internal/conjecture/data.py
@@ -52,6 +52,7 @@ class ConjectureData(object):
 
     @classmethod
     def for_buffer(self, buffer):
+        bytes = hbytes(buffer)
         return ConjectureData(
             max_length=len(buffer),
             draw_bytes=lambda data, n, distribution:

--- a/src/hypothesis/internal/conjecture/data.py
+++ b/src/hypothesis/internal/conjecture/data.py
@@ -52,7 +52,7 @@ class ConjectureData(object):
 
     @classmethod
     def for_buffer(self, buffer):
-        bytes = hbytes(buffer)
+        buffer = hbytes(buffer)
         return ConjectureData(
             max_length=len(buffer),
             draw_bytes=lambda data, n, distribution:

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -395,11 +395,6 @@ class ConjectureRunner(object):
 
         for i, b in enumerate(result):
             assert isinstance(b, int)
-            if node_index in self.forced:
-                if isinstance(result, hbytes):
-                    result = bytearray(result)
-                b = self.forced[node_index]
-                result[i] = b
             try:
                 new_node_index = node[b]
             except KeyError:

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -385,10 +385,8 @@ class ConjectureRunner(object):
             node = self.tree[node_index]
             try:
                 node_index = node[data.buffer[i]]
+                assert node_index not in self.dead
                 node = self.tree[node_index]
-                if node_index in self.dead:
-                    data.__hit_novelty = True
-                    return result
             except KeyError:
                 data.__hit_novelty = True
                 return result

--- a/src/hypothesis/internal/conjecture/utils.py
+++ b/src/hypothesis/internal/conjecture/utils.py
@@ -210,10 +210,6 @@ def biased_coin(data, p):
     return result
 
 
-def write(data, string):
-    data.write(string)
-
-
 class Sampler(object):
     """Sampler based on "Succinct Sampling from Discrete Distributions" by
     Bringmann and Larsen. In general it has some advantages and disadvantages

--- a/src/hypothesis/searchstrategy/collections.py
+++ b/src/hypothesis/searchstrategy/collections.py
@@ -20,7 +20,6 @@ from __future__ import division, print_function, absolute_import
 from collections import namedtuple
 
 import hypothesis.internal.conjecture.utils as cu
-from hypothesis.control import assume
 from hypothesis.internal.compat import OrderedDict, hbytes
 from hypothesis.searchstrategy.strategies import SearchStrategy, \
     MappedSearchStrategy, one_of_strategies

--- a/src/hypothesis/strategytests.py
+++ b/src/hypothesis/strategytests.py
@@ -42,7 +42,7 @@ def strategy_test_suite(
     settings = Settings(
         database=None,
         max_examples=max_examples,
-        max_iterations=max_examples * 2,
+        max_iterations=max_examples * 10,
         min_satisfying_examples=2,
     )
     random = random or Random()

--- a/src/hypothesis/version.py
+++ b/src/hypothesis/version.py
@@ -17,5 +17,5 @@
 
 from __future__ import division, print_function, absolute_import
 
-__version_info__ = (3, 16, 0)
+__version_info__ = (3, 16, 1)
 __version__ = '.'.join(map(str, __version_info__))

--- a/tests/common/debug.py
+++ b/tests/common/debug.py
@@ -56,3 +56,27 @@ def minimal(
         settings=settings,
         random=random,
     )
+
+
+def find_any(
+        definition, condition=None,
+        settings=None, random=None
+):
+    settings = Settings(
+        settings,
+        max_examples=1000,
+        max_iterations=1000,
+        max_shrinks=0000,
+        database=None,
+    )
+
+    if condition is None:
+        def condition(x):
+            return True
+
+    return find(
+        definition,
+        condition,
+        settings=settings,
+        random=random,
+    )

--- a/tests/cover/test_database_usage.py
+++ b/tests/cover/test_database_usage.py
@@ -79,7 +79,10 @@ def test_trashes_all_invalid_examples():
             find(
                 st.binary(min_size=100),
                 lambda x: assume(not finicky) and has_a_non_zero_byte(x),
-                settings=settings(database=database, timeout=5, strict=False),
+                settings=settings(
+                    database=database, strict=False,
+                    max_shrinks=10,
+                ),
                 database_key=key
             )
         except Unsatisfiable:

--- a/tests/nocover/test_large_examples.py
+++ b/tests/nocover/test_large_examples.py
@@ -1,0 +1,24 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2017 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+from tests.common.debug import find_any
+import hypothesis.strategies as st
+
+def test_can_generate_large_lists_with_min_size():
+    find_any(st.lists(st.integers(), min_size=400))

--- a/tests/nocover/test_large_examples.py
+++ b/tests/nocover/test_large_examples.py
@@ -17,8 +17,9 @@
 
 from __future__ import division, print_function, absolute_import
 
-from tests.common.debug import find_any
 import hypothesis.strategies as st
+from tests.common.debug import find_any
+
 
 def test_can_generate_large_lists_with_min_size():
     find_any(st.lists(st.integers(), min_size=400))


### PR DESCRIPTION
This is extracted from some upcoming work of mine that I realised made sense on its own.

It fixes the issue pointed out in https://github.com/HypothesisWorks/hypothesis-python/issues/751#issuecomment-319698767 that a large `min_size` on collections is still somewhat problematic. It will loop infinitely if it's still not reached `min_size` by the time it's forced to draw only zeroes. It also fixes #724 because I was in the area.

The key idea of it is to change write so that it actually modifies the output data rather than relying on the right data being there to draw. This has a few knock on changes to the engine (`rewrite_for_novelty` now needs to detect when this has happened and fast forward accordingly, tree usage changes a bit, and sometimes we can expect to get a shrink and actually end up with something larger).

This also modifies the existing collections code to take advantage of the new stronger invariants provided by `biased_coin`, which allows it to better take advantage of these changes.