### PR TITLE
Handle sets with few elements better.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -22,6 +22,15 @@ You should generally assume that an API is internal unless you have specific
 information to the contrary.
 
 -------------------
+3.18.1 - 2017-08-14
+-------------------
+
+This is a bug fix release to fix :issue:`780`, where
+:func:`~hypothesis.strategies.sets` and similar would trigger health check
+errors if their element strategy could only produce one element (e.g.
+if it was :func:`~hypothesis.strategies.just`).
+
+-------------------
 3.18.0 - 2017-08-13
 -------------------
 

--- a/src/hypothesis/internal/conjecture/utils.py
+++ b/src/hypothesis/internal/conjecture/utils.py
@@ -294,6 +294,7 @@ class many(object):
         self.count = 0
         self.rejections = 0
         self.drawn = False
+        self.force_stop = False
 
     def more(self):
         """Should I draw another element to add to the collection?"""
@@ -304,6 +305,8 @@ class many(object):
 
         if self.min_size == self.max_size:
             should_continue = self.count < self.min_size
+        elif self.force_stop:
+            should_continue = False
         else:
             if self.count < self.min_size:
                 p_continue = 1.0
@@ -326,5 +329,8 @@ class many(object):
         assert self.count > 0
         self.count -= 1
         self.rejections += 1
-        if self.rejections > self.count:
-            self.data.mark_invalid()
+        if self.rejections > 2 * self.count:
+            if self.count < self.min_size:
+                self.data.mark_invalid()
+            else:
+                self.force_stop = True

--- a/src/hypothesis/version.py
+++ b/src/hypothesis/version.py
@@ -17,5 +17,5 @@
 
 from __future__ import division, print_function, absolute_import
 
-__version_info__ = (3, 18, 0)
+__version_info__ = (3, 18, 1)
 __version__ = '.'.join(map(str, __version_info__))

--- a/tests/cover/test_simple_collections.py
+++ b/tests/cover/test_simple_collections.py
@@ -25,8 +25,9 @@ from flaky import flaky
 
 from hypothesis import find, given, settings
 from tests.common.debug import minimal
-from hypothesis.strategies import sets, text, lists, builds, tuples, \
-    booleans, integers, frozensets, dictionaries, fixed_dictionaries
+from hypothesis.strategies import none, sets, text, lists, builds, \
+    tuples, booleans, integers, frozensets, dictionaries, \
+    fixed_dictionaries
 from hypothesis.internal.compat import OrderedDict
 
 
@@ -253,3 +254,11 @@ def test_can_draw_empty_list_from_unsatisfiable_strategy():
 
 def test_can_draw_empty_set_from_unsatisfiable_strategy():
     assert sets(integers().filter(lambda s: False)).example() == set()
+
+
+small_set = sets(none())
+
+
+@given(lists(small_set, min_size=10))
+def test_small_sized_sets(x):
+    pass


### PR DESCRIPTION
This changes the implementation of `many()` so that when we've rejected too many elements we just stop drawing instead of marking the data as invalid (unless doing so would produce too small a result). It also relaxes the threshold at which it stops slightly.

Fixes #780