### PR TITLE
Zero forced bytes before permuting examples

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,8 @@
+RELEASE_TYPE: patch
+
+This release should improve the performance of some tests which
+experienced a slow down as a result of the 3.13.0 release.
+
+Tests most likely to benefit from this are ones that make extensive
+use of `min_size` parameters, but others may see some improvement
+as well.

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -534,6 +534,15 @@ class ConjectureRunner(object):
                     # (now with more zeros) and try again.
                     overdrawn = zero_bound_queue.pop()
                     buffer = bytearray(overdrawn.buffer)
+
+                    # These will have values written to them that are different
+                    # from what's in them anyway, so the value there doesn't
+                    # really "count" for distributional purposes, and if we
+                    # leave them in then they can cause the fraction of non
+                    # zero bytes to increase on redraw instead of decrease.
+                    for i in overdrawn.forced_indices:
+                        buffer[i] = 0
+
                     self.random.shuffle(buffer)
                     buffer = hbytes(buffer)
 


### PR DESCRIPTION
This is a rather niche patch. It serves two purposes:

* Helping some of the performance problems @mithrandi has been having since 3.13.0 (on his experiments he reports that it makes things better but still not as good as they were previously)
* To serve as a trial run of #787 

The idea here is that bytes that we explicitly wrote don't really "count" for the purposes of the permutation step: They're going to get inserted into the stream in the appropriate place anyway, so we don't really want to spread them out. This is especially true because it can result in the number of non-zero bytes increasing in this step, which leads to problems.

Sadly I have no tests for this - it's a relatively subtle change that shouldn't actually affect behaviour much (watch famous last words as everything breaks... but I'm reasonably confident).