### PR TITLE
Refactor charmap caching [Fixes #767]

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -165,6 +165,7 @@ their individual contributions.
 * `mulkieran <https://www.github.com/mulkieran>`_
 * `Nicholas Chammas <https://www.github.com/nchammas>`_
 * `Richard Boulton <https://www.github.com/rboulton>`_ (`richard@tartarus.org <mailto:richard@tartarus.org>`_)
+* `Sam Hames <https://www.github.com/SamHames>`_
 * `Saul Shanabrook <https://www.github.com/saulshanabrook>`_ (`s.shanabrook@gmail.com <mailto:s.shanabrook@gmail.com>`_)
 * `Tariq Khokhar <https://www.github.com/tkb>`_ (`tariq@khokhar.net <mailto:tariq@khokhar.net>`_)
 * `Will Hall <https://www.github.com/wrhall>`_ (`wrsh07@gmail.com <mailto:wrsh07@gmail.com>`_)

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+Hypothesis now transparently handles problems with an internal unicode cache,
+including file truncation or read-only filesystems (:issue:`767`).
+Thanks to Sam Hames for the patch.

--- a/src/hypothesis/internal/compat.py
+++ b/src/hypothesis/internal/compat.py
@@ -26,7 +26,6 @@ import math
 import codecs
 import platform
 import importlib
-from gzip import GzipFile
 from base64 import b64encode
 from decimal import Context, Decimal, Inexact
 from hashlib import sha1

--- a/tests/cover/test_charmap.py
+++ b/tests/cover/test_charmap.py
@@ -138,8 +138,17 @@ def test_exception_in_write_does_not_lead_to_broken_charmap(monkeypatch):
     cm._charmap = None
     monkeypatch.setattr(os.path, 'exists', lambda p: False)
     monkeypatch.setattr(os, 'rename', broken)
-    with pytest.raises(ValueError):
-        cm.charmap()
 
-    with pytest.raises(ValueError):
-        cm.charmap()
+    cm.charmap()
+    cm.charmap()
+
+
+def test_regenerate_broken_charmap_file():
+    cm.charmap()
+    file_loc = cm.charmap_file()
+
+    with open(file_loc, 'wb'):
+        pass
+
+    cm._charmap = None
+    cm.charmap()

--- a/tests/cover/test_charmap.py
+++ b/tests/cover/test_charmap.py
@@ -21,8 +21,6 @@ import os
 import sys
 import unicodedata
 
-import pytest
-
 import hypothesis.strategies as st
 import hypothesis.internal.charmap as cm
 from hypothesis import given, assume


### PR DESCRIPTION
If the cached pickle of the charmap data was corrupted in any way
initialisation would fail.

Now if a cache file cannot be found or read, it will be
regenerated. The logic is also slightly refactored, so we do not
need to write a file to disk, only to immediately read it back.

This will also help #768 by not depending on a file being written
to disk.