### PR TITLE
Fix bug where mocks can be used as test runners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ _build
 deploy_key
 .pypirc
 secrets.tar
+htmlcov

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -170,6 +170,7 @@ their individual contributions.
 * `Adam Sven Johnson <https://www.github.com/pkqk>`_
 * `Alex Stapleton <https://www.github.com/public>`_
 * `Alex Willmer <https://github.com/moreati>`_ (`alex@moreati.org.uk <mailto:alex@moreati.org.uk>`_)
+* `Ben Peterson <https://github.com/killthrush>`_ (`killthrush@hotmail.com <mailto:killthrush@hotmail.com>`_)
 * `Charles O'Farrell <https://www.github.com/charleso>`_
 * `Chris Down  <https://chrisdown.name>`_
 * `Christopher Martin <https://www.github.com/chris-martin>`_ (`ch.martin@gmail.com <mailto:ch.martin@gmail.com>`_)

--- a/Makefile
+++ b/Makefile
@@ -122,40 +122,40 @@ check-shellcheck: $(SHELLCHECK)
 	shellcheck scripts/*.sh
 
 check-py27: $(PY27) $(TOX)
-	$(TOX) -e py27-full
+	$(TOX) --recreate -e py27-full
 
 check-py273: $(PY273) $(TOX)
-	$(TOX) -e oldpy27
+	$(TOX) --recreate -e oldpy27
 
 check-py27-typing: $(PY27) $(TOX)
-	$(TOX) -e py27typing
+	$(TOX) --recreate -e py27typing
 
 check-py33: $(PY33) $(TOX)
-	$(TOX) -e py33-full
+	$(TOX) --recreate -e py33-full
 
 check-py34: $(PY34) $(TOX)
-	$(TOX) -e py34-full
+	$(TOX) --recreate -e py34-full
 
 check-py35: $(PY35) $(TOX)
-	$(TOX) -e py35-full
+	$(TOX) --recreate -e py35-full
 
 check-py36: $(BEST_PY3) $(TOX)
-	$(TOX) -e py36-full
+	$(TOX) --recreate -e py36-full
 
 check-pypy: $(PYPY) $(TOX)
-	$(TOX) -e pypy-full
+	$(TOX) --recreate -e pypy-full
 
 check-nose: $(TOX)
-	$(TOX) -e nose
+	$(TOX) --recreate -e nose
 
 check-pytest30: $(TOX)
-	$(TOX) -e pytest30
+	$(TOX) --recreate -e pytest30
 
 check-pytest28: $(TOX)
-	$(TOX) -e pytest28
+	$(TOX) --recreate -e pytest28
 
 check-quality: $(TOX)
-	$(TOX) -e quality
+	$(TOX) --recreate -e quality
 
 check-ancient-pip: $(PY273)
 	scripts/check-ancient-pip.sh $(PY273)
@@ -164,41 +164,41 @@ check-ancient-pip: $(PY273)
 check-pytest: check-pytest28 check-pytest30
 
 check-faker070: $(TOX)
-	$(TOX) -e faker070
+	$(TOX) --recreate -e faker070
 
 check-faker071: $(TOX)
-	$(TOX) -e faker071
+	$(TOX) --recreate -e faker071
 
 check-django18: $(TOX)
-	$(TOX) -e django18
+	$(TOX) --recreate -e django18
 
 check-django110: $(TOX)
-	$(TOX) -e django110
+	$(TOX) --recreate -e django110
 
 check-django111: $(TOX)
-	$(TOX) -e django111
+	$(TOX) --recreate -e django111
 
 check-django: check-django18 check-django110 check-django111
 
 check-examples2: $(TOX) $(PY27)
-	$(TOX) -e examples2
+	$(TOX) --recreate -e examples2
 
 check-examples3: $(TOX)
-	$(TOX) -e examples3
+	$(TOX) --recreate -e examples3
 
 check-coverage: $(TOX)
-	$(TOX) -e coverage
+	$(TOX) --recreate -e coverage
 
 check-unicode: $(TOX) $(PY27)
-	$(TOX) -e unicode
+	$(TOX) --recreate -e unicode
 
 check-noformat: check-coverage check-py26 check-py27 check-py33 check-py34 check-py35 check-pypy check-django check-pytest
 
 check: check-format check-noformat
 
 check-fast: lint $(PYPY) $(PY36) $(TOX)
-	$(TOX) -e pypy-brief
-	$(TOX) -e py36-prettyquick
+	$(TOX) --recreate -e pypy-brief
+	$(TOX) --recreate -e py36-prettyquick
 
 check-rst: $(RSTLINT) $(FLAKE8)
 	$(RSTLINT) *.rst

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,13 @@
+RELEASE_TYPE: patch
+Release to fix a bug where mocks can be used as test runners under certain
+conditions. Specifically, if a mock is injected into a test via pytest
+fixtures or patch decorators, and that mock is the first argument in the
+list, hypothesis will think it represents self and turns the mock
+into a test runner.  If this happens, the affected test always passes
+because the mock is executed instead of the test body. Sometimes, it
+will also fail health checks.
+
+Related to a section of issue 198 and fixes issue 491
+(a partial duplicate of 198).
+
+Thanks to Ben Peterson for this bug fix.

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -1,3 +1,4 @@
 flaky
 pytest
 pytest-xdist
+mock

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,6 +7,9 @@
 apipkg==1.4               # via execnet
 execnet==1.4.1            # via pytest-xdist
 flaky==3.4.0
+mock==2.0.0
+pbr==3.1.1                # via mock
 py==1.4.34                # via pytest
 pytest-xdist==1.18.2
 pytest==3.2.1
+six==1.10.0               # via mock

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -43,7 +43,7 @@ from hypothesis.internal.compat import str_to_bytes, get_type_hints, \
 from hypothesis.utils.conventions import infer
 from hypothesis.internal.escalation import \
     escalate_hypothesis_internal_error
-from hypothesis.internal.reflection import nicerepr, arg_string, \
+from hypothesis.internal.reflection import is_mock, nicerepr, arg_string, \
     impersonate, function_digest, fully_qualified_name, \
     define_function_signature, convert_positional_arguments, \
     get_pretty_function_description
@@ -426,6 +426,12 @@ def process_arguments_to_given(
         selfy = kwargs.get(argspec.args[0])
     elif arguments:
         selfy = arguments[0]
+
+    # Ensure that we don't mistake mocks for self here.
+    # This can cause the mock to be used as the test runner.
+    if is_mock(selfy):
+        selfy = None
+
     test_runner = new_style_executor(selfy)
 
     arguments = tuple(arguments)

--- a/src/hypothesis/internal/reflection.py
+++ b/src/hypothesis/internal/reflection.py
@@ -23,6 +23,7 @@ from __future__ import division, print_function, absolute_import
 
 import re
 import ast
+import uuid
 import types
 import hashlib
 import inspect
@@ -43,6 +44,21 @@ def fully_qualified_name(f):
         return f.__module__ + '.' + qualname(f)
     else:
         return qualname(f)
+
+
+def is_mock(obj):
+    """Determine if the given argument is a mock type.
+
+    We want to be able to detect these when dealing with various test
+    args. As they are sneaky and can look like almost anything else,
+    we'll check this by looking for random attributes.  This is more
+    robust than looking for types.
+
+    """
+    if obj is None:
+        return False
+    random_attributes = [uuid.uuid4()] * 10
+    return all([getattr(obj, str(attr), None) for attr in random_attributes])
 
 
 def function_digest(function):

--- a/src/hypothesis/internal/reflection.py
+++ b/src/hypothesis/internal/reflection.py
@@ -55,10 +55,10 @@ def is_mock(obj):
     robust than looking for types.
 
     """
-    if obj is None:
-        return False
-    random_attributes = [uuid.uuid4()] * 10
-    return all([getattr(obj, str(attr), None) for attr in random_attributes])
+    for _ in range(10):
+        if not hasattr(obj, str(uuid.uuid4())):
+            return False
+    return True
 
 
 def function_digest(function):

--- a/tests/cover/test_reflection.py
+++ b/tests/cover/test_reflection.py
@@ -569,6 +569,8 @@ def test_is_mock_with_negative_cases():
     assert not is_mock(is_mock)
     assert not is_mock(BittySnowman())
     assert not is_mock('foobar')
+    assert not is_mock(Mock(spec=BittySnowman))
+    assert not is_mock(MagicMock(spec=BittySnowman))
 
 
 def test_is_mock_with_positive_cases():

--- a/tests/cover/test_reflection.py
+++ b/tests/cover/test_reflection.py
@@ -20,11 +20,10 @@ from __future__ import division, print_function, absolute_import
 import sys
 from copy import deepcopy
 from functools import partial
-from unittest.mock import Mock, MagicMock, NonCallableMock, \
-    NonCallableMagicMock
 
 import pytest
 
+from mock import Mock, MagicMock, NonCallableMock, NonCallableMagicMock
 from tests.common.utils import raises
 from hypothesis.internal.compat import PY3, FullArgSpec, getfullargspec
 from hypothesis.internal.reflection import is_mock, proxies, arg_string, \

--- a/tests/cover/test_reflection.py
+++ b/tests/cover/test_reflection.py
@@ -20,12 +20,14 @@ from __future__ import division, print_function, absolute_import
 import sys
 from copy import deepcopy
 from functools import partial
+from unittest.mock import Mock, MagicMock, NonCallableMock, \
+    NonCallableMagicMock
 
 import pytest
 
 from tests.common.utils import raises
 from hypothesis.internal.compat import PY3, FullArgSpec, getfullargspec
-from hypothesis.internal.reflection import proxies, arg_string, \
+from hypothesis.internal.reflection import is_mock, proxies, arg_string, \
     unbind_method, eval_directory, function_digest, fully_qualified_name, \
     source_exec_as_module, convert_keyword_arguments, \
     define_function_signature, convert_positional_arguments, \
@@ -556,9 +558,22 @@ def test_does_not_put_eval_directory_on_path():
     assert eval_directory() not in sys.path
 
 
-def varargs(*args, **kwargs):
-    pass
-
-
 def test_kwargs_appear_in_arg_string():
+    def varargs(*args, **kwargs):
+        pass
     assert 'x=1' in arg_string(varargs, (), {'x': 1})
+
+
+def test_is_mock_with_negative_cases():
+    assert not is_mock(None)
+    assert not is_mock(1234)
+    assert not is_mock(is_mock)
+    assert not is_mock(BittySnowman())
+    assert not is_mock('foobar')
+
+
+def test_is_mock_with_positive_cases():
+    assert is_mock(Mock())
+    assert is_mock(MagicMock())
+    assert is_mock(NonCallableMock())
+    assert is_mock(NonCallableMagicMock())

--- a/tests/cover/test_regressions.py
+++ b/tests/cover/test_regressions.py
@@ -55,3 +55,26 @@ def test_can_find_non_zero():
 
     with pytest.raises(AssertionError):
         test()
+
+
+def test_mock_injection():
+    """Ensure that it's possible for mechanisms like `pytest.fixture` and
+    `patch` to inject mocks into hypothesis test functions without side
+    effects.
+
+    (covers https://github.com/HypothesisWorks/hypothesis-
+    python/issues/491)
+
+    """
+    from mock import Mock
+
+    class Bar():
+        pass
+
+    @given(inp=st.integers())
+    def test_foo_spec(bar, inp):
+        pass
+
+    test_foo_spec(Bar())
+    test_foo_spec(Mock(Bar))
+    test_foo_spec(Mock())

--- a/tests/pytest/test_fixtures.py
+++ b/tests/pytest/test_fixtures.py
@@ -19,7 +19,7 @@ from __future__ import division, print_function, absolute_import
 
 import pytest
 
-from mock import Mock, MagicMock, create_autospec
+from mock import Mock, create_autospec
 from hypothesis import given, example
 from tests.common.utils import fails
 from hypothesis.strategies import integers
@@ -67,9 +67,10 @@ def test_can_mix_fixture_example_and_keyword_strategy(xs, infinity):
 @fails
 @given(integers())
 def test_can_inject_mock_via_fixture(mock_fixture, xs):
-    """A negative test is better for this one - this condition uncovers a bug whereby
-    the mock fixture is executed instead of the test body and always succeeds.
-    If this test fails, then we know we've run the test body instead of the mock.
+    """A negative test is better for this one - this condition uncovers a bug
+    whereby the mock fixture is executed instead of the test body and always
+    succeeds. If this test fails, then we know we've run the test body instead
+    of the mock.
     """
     assert False
 

--- a/tests/pytest/test_fixtures.py
+++ b/tests/pytest/test_fixtures.py
@@ -17,15 +17,39 @@
 
 from __future__ import division, print_function, absolute_import
 
+from unittest.mock import Mock, MagicMock, NonCallableMock, \
+    NonCallableMagicMock
+
 import pytest
 
 from hypothesis import given, example
+from tests.common.utils import fails
 from hypothesis.strategies import integers
 
 
 @pytest.fixture
 def infinity():
     return float('inf')
+
+
+@pytest.fixture
+def m_fixture():
+    return Mock()
+
+
+@pytest.fixture
+def mm_fixture():
+    return MagicMock()
+
+
+@pytest.fixture
+def ncmm_fixture():
+    return NonCallableMagicMock()
+
+
+@pytest.fixture
+def ncm_fixture():
+    return NonCallableMock()
 
 
 @given(integers())
@@ -44,3 +68,27 @@ def test_can_mix_fixture_and_keyword_strategy(xs, infinity):
 @given(xs=integers())
 def test_can_mix_fixture_example_and_keyword_strategy(xs, infinity):
     assert xs <= infinity
+
+
+@fails
+@given(integers())
+def test_can_inject_mock_via_fixture(m_fixture, x):
+    assert False
+
+
+@fails
+@given(integers())
+def test_can_inject_magicmock_via_fixture(mm_fixture, x):
+    assert False
+
+
+@fails
+@given(integers())
+def test_can_inject_nc_mock_via_fixture(ncm_fixture, x):
+    assert False
+
+
+@fails
+@given(integers())
+def test_can_inject_nc_magicmock_via_fixture(ncmm_fixture, x):
+    assert False

--- a/tests/pytest/test_fixtures.py
+++ b/tests/pytest/test_fixtures.py
@@ -17,11 +17,9 @@
 
 from __future__ import division, print_function, absolute_import
 
-from unittest.mock import Mock, MagicMock, NonCallableMock, \
-    NonCallableMagicMock
-
 import pytest
 
+from mock import Mock, MagicMock, NonCallableMock, NonCallableMagicMock
 from hypothesis import given, example
 from tests.common.utils import fails
 from hypothesis.strategies import integers


### PR DESCRIPTION
Fix bug where mocks can be used as test runners under certain
conditions. Specifically, if a mock is injected into a test via pytest
fixtures or patch decorators, and that mock is the first argument in the
list, hypothesis will think it represents self and turns the mock
into a test runner.  If this happens, the affected test always passes
because the mock is executed instead of the test body.

Specifics:
- Add a function to check for mocks by looking for random attributes
  that would be EXTREMELY unlikely to occur in an object that isn't a
  mock.
- Add a check in  to determine if the argument we think is
   self is really a mock.  If that's the case, don't use it.