### PR TITLE
Improved validation for integers() bounds

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This is a bugfix release for `~hypothesis.strategies.integers`.
+Previously the strategy would hit an internal assertion if passed non-integer
+bounds for ``min_value`` and ``max_value`` that had no integers between them.
+The strategy now raises InvalidArgument instead.

--- a/src/hypothesis/internal/compat.py
+++ b/src/hypothesis/internal/compat.py
@@ -501,11 +501,18 @@ else:
 
 
 if PY2:
+    # Under Python 2, math.floor and math.ceil return floats, which cannot
+    # represent large integers - eg `float(2**53) == float(2**53 + 1)`.
+    # We therefore implement them entirely in (long) integer operations.
     def floor(x):
-        return int(math.floor(x))
+        if int(x) != x and x < 0:
+            return int(x) - 1
+        return int(x)
 
     def ceil(x):
-        return int(math.ceil(x))
+        if int(x) != x and x > 0:
+            return int(x) + 1
+        return int(x)
 else:
     floor = math.floor
     ceil = math.ceil

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -29,8 +29,8 @@ from hypothesis.errors import InvalidArgument, ResolutionFailed
 from hypothesis.control import assume
 from hypothesis._settings import note_deprecation
 from hypothesis.searchstrategy import SearchStrategy
-from hypothesis.internal.compat import hrange, text_type, integer_types, \
-    get_type_hints, getfullargspec, implements_iterator
+from hypothesis.internal.compat import ceil, floor, hrange, text_type, \
+    integer_types, get_type_hints, getfullargspec, implements_iterator
 from hypothesis.internal.floats import is_negative, float_to_int, \
     int_to_float, count_between_floats
 from hypothesis.utils.conventions import infer, not_set
@@ -205,17 +205,13 @@ def integers(min_value=None, max_value=None):
     from hypothesis.searchstrategy.numbers import IntegersFromStrategy, \
         BoundedIntStrategy, WideRangeIntStrategy
 
-    min_int_value = None
-    if min_value is not None:
-        min_int_value = int(min_value)
-        if min_int_value != min_value and min_value > 0:
-            min_int_value += 1
+    min_int_value = None if min_value is None else ceil(min_value)
+    max_int_value = None if max_value is None else floor(max_value)
 
-    max_int_value = None
-    if max_value is not None:
-        max_int_value = int(max_value)
-        if max_int_value != max_value and max_value < 0:
-            max_int_value -= 1
+    if min_int_value is not None and max_int_value is not None and \
+            min_int_value > max_int_value:
+        raise InvalidArgument('No integers between min_value=%r and '
+                              'max_value=%r' % (min_value, max_value))
 
     if min_int_value is None:
         if max_int_value is None:

--- a/tests/cover/test_direct_strategies.py
+++ b/tests/cover/test_direct_strategies.py
@@ -58,6 +58,7 @@ def fn_ktest(*fnkwargs):
 @fn_ktest(
     (ds.integers, {'min_value': float('nan')}),
     (ds.integers, {'min_value': 2, 'max_value': 1}),
+    (ds.integers, {'min_value': 0.1, 'max_value': 0.2}),
     (ds.decimals, {'min_value': float('nan')}),
     (ds.decimals, {'min_value': 2, 'max_value': 1}),
     (ds.decimals, {'max_value': '-snan'}),
@@ -109,6 +110,7 @@ def test_validates_keyword_arguments(fn, kwargs):
     (ds.integers, {'min_value': 11, 'max_value': 100}),
     (ds.integers, {'max_value': 0}),
     (ds.integers, {'min_value': decimal.Decimal('1.5')}),
+    (ds.integers, {'min_value': -1.5, 'max_value': -0.5}),
     (ds.decimals, {'min_value': 1.0, 'max_value': 1.5}),
     (ds.decimals, {'min_value': '1.0', 'max_value': '1.5'}),
     (ds.decimals, {'min_value': decimal.Decimal('1.5')}),

--- a/tests/nocover/test_compat.py
+++ b/tests/nocover/test_compat.py
@@ -24,8 +24,9 @@ import pytest
 
 from hypothesis import strategies as st
 from hypothesis import given
-from hypothesis.internal.compat import FullArgSpec, hrange, qualname, \
-    int_to_bytes, getfullargspec, int_from_bytes
+from hypothesis.internal.compat import FullArgSpec, ceil, floor, hrange, \
+    qualname, int_to_bytes, integer_types, getfullargspec, \
+    int_from_bytes
 
 
 def test_small_hrange():
@@ -115,3 +116,22 @@ def test_inspection_compat():
                     reason='inspect.FullArgSpec only exists under Python 3')
 def test_inspection_result_compat():
     assert FullArgSpec is inspect.FullArgSpec
+
+
+@given(st.fractions())
+def test_ceil(x):
+    """The compat ceil function always has the Python 3 semantics.
+
+    Under Python 2, math.ceil returns a float, which cannot represent large
+    integers - for example, `float(2**53) == float(2**53 + 1)` - and this
+    is obviously incorrect for unlimited-precision integer operations.
+
+    """
+    assert isinstance(ceil(x), integer_types)
+    assert x <= ceil(x) < x + 1
+
+
+@given(st.fractions())
+def test_floor(x):
+    assert isinstance(floor(x), integer_types)
+    assert x - 1 < floor(x) <= x


### PR DESCRIPTION
Extracted from #777.  Turns an assertion into an InvalidArgument error, and adds a test to make sure it doesn't come back.