### PR TITLE
Upstream hypothesis-regex 3: Tokyo Drift

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -190,6 +190,7 @@ their individual contributions.
 * `Markus Unterwaditzer <http://github.com/untitaker/>`_ (`markus@unterwaditzer.net <mailto:markus@unterwaditzer.net>`_)
 * `Matt Bachmann <https://www.github.com/bachmann1234>`_ (`bachmann.matt@gmail.com <mailto:bachmann.matt@gmail.com>`_)
 * `Max Nordlund <https://www.github.com/maxnordlund>`_ (`max.nordlund@gmail.com <mailto:max.nordlund@gmail.com>`_)
+* `Maxim Kulkin <https://www.github.com/maximkulkin>`_ (`maxim.kulkin@gmail.com <mailto:maxim.kulkin@gmail.com>`_)
 * `mulkieran <https://www.github.com/mulkieran>`_
 * `Nicholas Chammas <https://www.github.com/nchammas>`_
 * `Richard Boulton <https://www.github.com/rboulton>`_ (`richard@tartarus.org <mailto:richard@tartarus.org>`_)

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,8 @@
+RELEASE_TYPE: minor
+
+This release adds the :func:`~hypothesis.strategies.from_regex` strategy,
+which generates strings that contain a match of a regular expression.
+
+Thanks to Maxim Kulkin for creating the
+`hypothesis-regex <https://github.com/maximkulkin/hypothesis-regex>`_
+package and then merging it upstream! (:issue:`662`)

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -5,4 +5,4 @@ which generates strings that contain a match of a regular expression.
 
 Thanks to Maxim Kulkin for creating the
 `hypothesis-regex <https://github.com/maximkulkin/hypothesis-regex>`_
-package and then merging it upstream! (:issue:`662`)
+package and then helping to upstream it! (:issue:`662`)

--- a/docs/strategies.rst
+++ b/docs/strategies.rst
@@ -8,9 +8,8 @@ the list!  The only inclusion criterion right now is that if it's a Python
 library then it should be available on pypi.
 
 * `hs-dbus-signature <https://github.com/stratis-storage/hs-dbus-signature>`_ - strategy to generate arbitrary D-Bus signatures
-* `hypothesis-regex <https://github.com/maximkulkin/hypothesis-regex>`_ - strategy
-  to generate strings that match given regular expression (merged into Hypothesis as
-  the :func:`~hypothesis.strategies.strings_matching_regex` strategy).
+* `hypothesis-regex <https://github.com/maximkulkin/hypothesis-regex>`_ -
+  merged into Hypothesis as the :func:`~hypothesis.strategies.from_regex` strategy.*
 * `lollipop-hypothesis <https://github.com/maximkulkin/lollipop-hypothesis>`_ -
   strategy to generate data based on
   `Lollipop <https://github.com/maximkulkin/lollipop>`_ schema definitions.

--- a/docs/strategies.rst
+++ b/docs/strategies.rst
@@ -9,7 +9,8 @@ library then it should be available on pypi.
 
 * `hs-dbus-signature <https://github.com/stratis-storage/hs-dbus-signature>`_ - strategy to generate arbitrary D-Bus signatures
 * `hypothesis-regex <https://github.com/maximkulkin/hypothesis-regex>`_ - strategy
-  to generate strings that match given regular expression.
+  to generate strings that match given regular expression (merged into Hypothesis as
+  the :func:`~hypothesis.strategies.strings_matching_regex` strategy).
 * `lollipop-hypothesis <https://github.com/maximkulkin/lollipop-hypothesis>`_ -
   strategy to generate data based on
   `Lollipop <https://github.com/maximkulkin/lollipop>`_ schema definitions.

--- a/src/hypothesis/internal/compat.py
+++ b/src/hypothesis/internal/compat.py
@@ -107,6 +107,9 @@ def quiet_raise(exc):
     def zero_byte_sequence(n):
         return bytes(n)
 
+    def int_to_byte(i):
+        return bytes([i])
+
     import struct
 
     struct_pack = struct.pack
@@ -158,6 +161,8 @@ else:
         if i:
             raise OverflowError('int too big to convert')
         return hbytes(result)
+
+    int_to_byte = chr
 
     def bytes_from_list(ls):
         return hbytes(bytearray(ls))

--- a/src/hypothesis/internal/escalation.py
+++ b/src/hypothesis/internal/escalation.py
@@ -27,6 +27,7 @@ FILE_CACHE = {}
 
 
 def is_hypothesis_file(filepath):
+    return False
     try:
         return FILE_CACHE[filepath]
     except KeyError:

--- a/src/hypothesis/internal/escalation.py
+++ b/src/hypothesis/internal/escalation.py
@@ -27,7 +27,6 @@ FILE_CACHE = {}
 
 
 def is_hypothesis_file(filepath):
-    return False
     try:
         return FILE_CACHE[filepath]
     except KeyError:

--- a/src/hypothesis/searchstrategy/regex.py
+++ b/src/hypothesis/searchstrategy/regex.py
@@ -369,9 +369,6 @@ def _strategy(codes, context, pattern):
             # Regexes like '^...', '...$', '\bfoo', '\Bfoo'
             # An empty string (or newline) will match the token itself, but
             # we don't and can't check the position (eg '%' at the end)
-            if value == sre.AT_END:
-                newline = u'\n' if isinstance(pattern, text_type) else b'\n'
-                return st.sampled_from([empty, newline])
             return st.just(empty)
 
         elif code == sre.SUBPATTERN:

--- a/src/hypothesis/searchstrategy/regex.py
+++ b/src/hypothesis/searchstrategy/regex.py
@@ -1,0 +1,352 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2017 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import re
+import sys
+import sre_parse as sre
+
+import hypothesis.strategies as hs
+from hypothesis.errors import InvalidArgument
+from hypothesis.internal.compat import PY3, hrange, hunichr
+
+HAS_SUBPATTERN_FLAGS = sys.version_info[:2] >= (3, 6)
+
+
+UNICODE_CATEGORIES = set([
+    'Cf', 'Cn', 'Co', 'LC', 'Ll', 'Lm', 'Lo', 'Lt', 'Lu',
+    'Mc', 'Me', 'Mn', 'Nd', 'Nl', 'No', 'Pc', 'Pd', 'Pe',
+    'Pf', 'Pi', 'Po', 'Ps', 'Sc', 'Sk', 'Sm', 'So', 'Zl',
+    'Zp', 'Zs',
+])
+
+
+SPACE_CHARS = set(u' \t\n\r\f\v')
+UNICODE_SPACE_CHARS = SPACE_CHARS | set(u'\x1c\x1d\x1e\x1f\x85')
+UNICODE_DIGIT_CATEGORIES = set(['Nd'])
+UNICODE_SPACE_CATEGORIES = set(['Zs', 'Zl', 'Zp'])
+UNICODE_LETTER_CATEGORIES = set(['LC', 'Ll', 'Lm', 'Lo', 'Lt', 'Lu'])
+UNICODE_WORD_CATEGORIES = UNICODE_LETTER_CATEGORIES | set(['Nd', 'Nl', 'No'])
+
+# On Python >= 3.0 and < 3.4 particular unicode word chars are not
+# considered as word chars, thus not matched by "\w" category in regex
+HAS_WEIRD_WORD_CHARS = (2, 7) <= sys.version_info[:2] < (3, 4)
+UNICODE_WEIRD_NONWORD_CHARS = set(u'\U00012432\U00012433\U00012456\U00012457')
+
+
+class Context(object):
+    __slots__ = ['groups', 'flags']
+
+    def __init__(self, groups=None, flags=0):
+        self.groups = groups or {}
+        self.flags = flags
+
+
+class CharactersBuilder(object):
+    """Helper object that allows to configure `characters` strategy with
+    various unicode categories and characters. Also allows negation of
+    configured set.
+
+    :param negate: If True, configure :func:`hypothesis.strategies.characters`
+        to match anything other than configured character set
+    :param flags: Regex flags. They affect how and which characters are matched
+
+    """
+
+    def __init__(self, negate=False, flags=0):
+        self._categories = set()
+        self._whitelist_chars = set()
+        self._blacklist_chars = set()
+        self._negate = negate
+        self._ignorecase = flags & re.IGNORECASE
+        self._unicode = not bool(flags & re.ASCII) \
+            if PY3 else bool(flags & re.UNICODE)
+
+    @property
+    def strategy(self):
+        """Returns resulting strategy that generates configured char set."""
+        max_codepoint = None if self._unicode else 127
+
+        strategies = []
+        if self._negate:
+            if self._categories or self._whitelist_chars:  # pragma: no branch
+                strategies.append(
+                    hs.characters(
+                        blacklist_categories=self._categories | set(
+                            ['Cc', 'Cs']),
+                        blacklist_characters=self._whitelist_chars,
+                        max_codepoint=max_codepoint,
+                    )
+                )
+            if self._blacklist_chars:
+                strategies.append(
+                    hs.sampled_from(
+                        sorted(self._blacklist_chars - self._whitelist_chars)
+                    )
+                )
+        else:
+            if self._categories or self._blacklist_chars:
+                strategies.append(
+                    hs.characters(
+                        whitelist_categories=self._categories,
+                        blacklist_characters=self._blacklist_chars,
+                        max_codepoint=max_codepoint,
+                    )
+                )
+            if self._whitelist_chars:
+                strategies.append(
+                    hs.sampled_from(
+                        sorted(self._whitelist_chars - self._blacklist_chars)
+                    )
+                )
+
+        return hs.one_of(*strategies) if strategies else hs.just(u'')
+
+    def add_category(self, category):
+        """Add unicode category to set.
+
+        Unicode categories are strings like 'Ll', 'Lu', 'Nd', etc. See
+        `unicodedata.category()`
+
+        """
+        if category == sre.CATEGORY_DIGIT:
+            self._categories |= UNICODE_DIGIT_CATEGORIES
+        elif category == sre.CATEGORY_NOT_DIGIT:
+            self._categories |= UNICODE_CATEGORIES - UNICODE_DIGIT_CATEGORIES
+        elif category == sre.CATEGORY_SPACE:
+            self._categories |= UNICODE_SPACE_CATEGORIES
+            self._whitelist_chars |= UNICODE_SPACE_CHARS \
+                if self._unicode else SPACE_CHARS
+        elif category == sre.CATEGORY_NOT_SPACE:
+            self._categories |= UNICODE_CATEGORIES - UNICODE_SPACE_CATEGORIES
+            self._blacklist_chars |= UNICODE_SPACE_CHARS \
+                if self._unicode else SPACE_CHARS
+        elif category == sre.CATEGORY_WORD:
+            self._categories |= UNICODE_WORD_CATEGORIES
+            self._whitelist_chars.add(u'_')
+            if HAS_WEIRD_WORD_CHARS and self._unicode:  # pragma: no cover
+                # This code is workaround of weird behavior in
+                # specific Python versions and run only on those versions
+                self._blacklist_chars |= UNICODE_WEIRD_NONWORD_CHARS
+        elif category == sre.CATEGORY_NOT_WORD:  # pragma: no branch
+            self._categories |= UNICODE_CATEGORIES - UNICODE_WORD_CATEGORIES
+            self._blacklist_chars.add(u'_')
+            if HAS_WEIRD_WORD_CHARS and self._unicode:  # pragma: no cover
+                # This code is workaround of weird behavior in
+                # specific Python versions and run only on those versions
+                self._whitelist_chars |= UNICODE_WEIRD_NONWORD_CHARS
+        else:  # pragma: no cover
+            raise InvalidArgument(
+                'Unknown character category: %s' % category
+            )
+
+    def add_chars(self, chars):
+        """Add given chars to char set."""
+        for c in chars:
+            if self._ignorecase:
+                self._whitelist_chars.add(c.lower())
+                self._whitelist_chars.add(c.upper())
+            else:
+                self._whitelist_chars.add(c)
+
+
+def regex_strategy(regex):
+    if not hasattr(regex, 'pattern'):
+        regex = re.compile(regex)
+
+    pattern = regex.pattern
+    flags = regex.flags
+
+    codes = sre.parse(pattern)
+
+    return _strategy(codes, Context(flags=flags)).filter(regex.match)
+
+
+def _strategy(codes, context):
+    """Convert SRE regex parse tree to strategy that generates strings matching
+    that regex represented by that parse tree.
+
+    `codes` is either a list of SRE regex elements representations or a
+    particular element representation. Each element is a tuple of element code
+    (as string) and parameters. E.g. regex 'ab[0-9]+' compiles to following
+    elements:
+
+        [
+            ('literal', 97),
+            ('literal', 98),
+            ('max_repeat', (1, 4294967295, [
+                ('in', [
+                    ('range', (48, 57))
+                ])
+            ]))
+        ]
+
+    The function recursively traverses regex element tree and converts each
+    element to strategy that generates strings that match that element.
+
+    Context stores
+    1. List of groups (for backreferences)
+    2. Active regex flags (e.g. IGNORECASE, DOTALL, UNICODE, they affect
+       behavior of various inner strategies)
+
+    """
+    if not isinstance(codes, tuple):
+        # List of codes
+        strategies = []
+
+        i = 0
+        while i < len(codes):
+            if codes[i][0] == sre.LITERAL and \
+                    not context.flags & re.IGNORECASE:
+                # Merge subsequent "literals" into one `just()` strategy
+                # that generates corresponding text if no IGNORECASE
+                j = i + 1
+                while j < len(codes) and codes[j][0] == sre.LITERAL:
+                    j += 1
+
+                if i + 1 < j:
+                    strategies.append(hs.just(
+                        u''.join([hunichr(charcode)
+                                  for (_, charcode) in codes[i:j]])
+                    ))
+
+                    i = j
+                    continue
+
+            strategies.append(_strategy(codes[i], context))
+            i += 1
+
+        return hs.tuples(*strategies).map(u''.join)
+    else:
+        # Single code
+        code, value = codes
+        if code == sre.LITERAL:
+            # Regex 'a' (single char)
+            c = hunichr(value)
+            if context.flags & re.IGNORECASE:
+                return hs.sampled_from([c.lower(), c.upper()])
+
+            return hs.just(c)
+
+        elif code == sre.NOT_LITERAL:
+            # Regex '[^a]' (negation of a single char)
+            c = hunichr(value)
+            blacklist = set([c.lower(), c.upper()]) \
+                if context.flags & re.IGNORECASE else [c]
+            return hs.characters(blacklist_characters=blacklist)
+
+        elif code == sre.IN:
+            # Regex '[abc0-9]' (set of characters)
+            charsets = value
+
+            builder = CharactersBuilder(negate=charsets[0][0] == sre.NEGATE,
+                                        flags=context.flags)
+
+            for charset_code, charset_value in charsets:
+                if charset_code == sre.NEGATE:
+                    # Regex '[^...]' (negation)
+                    pass
+                elif charset_code == sre.LITERAL:
+                    # Regex '[a]' (single char)
+                    builder.add_chars(hunichr(charset_value))
+                elif charset_code == sre.RANGE:
+                    # Regex '[a-z]' (char range)
+                    low, high = charset_value
+                    for char_code in hrange(low, high + 1):
+                        builder.add_chars(hunichr(char_code))
+                elif charset_code == sre.CATEGORY:
+                    # Regex '[\w]' (char category)
+                    builder.add_category(charset_value)
+                else:  # pragma: no cover
+                    # Currently there are no known code points other than
+                    # handled here. This code is just future proofing
+                    raise InvalidArgument(
+                        'Unknown charset code: %s' % charset_code
+                    )
+
+            return builder.strategy
+
+        elif code == sre.ANY:
+            # Regex '.' (any char)
+            if context.flags & re.DOTALL:
+                return hs.characters()
+
+            return hs.characters(blacklist_characters='\n')
+
+        elif code == sre.AT:
+            # Regexes like '^...', '...$', '\bfoo', '\Bfoo'
+            if value == sre.AT_END:
+                return hs.one_of(hs.just(u''), hs.just(u'\n'))
+            return hs.just('')
+
+        elif code == sre.SUBPATTERN:
+            # Various groups: '(...)', '(:...)' or '(?P<name>...)'
+            old_flags = context.flags
+            if HAS_SUBPATTERN_FLAGS:  # pragma: no cover
+                # This feature is available only in specific Python versions
+                context.flags = (context.flags | value[1]) & ~value[2]
+
+            strat = _strategy(value[-1], context)
+
+            context.flags = old_flags
+
+            if value[0]:
+                context.groups[value[0]] = strat
+                strat = hs.shared(strat, key=value[0])
+
+            return strat
+
+        elif code == sre.GROUPREF:
+            # Regex '\\1' or '(?P=name)' (group reference)
+            return hs.shared(context.groups[value], key=value)
+
+        elif code == sre.ASSERT:
+            # Regex '(?=...)' or '(?<=...)' (positive lookahead/lookbehind)
+            return _strategy(value[1], context)
+
+        elif code == sre.ASSERT_NOT:
+            # Regex '(?!...)' or '(?<!...)' (negative lookahead/lookbehind)
+            return hs.just('')
+
+        elif code == sre.BRANCH:
+            # Regex 'a|b|c' (branch)
+            return hs.one_of([_strategy(branch, context)
+                              for branch in value[1]])
+
+        elif code in [sre.MIN_REPEAT, sre.MAX_REPEAT]:
+            # Regexes 'a?', 'a*', 'a+' and their non-greedy variants
+            # (repeaters)
+            at_least, at_most, subregex = value
+            if at_most == sre.MAXREPEAT:
+                at_most = None
+            return hs.lists(_strategy(subregex, context),
+                            min_size=at_least,
+                            max_size=at_most).map(''.join)
+
+        elif code == sre.GROUPREF_EXISTS:
+            # Regex '(?(id/name)yes-pattern|no-pattern)'
+            # (if group exists choice)
+            return hs.one_of(
+                _strategy(value[1], context),
+                _strategy(value[2], context) if value[2] else hs.just(u''),
+            )
+
+        else:  # pragma: no cover
+            # Currently there are no known code points other than handled here.
+            # This code is just future proofing
+            raise InvalidArgument('Unknown code point: %s' % repr(code))

--- a/src/hypothesis/searchstrategy/regex.py
+++ b/src/hypothesis/searchstrategy/regex.py
@@ -358,7 +358,10 @@ def _strategy(codes, context, pattern):
             strategies.append(recurse(codes[i]))
             i += 1
 
-        assert strategies
+        # We handle this separately at the top level, but some regex can
+        # contain empty lists internally, so we need to handle this here too.
+        if not strategies:
+            return st.just(empty)
 
         if len(strategies) == 1:
             return strategies[0]

--- a/src/hypothesis/searchstrategy/regex.py
+++ b/src/hypothesis/searchstrategy/regex.py
@@ -218,6 +218,12 @@ class BytesBuilder(CharactersBuilder):
 def maybe_pad(draw, regex, strategy):
     """Attempt to insert padding around the result of a regex draw while
     preserving the match."""
+    if not regex.pattern:
+        if isinstance(regex.pattern, text_type):
+            return draw(st.text())
+        else:
+            return draw(st.binary())
+
     result = draw(strategy)
 
     if isinstance(regex.pattern, text_type):

--- a/src/hypothesis/searchstrategy/regex.py
+++ b/src/hypothesis/searchstrategy/regex.py
@@ -175,14 +175,18 @@ class BytesBuilder(CharactersBuilder):
         self._whitelist_chars |= BYTES_LOOKUP[category]
 
 
-def regex_strategy(regex):
-    if not hasattr(regex, 'pattern'):
-        regex = re.compile(regex)
+def base_regex_strategy(regex):
     return _strategy(
         sre.parse(regex.pattern),
         Context(flags=regex.flags),
         regex.pattern
-    ).filter(regex.match)
+    )
+
+
+def regex_strategy(regex):
+    if not hasattr(regex, 'pattern'):
+        regex = re.compile(regex)
+    return base_regex_strategy(regex).filter(regex.match)
 
 
 def _strategy(codes, context, pattern):

--- a/src/hypothesis/searchstrategy/regex.py
+++ b/src/hypothesis/searchstrategy/regex.py
@@ -25,7 +25,7 @@ import sre_parse as sre
 import hypothesis.strategies as st
 from hypothesis import reject
 from hypothesis.internal.compat import PY3, hrange, hunichr, text_type, \
-    binary_type, int_to_byte
+    int_to_byte
 
 HAS_SUBPATTERN_FLAGS = sys.version_info[:2] >= (3, 6)
 
@@ -220,12 +220,12 @@ def maybe_pad(draw, regex, strategy, left_pad_strategy, right_pad_strategy):
     """Attempt to insert padding around the result of a regex draw while
     preserving the match."""
     result = draw(strategy)
-    left_padded = draw(left_pad_strategy) + result
-    if regex.search(left_padded):
-        result = left_padded
-    right_padded = result + draw(right_pad_strategy)
-    if regex.search(right_padded):
-        result = right_padded
+    left_pad = draw(left_pad_strategy)
+    if left_pad and regex.search(left_pad + result):
+        result = left_pad + result
+    right_pad = draw(right_pad_strategy)
+    if right_pad and regex.search(result + right_pad):
+        result += right_pad
     return result
 
 

--- a/src/hypothesis/searchstrategy/regex.py
+++ b/src/hypothesis/searchstrategy/regex.py
@@ -251,17 +251,19 @@ def maybe_pad(draw, regex, strategy):
 
 
 def base_regex_strategy(regex):
-    return maybe_pad(regex, clear_cache_after_draw(_strategy(
+    return clear_cache_after_draw(_strategy(
         sre.parse(regex.pattern),
         Context(flags=regex.flags),
         regex.pattern
-    )))
+    ))
 
 
 def regex_strategy(regex):
     if not hasattr(regex, 'pattern'):
         regex = re.compile(regex)
-    return base_regex_strategy(regex).filter(regex.search)
+    return maybe_pad(
+        regex,
+        base_regex_strategy(regex).filter(regex.search))
 
 
 def _strategy(codes, context, pattern):

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -44,7 +44,7 @@ __all__ = [
     'choices', 'streaming',
     'booleans', 'integers', 'floats', 'complex_numbers', 'fractions',
     'decimals',
-    'characters', 'text', 'binary', 'uuids',
+    'characters', 'text', 'strings_matching_regex', 'binary', 'uuids',
     'tuples', 'lists', 'sets', 'frozensets', 'iterables',
     'dictionaries', 'fixed_dictionaries',
     'sampled_from', 'permutations',
@@ -737,6 +737,32 @@ def text(
         char_strategy, average_size=average_size, min_size=min_size,
         max_size=max_size
     ))
+
+
+@cacheable
+@defines_strategy
+def strings_matching_regex(regex):
+    """Return strategy that generates strings that match given regex.
+
+    Regex can be either a string or compiled regex (through
+    :func:`re.compile`).
+
+    You can use regex flags (such as :const:`python:re.IGNORECASE`,
+    :const:`python:re.DOTALL` or :const:`python:re.UNICODE`) to control
+    generation. Flags can be passed either in compiled regex (specify flags in
+    call to :func:`re.compile`) or inside pattern with (?iLmsux) group.
+
+    Some tricky regular expressions are partly supported or not supported at
+    all. "^" and "$" do not affect generation. Positive lookahead/lookbehind
+    groups are considered normal groups. Negative lookahead/lookbehind groups
+    do not do anything. Ternary regex groups
+    ('(?(name)yes-pattern|no-pattern)') generate variants regardless of
+    presence of named group and rely on filtering to produce correct results
+    (therefore can be slower than straightforward generation).
+
+    """
+    from hypothesis.searchstrategy.regex import regex_strategy
+    return regex_strategy(regex)
 
 
 @cacheable

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -761,9 +761,9 @@ def from_regex(regex):
     mainly includes (positive or negative) lookahead and lookbehind groups.
 
     If you want the generated string to match the whole regex you should use
-    boundary markers. So e.g. r"\A.\Z" will return a single character string,
-    while "." will return any string, and r"\A.$" will return a single
-    character optionally followed by a \n.
+    boundary markers. So e.g. ``r"\\A.\\Z"`` will return a single character
+    string, while ``"."`` will return any string, and ``r"\\A.$"`` will return a
+    single character optionally followed by a ``"\\n"``.
 
     """
     from hypothesis.searchstrategy.regex import regex_strategy

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -742,11 +742,12 @@ def text(
 @cacheable
 @defines_strategy
 def from_regex(regex):
-    """Generates strings that match the given regex.
+    """Generates strings that contain a match for the given regex (i.e. ones
+    for which re.search will return a non-None result).
 
     ``regex`` may be a pattern or :func:`compiled regex <python:re.compile>`.
     Both byte-strings and unicode strings are supported, and will generate
-    examples of the given type.
+    examples of the same type.
 
     You can use regex flags (such as :const:`python:re.IGNORECASE`,
     :const:`python:re.DOTALL` or :const:`python:re.UNICODE`) to control
@@ -756,14 +757,12 @@ def from_regex(regex):
     Some regular expressions are only partly supported - the underlying
     strategy checks local matching and relies on filtering to resolve
     context-dependent expressions.  Using too many of these constructs may
-    cause health-check errors as too many examples are filtered out.
+    cause health-check errors as too many examples are filtered out. This
+    mainly includes (positive or negative) lookahead and lookbehind groups.
 
-    - Position markers - ``^``, ``\b``, ``\B`` - generate the empty string
-      but defer matching to the filter.  ``$`` may also generate a newline.
-    - Positive lookahead and lookbehind groups are considered normal groups.
-    - Negative lookahead and lookbehind groups do not do anything.
-    - Ternary regex groups - ``(?(name)yes-pattern|no-pattern)`` - rely on
-      filtering to produce the right group.
+    If you want the generated string to match the whole regex you should use
+    boundary markers. So e.g. "^.$" will return a single character string,
+    while "." will return any string.
 
     """
     from hypothesis.searchstrategy.regex import regex_strategy

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -762,8 +762,8 @@ def from_regex(regex):
 
     If you want the generated string to match the whole regex you should use
     boundary markers. So e.g. ``r"\\A.\\Z"`` will return a single character
-    string, while ``"."`` will return any string, and ``r"\\A.$"`` will return a
-    single character optionally followed by a ``"\\n"``.
+    string, while ``"."`` will return any string, and ``r"\\A.$"`` will return
+    a single character optionally followed by a ``"\\n"``.
 
     """
     from hypothesis.searchstrategy.regex import regex_strategy

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -44,7 +44,7 @@ __all__ = [
     'choices', 'streaming',
     'booleans', 'integers', 'floats', 'complex_numbers', 'fractions',
     'decimals',
-    'characters', 'text', 'strings_matching_regex', 'binary', 'uuids',
+    'characters', 'text', 'from_regex', 'binary', 'uuids',
     'tuples', 'lists', 'sets', 'frozensets', 'iterables',
     'dictionaries', 'fixed_dictionaries',
     'sampled_from', 'permutations',
@@ -741,24 +741,29 @@ def text(
 
 @cacheable
 @defines_strategy
-def strings_matching_regex(regex):
-    """Return strategy that generates strings that match given regex.
+def from_regex(regex):
+    """Generates strings that match the given regex.
 
-    Regex can be either a string or compiled regex (through
-    :func:`re.compile`).
+    ``regex`` may be a pattern or :func:`compiled regex <python:re.compile>`.
+    Both byte-strings and unicode strings are supported, and will generate
+    examples of the given type.
 
     You can use regex flags (such as :const:`python:re.IGNORECASE`,
     :const:`python:re.DOTALL` or :const:`python:re.UNICODE`) to control
-    generation. Flags can be passed either in compiled regex (specify flags in
-    call to :func:`re.compile`) or inside pattern with (?iLmsux) group.
+    generation. Flags can be passed either in compiled regex or inside the
+    pattern with a ``(?iLmsux)`` group.
 
-    Some tricky regular expressions are partly supported or not supported at
-    all. "^" and "$" do not affect generation. Positive lookahead/lookbehind
-    groups are considered normal groups. Negative lookahead/lookbehind groups
-    do not do anything. Ternary regex groups
-    ('(?(name)yes-pattern|no-pattern)') generate variants regardless of
-    presence of named group and rely on filtering to produce correct results
-    (therefore can be slower than straightforward generation).
+    Some regular expressions are only partly supported - the underlying
+    strategy checks local matching and relies on filtering to resolve
+    context-dependent expressions.  Using too many of these constructs may
+    cause health-check errors as too many examples are filtered out.
+
+    - Position markers - ``^``, ``\b``, ``\B`` - generate the empty string
+      but defer matching to the filter.  ``$`` may also generate a newline.
+    - Positive lookahead and lookbehind groups are considered normal groups.
+    - Negative lookahead and lookbehind groups do not do anything.
+    - Ternary regex groups - ``(?(name)yes-pattern|no-pattern)`` - rely on
+      filtering to produce the right group.
 
     """
     from hypothesis.searchstrategy.regex import regex_strategy

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -761,9 +761,9 @@ def from_regex(regex):
     mainly includes (positive or negative) lookahead and lookbehind groups.
 
     If you want the generated string to match the whole regex you should use
-    boundary markers. So e.g. r"^.\Z" will return a single character string,
-    while "." will return any string, and r"^.$" will return a single character
-    optionally followed by a \n.
+    boundary markers. So e.g. r"\A.\Z" will return a single character string,
+    while "." will return any string, and r"\A.$" will return a single
+    character optionally followed by a \n.
 
     """
     from hypothesis.searchstrategy.regex import regex_strategy

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -761,8 +761,9 @@ def from_regex(regex):
     mainly includes (positive or negative) lookahead and lookbehind groups.
 
     If you want the generated string to match the whole regex you should use
-    boundary markers. So e.g. "^.$" will return a single character string,
-    while "." will return any string.
+    boundary markers. So e.g. r"^.\Z" will return a single character string,
+    while "." will return any string, and r"^.$" will return a single character
+    optionally followed by a \n.
 
     """
     from hypothesis.searchstrategy.regex import regex_strategy

--- a/tests/cover/test_regex.py
+++ b/tests/cover/test_regex.py
@@ -193,8 +193,6 @@ def test_any_with_dotall_generate_newline_binary(pattern):
 @pytest.mark.parametrize('is_unicode', [False, True])
 @pytest.mark.parametrize('invert', [False, True])
 def test_groups(pattern, is_unicode, invert):
-    pattern = u'^%s\\Z' % (pattern,)
-
     if u'd' in pattern.lower():
         group_pred = is_digit
     elif u'w' in pattern.lower():
@@ -209,6 +207,8 @@ def test_groups(pattern, is_unicode, invert):
 
         def group_pred(s):
             return not _p(s)
+
+    pattern = u'^%s\\Z' % (pattern,)
 
     compiler = unicode_regex if is_unicode else ascii_regex
     strategy = st.from_regex(compiler(pattern))

--- a/tests/cover/test_regex.py
+++ b/tests/cover/test_regex.py
@@ -353,3 +353,17 @@ def test_can_pad_empty_strings():
 def test_can_pad_strings_with_newlines():
     find_any(st.from_regex(u'^$'), bool)
     find_any(st.from_regex(b'^$'), bool)
+
+
+def test_given_multiline_regex_can_insert_after_dollar():
+    find_any(
+        st.from_regex(re.compile(u"\Ahi$", re.MULTILINE)),
+        lambda x: '\n' in x and x.split(u"\n")[1]
+    )
+
+
+def test_given_multiline_regex_can_insert_before_caret():
+    find_any(
+        st.from_regex(re.compile(u"^hi\Z", re.MULTILINE)),
+        lambda x: '\n' in x and x.split(u"\n")[0]
+    )

--- a/tests/cover/test_regex.py
+++ b/tests/cover/test_regex.py
@@ -331,6 +331,10 @@ def test_regex_have_same_type_as_pattern(pattern):
 
 
 def test_can_pad_strings_arbitrarily():
-    find_any(st.from_regex('a'), lambda x: x[0] != 'a')
-    find_any(st.from_regex('a'), lambda x: x[-1] != 'a')
-    find_any(st.from_regex(''), bool)
+    find_any(st.from_regex(u'a'), lambda x: x[0] != u'a')
+    find_any(st.from_regex(u'a'), lambda x: x[-1] != u'a')
+
+
+def test_can_pad_empty_strings():
+    find_any(st.from_regex(u''), bool)
+    find_any(st.from_regex(b''), bool)

--- a/tests/cover/test_regex.py
+++ b/tests/cover/test_regex.py
@@ -367,3 +367,8 @@ def test_given_multiline_regex_can_insert_before_caret():
         st.from_regex(re.compile(u"^hi\Z", re.MULTILINE)),
         lambda x: '\n' in x and x.split(u"\n")[0]
     )
+
+
+def test_does_not_left_pad_beginning_of_string_marker():
+    assert_all_examples(
+        st.from_regex(u'\\Afoo'), lambda x: x.startswith(u'foo'))

--- a/tests/cover/test_regex.py
+++ b/tests/cover/test_regex.py
@@ -249,6 +249,16 @@ def test_groupref_exists():
     )
 
 
+def test_impossible_negative_lookahead():
+    with pytest.raises(NoExamples):
+        st.from_regex(u'(?!foo)foo').example()
+
+
+@given(st.from_regex(u"(\\Afoo\\Z)"))
+def test_can_handle_boundaries_nested(s):
+    assert s == u"foo"
+
+
 def test_groupref_not_shared_between_regex():
     # If group references are (incorrectly!) shared between regex, this would
     # fail as the would only be one reference.
@@ -375,4 +385,8 @@ def test_does_not_left_pad_beginning_of_string_marker():
 
 
 def test_bare_caret_can_produce():
-    find_any(st.from_regex(u'^', bool))
+    find_any(st.from_regex(u'^'), bool)
+
+
+def test_bare_dollar_can_produce():
+    find_any(st.from_regex(u'$'), bool)

--- a/tests/cover/test_regex.py
+++ b/tests/cover/test_regex.py
@@ -26,7 +26,7 @@ import pytest
 from hypothesis import given, assume, reject
 from hypothesis.errors import NoExamples, FailedHealthCheck
 from hypothesis.strategies import data, text, binary, tuples, from_regex
-from hypothesis.internal.compat import PY3, hrange, hunichr
+from hypothesis.internal.compat import PY3, hrange, hunichr, text_type
 from hypothesis.searchstrategy.regex import SPACE_CHARS, \
     UNICODE_SPACE_CHARS, HAS_WEIRD_WORD_CHARS, UNICODE_WORD_CATEGORIES, \
     UNICODE_DIGIT_CATEGORIES, UNICODE_SPACE_CATEGORIES, \
@@ -314,3 +314,12 @@ def test_fuzz_stuff(pattern):
         inner()
     except (NoExamples, FailedHealthCheck):
         reject()
+
+
+@pytest.mark.parametrize('pattern', [b'.', u'.'])
+def test_regex_have_same_type_as_pattern(pattern):
+    @given(from_regex(pattern))
+    def test_result_type(s):
+        assert type(s) == type(pattern)
+
+    test_result_type()

--- a/tests/cover/test_regex.py
+++ b/tests/cover/test_regex.py
@@ -372,3 +372,7 @@ def test_given_multiline_regex_can_insert_before_caret():
 def test_does_not_left_pad_beginning_of_string_marker():
     assert_all_examples(
         st.from_regex(u'\\Afoo'), lambda x: x.startswith(u'foo'))
+
+
+def test_bare_caret_can_produce():
+    find_any(st.from_regex(u'^', bool))

--- a/tests/cover/test_regex.py
+++ b/tests/cover/test_regex.py
@@ -250,12 +250,12 @@ def test_groupref_not_shared_between_regex():
 
 @given(data())
 def test_group_ref_is_not_shared_between_identical_regex(data):
-    pattern = re.compile(r"(.+)\1", re.UNICODE)
+    pattern = re.compile(u"(.+)\\1", re.UNICODE)
     x = data.draw(base_regex_strategy(pattern))
     y = data.draw(base_regex_strategy(pattern))
     assume(x != y)
-    assert re.match(x)
-    assert re.match(y)
+    assert pattern.match(x).end() == len(x)
+    assert pattern.match(y).end() == len(y)
 
 
 def test_positive_lookbehind():

--- a/tests/cover/test_regex.py
+++ b/tests/cover/test_regex.py
@@ -321,6 +321,11 @@ def test_subpattern_flags():
         strategy.filter(lambda s: s[1] == u'B').example()
 
 
+def test_can_handle_binary_regex_which_is_not_ascii():
+    bad = b'\xad'
+    assert_all_examples(st.from_regex(bad), lambda x: bad in x)
+
+
 @pytest.mark.parametrize('pattern', [b'.', u'.'])
 def test_regex_have_same_type_as_pattern(pattern):
     @given(st.from_regex(pattern))

--- a/tests/cover/test_regex.py
+++ b/tests/cover/test_regex.py
@@ -24,8 +24,8 @@ import unicodedata
 import pytest
 
 import hypothesis.strategies as st
-from hypothesis import given, assume, reject
-from hypothesis.errors import NoExamples, FailedHealthCheck
+from hypothesis import given, assume
+from hypothesis.errors import NoExamples
 from hypothesis.internal.compat import PY3, hrange, hunichr
 from hypothesis.searchstrategy.regex import SPACE_CHARS, \
     UNICODE_SPACE_CHARS, HAS_WEIRD_WORD_CHARS, UNICODE_WORD_CATEGORIES, \
@@ -298,23 +298,6 @@ def test_subpattern_flags():
 
     with pytest.raises(NoExamples):
         strategy.filter(lambda s: s[1] == u'B').example()
-
-
-@given(st.text(max_size=100) | st.binary(max_size=100))
-def test_fuzz_stuff(pattern):
-    try:
-        regex = re.compile(pattern)
-    except re.error:
-        reject()
-
-    @given(st.from_regex(regex))
-    def inner(ex):
-        assert regex.match(ex)
-
-    try:
-        inner()
-    except (NoExamples, FailedHealthCheck):
-        reject()
 
 
 @pytest.mark.parametrize('pattern', [b'.', u'.'])

--- a/tests/cover/test_regex.py
+++ b/tests/cover/test_regex.py
@@ -25,7 +25,7 @@ import pytest
 
 from hypothesis import given, reject
 from hypothesis.errors import NoExamples, FailedHealthCheck
-from hypothesis.strategies import text, binary, from_regex
+from hypothesis.strategies import text, binary, tuples, from_regex
 from hypothesis.internal.compat import PY3, hrange, hunichr
 from hypothesis.searchstrategy.regex import SPACE_CHARS, \
     UNICODE_SPACE_CHARS, HAS_WEIRD_WORD_CHARS, UNICODE_WORD_CATEGORIES, \
@@ -240,6 +240,13 @@ def test_groupref_exists():
         from_regex(u'^(a)?(?(1)b|c)$'),
         lambda s: s in (u'ab', u'ab\n', u'c', u'c\n')
     )
+
+
+def test_groupref_not_shared_between_regex():
+    # If group references are (incorrectly!) shared between regex, this would
+    # fail as the would only be one reference.  Instead, we use a tuple of
+    # (pattern, group) as the key - it's OK to share if pattern is identical!
+    tuples(from_regex('(a)\\1'), from_regex('(b)\\1')).example()
 
 
 def test_positive_lookbehind():

--- a/tests/cover/test_regex.py
+++ b/tests/cover/test_regex.py
@@ -333,3 +333,4 @@ def test_regex_have_same_type_as_pattern(pattern):
 def test_can_pad_strings_arbitrarily():
     find_any(st.from_regex('a'), lambda x: x[0] != 'a')
     find_any(st.from_regex('a'), lambda x: x[-1] != 'a')
+    find_any(st.from_regex(''), bool)

--- a/tests/cover/test_regex.py
+++ b/tests/cover/test_regex.py
@@ -258,6 +258,14 @@ def test_group_ref_is_not_shared_between_identical_regex(data):
     assert pattern.match(y).end() == len(y)
 
 
+@given(st.data())
+def test_does_not_leak_groups(data):
+    a = data.draw(base_regex_strategy(re.compile(u"(a)")))
+    assert a == 'a'
+    b = data.draw(base_regex_strategy(re.compile(u"(?(1)a|b)(.)")))
+    assert b[0] == 'b'
+
+
 def test_positive_lookbehind():
     st.from_regex(u'.*(?<=ab)c').filter(lambda s: s.endswith(u'abc')).example()
 

--- a/tests/cover/test_regex.py
+++ b/tests/cover/test_regex.py
@@ -224,7 +224,7 @@ def test_caret_in_the_middle_does_not_generate_anything():
     r = re.compile(u'a^b')
 
     with pytest.raises(NoExamples):
-        st.from_regex(r).filter(r.search).example()
+        st.from_regex(r).example()
 
 
 def test_end_with_terminator_does_not_pad():

--- a/tests/cover/test_regex.py
+++ b/tests/cover/test_regex.py
@@ -390,3 +390,10 @@ def test_bare_caret_can_produce():
 
 def test_bare_dollar_can_produce():
     find_any(st.from_regex(u'$'), bool)
+
+
+def test_shared_union():
+    # This gets parsed as [(ANY, None), (BRANCH, (None, [[], []]))], the
+    # interesting feature of which is that it contains empty sub-expressions
+    # in the branch.
+    st.from_regex('.|.').example()

--- a/tests/cover/test_regex.py
+++ b/tests/cover/test_regex.py
@@ -1,0 +1,437 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2017 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import re
+import sys
+import unicodedata
+
+import pytest
+
+from hypothesis import given, settings
+from hypothesis.errors import NoExamples
+from hypothesis.strategies import strings_matching_regex
+from hypothesis.internal.compat import PY3, hrange, hunichr
+from hypothesis.searchstrategy.regex import SPACE_CHARS, \
+    UNICODE_SPACE_CHARS, HAS_WEIRD_WORD_CHARS, UNICODE_WORD_CATEGORIES, \
+    UNICODE_DIGIT_CATEGORIES, UNICODE_SPACE_CATEGORIES, \
+    UNICODE_WEIRD_NONWORD_CHARS
+
+
+def is_ascii(s):
+    return all(ord(c) < 128 for c in s)
+
+
+def is_digit(s):
+    return all(unicodedata.category(c) in UNICODE_DIGIT_CATEGORIES for c in s)
+
+
+def is_space(s):
+    return all(c in SPACE_CHARS for c in s)
+
+
+def is_unicode_space(s):
+    return all(
+        unicodedata.category(c) in UNICODE_SPACE_CATEGORIES or
+        c in UNICODE_SPACE_CHARS
+        for c in s
+    )
+
+
+def is_word(s):
+    return all(
+        c == '_' or (
+            (not HAS_WEIRD_WORD_CHARS or
+             c not in UNICODE_WEIRD_NONWORD_CHARS) and
+            unicodedata.category(c) in UNICODE_WORD_CATEGORIES
+        )
+        for c in s
+    )
+
+
+def ascii_regex(pattern):
+    flags = re.ASCII if PY3 else 0
+    return re.compile(pattern, flags)
+
+
+def unicode_regex(pattern):
+    return re.compile(pattern, re.UNICODE)
+
+
+def _test_matching_pattern(pattern, isvalidchar, is_unicode=False):
+    r = unicode_regex(pattern) if is_unicode else ascii_regex(pattern)
+
+    codepoints = hrange(0, sys.maxunicode + 1) \
+        if is_unicode else hrange(1, 128)
+    for c in [hunichr(x) for x in codepoints]:
+        if isvalidchar(c):
+            assert r.match(c), (
+                '"%s" supposed to match "%s" (%r, category "%s"), '
+                'but it doesnt' % (pattern, c, c, unicodedata.category(c))
+            )
+        else:
+            assert not r.match(c), (
+                '"%s" supposed not to match "%s" (%r, category "%s"), '
+                'but it does' % (pattern, c, c, unicodedata.category(c))
+            )
+
+
+def test_matching_ascii_word_chars():
+    _test_matching_pattern(r'\w', is_word)
+
+
+def test_matching_unicode_word_chars():
+    _test_matching_pattern(r'\w', is_word, is_unicode=True)
+
+
+def test_matching_ascii_non_word_chars():
+    _test_matching_pattern(r'\W', lambda s: not is_word(s))
+
+
+def test_matching_unicode_non_word_chars():
+    _test_matching_pattern(r'\W', lambda s: not is_word(s), is_unicode=True)
+
+
+def test_matching_ascii_digits():
+    _test_matching_pattern(r'\d', is_digit)
+
+
+def test_matching_unicode_digits():
+    _test_matching_pattern(r'\d', is_digit, is_unicode=True)
+
+
+def test_matching_ascii_non_digits():
+    _test_matching_pattern(r'\D', lambda s: not is_digit(s))
+
+
+def test_matching_unicode_non_digits():
+    _test_matching_pattern(r'\D', lambda s: not is_digit(s), is_unicode=True)
+
+
+def test_matching_ascii_spaces():
+    _test_matching_pattern(r'\s', is_space)
+
+
+def test_matching_unicode_spaces():
+    _test_matching_pattern(r'\s', is_unicode_space, is_unicode=True)
+
+
+def test_matching_ascii_non_spaces():
+    _test_matching_pattern(r'\S', lambda s: not is_space(s))
+
+
+def test_matching_unicode_non_spaces():
+    _test_matching_pattern(r'\S', lambda s: not is_unicode_space(s),
+                           is_unicode=True)
+
+
+def assert_all_examples(strategy, predicate):
+    """Checks that there are no examples with given strategy that do not match
+    predicate.
+
+    :param strategy: Hypothesis strategy to check
+    :param predicate: (callable) Predicate that takes string example and
+        returns bool
+
+    """
+    @settings(max_examples=1000, max_iterations=5000)
+    @given(strategy)
+    def assert_examples(s):
+        assert predicate(s), \
+            'Found %r using strategy %s which does not match' % (s, strategy)
+
+    assert_examples()
+
+
+def assert_can_generate(pattern):
+    """Checks that regex strategy for given pattern generates examples that
+    match that regex pattern."""
+    compiled_pattern = re.compile(pattern)
+    strategy = strings_matching_regex(pattern)
+
+    assert_all_examples(strategy, compiled_pattern.match)
+
+
+@pytest.mark.parametrize('pattern', ['a', 'abc', '[a][b][c]'])
+def test_literals(pattern):
+    assert_can_generate(pattern)
+
+
+@pytest.mark.parametrize('pattern', [
+    re.compile('a', re.IGNORECASE),
+    '(?i)a',
+    re.compile('[ab]', re.IGNORECASE),
+    '(?i)[ab]',
+])
+def test_literals_with_ignorecase(pattern):
+    strategy = strings_matching_regex(pattern)
+
+    strategy.filter(lambda s: s == 'a').example()
+    strategy.filter(lambda s: s == 'A').example()
+
+
+def test_not_literal():
+    assert_can_generate('[^a][^b][^c]')
+
+
+@pytest.mark.parametrize('pattern', [
+    re.compile('[^a][^b]', re.IGNORECASE),
+    '(?i)[^a][^b]'
+])
+def test_not_literal_with_ignorecase(pattern):
+    assert_all_examples(
+        strings_matching_regex(pattern),
+        lambda s: s[0] not in ('a', 'A') and s[1] not in ('b', 'B')
+    )
+
+
+def test_any():
+    assert_can_generate('.')
+
+
+def test_any_doesnt_generate_newline():
+    assert_all_examples(strings_matching_regex('.'), lambda s: s != '\n')
+
+
+@pytest.mark.parametrize('pattern', [re.compile('.', re.DOTALL), '(?s).'])
+def test_any_with_dotall_generate_newline(pattern):
+    strings_matching_regex(pattern).filter(lambda s: s == '\n').example()
+
+
+def test_range():
+    assert_can_generate('[a-z0-9_]')
+
+
+def test_negative_range():
+    assert_can_generate('[^a-z0-9_]')
+
+
+@pytest.mark.parametrize('pattern', [r'\d', '[\d]', '[^\D]'])
+def test_ascii_digits(pattern):
+    strategy = strings_matching_regex(ascii_regex(pattern))
+
+    assert_all_examples(strategy, lambda s: is_digit(s) and is_ascii(s))
+
+
+@pytest.mark.parametrize('pattern', [r'\d', '[\d]', '[^\D]'])
+def test_unicode_digits(pattern):
+    strategy = strings_matching_regex(unicode_regex(pattern))
+
+    strategy.filter(lambda s: is_digit(s) and is_ascii(s)).example()
+    strategy.filter(lambda s: is_digit(s) and not is_ascii(s)).example()
+
+    assert_all_examples(strategy, is_digit)
+
+
+@pytest.mark.parametrize('pattern', [r'\D', '[\D]', '[^\d]'])
+def test_ascii_non_digits(pattern):
+    strategy = strings_matching_regex(ascii_regex(pattern))
+
+    assert_all_examples(strategy, lambda s: not is_digit(s) and is_ascii(s))
+
+
+@pytest.mark.parametrize('pattern', [r'\D', '[\D]', '[^\d]'])
+def test_unicode_non_digits(pattern):
+    strategy = strings_matching_regex(unicode_regex(pattern))
+
+    strategy.filter(lambda s: not is_digit(s) and is_ascii(s)).example()
+    strategy.filter(lambda s: not is_digit(s) and not is_ascii(s)).example()
+
+    assert_all_examples(strategy, lambda s: not is_digit(s))
+
+
+@pytest.mark.parametrize('pattern', [r'\s', '[\s]', '[^\S]'])
+def test_ascii_whitespace(pattern):
+    strategy = strings_matching_regex(ascii_regex(pattern))
+
+    assert_all_examples(strategy, lambda s: is_space(s) and is_ascii(s))
+
+
+@pytest.mark.parametrize('pattern', [r'\s', '[\s]', '[^\S]'])
+def test_unicode_whitespace(pattern):
+    strategy = strings_matching_regex(unicode_regex(pattern))
+
+    strategy.filter(lambda s: is_unicode_space(s) and is_ascii(s)).example()
+    strategy.filter(lambda s: is_unicode_space(s) and not is_ascii(s))\
+        .example()
+
+    assert_all_examples(strategy, is_unicode_space)
+
+
+@pytest.mark.parametrize('pattern', [r'\S', '[\S]', '[^\s]'])
+def test_ascii_non_whitespace(pattern):
+    strategy = strings_matching_regex(ascii_regex(pattern))
+
+    assert_all_examples(strategy, lambda s: not is_space(s) and is_ascii(s))
+
+
+@pytest.mark.parametrize('pattern', [r'\S', '[\S]', '[^\s]'])
+def test_unicode_non_whitespace(pattern):
+    strategy = strings_matching_regex(unicode_regex(pattern))
+
+    strategy.filter(lambda s: not is_unicode_space(s) and is_ascii(s))\
+        .example()
+    strategy.filter(lambda s: not is_unicode_space(s) and not is_ascii(s))\
+        .example()
+
+    assert_all_examples(strategy, lambda s: not is_unicode_space(s))
+
+
+@pytest.mark.parametrize('pattern', [r'\w', '[\w]', '[^\W]'])
+def test_ascii_word(pattern):
+    strategy = strings_matching_regex(ascii_regex(pattern))
+
+    assert_all_examples(strategy, lambda s: is_word(s) and is_ascii(s))
+
+
+@pytest.mark.parametrize('pattern', [r'\w', '[\w]', '[^\W]'])
+def test_unicode_word(pattern):
+    strategy = strings_matching_regex(unicode_regex(pattern))
+
+    strategy.filter(lambda s: is_word(s) and is_ascii(s)).example()
+    strategy.filter(lambda s: is_word(s) and not is_ascii(s)).example()
+
+    assert_all_examples(strategy, is_word)
+
+
+@pytest.mark.parametrize('pattern', [r'\W', '[\W]', '[^\w]'])
+def test_ascii_non_word(pattern):
+    strategy = strings_matching_regex(ascii_regex(pattern))
+
+    assert_all_examples(strategy, lambda s: not is_word(s) and is_ascii(s))
+
+
+@pytest.mark.parametrize('pattern', [r'\W', '[\W]', '[^\w]'])
+def test_unicode_non_word(pattern):
+    strategy = strings_matching_regex(unicode_regex(pattern))
+
+    strategy.filter(lambda s: not is_word(s) and is_ascii(s)).example()
+    strategy.filter(lambda s: not is_word(s) and not is_ascii(s)).example()
+
+    assert_all_examples(strategy, lambda s: not is_word(s))
+
+
+def test_question_mark_quantifier():
+    assert_can_generate('ab?')
+
+
+def test_asterisk_quantifier():
+    assert_can_generate('ab*')
+
+
+def test_plus_quantifier():
+    assert_can_generate('ab+')
+
+
+def test_repeater():
+    assert_can_generate('ab{5}')
+    assert_can_generate('ab{5,10}')
+    assert_can_generate('ab{,10}')
+    assert_can_generate('ab{5,}')
+
+
+def test_branch():
+    assert_can_generate('ab|cd|ef')
+
+
+def test_group():
+    assert_can_generate('(foo)+')
+
+
+def test_group_backreference():
+    assert_can_generate('([\'"])[a-z]+\\1')
+
+
+def test_non_capturing_group():
+    assert_can_generate('(?:[a-z])([\'"])[a-z]+\\1')
+
+
+def test_named_groups():
+    assert_can_generate('(?P<foo>[\'"])[a-z]+(?P=foo)')
+
+
+def test_begining():
+    assert_can_generate('^abc')
+
+
+def test_caret_in_the_middle_does_not_generate_anything():
+    r = re.compile('a^b')
+
+    with pytest.raises(NoExamples):
+        strings_matching_regex(r).filter(r.match).example()
+
+
+def test_end():
+    strategy = strings_matching_regex('abc$')
+
+    strategy.filter(lambda s: s == 'abc').example()
+    strategy.filter(lambda s: s == 'abc\n').example()
+
+
+def test_groupref_exists():
+    assert_all_examples(
+        strings_matching_regex('^(<)?a(?(1)>)$'),
+        lambda s: s in ('a', 'a\n', '<a>', '<a>\n')
+    )
+    assert_all_examples(
+        strings_matching_regex('^(a)?(?(1)b|c)$'),
+        lambda s: s in ('ab', 'ab\n', 'c', 'c\n')
+    )
+
+
+def test_positive_lookbehind():
+    strings_matching_regex('.*(?<=ab)c').filter(lambda s: s.endswith('abc'))\
+        .example()
+
+
+def test_positive_lookahead():
+    strings_matching_regex('a(?=bc).*').filter(lambda s: s.startswith('abc'))\
+        .example()
+
+
+def test_negative_lookbehind():
+    # no efficient support
+    strategy = strings_matching_regex('[abc]*(?<!abc)d')
+
+    assert_all_examples
+    with pytest.raises(NoExamples):
+        strategy.filter(lambda s: s.endswith('abcd')).example()
+
+
+def test_negative_lookahead():
+    # no efficient support
+    strategy = strings_matching_regex('ab(?!cd)[abcd]*')
+
+    assert_all_examples
+    with pytest.raises(NoExamples):
+        strategy.filter(lambda s: s.startswith('abcd')).example()
+
+
+@pytest.mark.skipif(sys.version_info[:2] < (3, 6),
+                    reason='requires Python 3.6')
+def test_subpattern_flags():
+    strategy = strings_matching_regex('(?i)a(?-i:b)')
+
+    # "a" is case insensitive
+    strategy.filter(lambda s: s[0] == 'a').example()
+    strategy.filter(lambda s: s[0] == 'A').example()
+    # "b" is case sensitive
+    strategy.filter(lambda s: s[1] == 'b').example()
+
+    with pytest.raises(NoExamples):
+        strategy.filter(lambda s: s[1] == 'B').example()

--- a/tests/cover/test_regex.py
+++ b/tests/cover/test_regex.py
@@ -300,6 +300,12 @@ def test_generates_only_the_provided_characters_given_boundaries(xs):
     assert set(xs) == {u"a"}
 
 
+@given(st.from_regex(u"^(.)?\\1$"))
+def test_group_backref_may_not_be_present(s):
+    assert len(s) == 2
+    assert s[0] == s[1]
+
+
 @pytest.mark.skipif(sys.version_info[:2] < (3, 6),
                     reason='requires Python 3.6')
 def test_subpattern_flags():

--- a/tests/cover/test_regex.py
+++ b/tests/cover/test_regex.py
@@ -26,7 +26,7 @@ import pytest
 from hypothesis import given, assume, reject
 from hypothesis.errors import NoExamples, FailedHealthCheck
 from hypothesis.strategies import data, text, binary, tuples, from_regex
-from hypothesis.internal.compat import PY3, hrange, hunichr, text_type
+from hypothesis.internal.compat import PY3, hrange, hunichr
 from hypothesis.searchstrategy.regex import SPACE_CHARS, \
     UNICODE_SPACE_CHARS, HAS_WEIRD_WORD_CHARS, UNICODE_WORD_CATEGORIES, \
     UNICODE_DIGIT_CATEGORIES, UNICODE_SPACE_CATEGORIES, \

--- a/tests/cover/test_regex.py
+++ b/tests/cover/test_regex.py
@@ -228,7 +228,6 @@ def test_end():
     strategy = st.from_regex(u'abc$')
 
     strategy.filter(lambda s: s == u'abc').example()
-    strategy.filter(lambda s: s == u'abc\n').example()
 
 
 def test_groupref_exists():
@@ -291,6 +290,11 @@ def test_negative_lookahead():
     assert_all_examples(strategy, lambda s: not s.startswith(u'abcd'))
     with pytest.raises(NoExamples):
         strategy.filter(lambda s: s.startswith(u'abcd')).example()
+
+
+@given(st.from_regex(u"^a+$"))
+def test_generates_only_the_provided_characters_given_boundaries(xs):
+    assert set(xs) == {u"a"}
 
 
 @pytest.mark.skipif(sys.version_info[:2] < (3, 6),

--- a/tests/nocover/test_regex.py
+++ b/tests/nocover/test_regex.py
@@ -45,9 +45,9 @@ def conservative_regex(draw):
         st.just(u"."),
         charset(),
         CONSERVATIVE_REGEX.map(lambda s: u"(%s)" % (s,)),
-        CONSERVATIVE_REGEX.map(lambda s: s + '+'),
-        CONSERVATIVE_REGEX.map(lambda s: s + '?'),
-        CONSERVATIVE_REGEX.map(lambda s: s + '*'),
+        CONSERVATIVE_REGEX.map(lambda s: s + u'+'),
+        CONSERVATIVE_REGEX.map(lambda s: s + u'?'),
+        CONSERVATIVE_REGEX.map(lambda s: s + u'*'),
         st.lists(CONSERVATIVE_REGEX, min_size=1).map(u"|".join),
         st.lists(CONSERVATIVE_REGEX, min_size=1).map(u"".join),
     ))

--- a/tests/nocover/test_regex.py
+++ b/tests/nocover/test_regex.py
@@ -1,0 +1,65 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2017 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import re
+import string
+
+import hypothesis.strategies as st
+from hypothesis import given, assume
+from hypothesis.searchstrategy.regex import base_regex_strategy
+
+
+@st.composite
+def charset(draw):
+    negated = draw(st.booleans())
+    chars = draw(st.text(string.ascii_letters + string.digits, min_size=1))
+    if negated:
+        return u"[^%s]" % (chars,)
+    else:
+        return u"[%s]" % (chars,)
+
+
+COMBINED_MATCHER = re.compile(u"[?+*]{2}")
+
+
+@st.composite
+def conservative_regex(draw):
+    result = draw(st.one_of(
+        st.just(u"."),
+        charset(),
+        CONSERVATIVE_REGEX.map(lambda s: u"(%s)" % (s,)),
+        CONSERVATIVE_REGEX.map(lambda s: s + '+'),
+        CONSERVATIVE_REGEX.map(lambda s: s + '?'),
+        CONSERVATIVE_REGEX.map(lambda s: s + '*'),
+        st.lists(CONSERVATIVE_REGEX, min_size=1).map(u"|".join),
+        st.lists(CONSERVATIVE_REGEX, min_size=1).map(u"".join),
+    ))
+    assume(COMBINED_MATCHER.search(result) is None)
+    return result
+
+
+CONSERVATIVE_REGEX = conservative_regex()
+
+
+@given(st.data())
+def test_conservative_regex_are_correct_by_construction(data):
+    pattern = re.compile(data.draw(CONSERVATIVE_REGEX))
+    pattern = re.compile(pattern)
+    result = data.draw(base_regex_strategy(pattern))
+    assert pattern.match(result) is not None

--- a/tests/nocover/test_regex.py
+++ b/tests/nocover/test_regex.py
@@ -21,7 +21,7 @@ import re
 import string
 
 import hypothesis.strategies as st
-from hypothesis import given, assume, reject, settings
+from hypothesis import given, assume, reject
 from hypothesis.searchstrategy.regex import base_regex_strategy
 
 
@@ -69,7 +69,6 @@ def test_conservative_regex_are_correct_by_construction(data):
     assert pattern.search(result) is not None
 
 
-@settings(max_examples=10**6)
 @given(st.data())
 def test_fuzz_stuff(data):
     pattern = data.draw(


### PR DESCRIPTION
In what is definitely our longest chaining of passing the baton yet, I'm taking over #776 from @Zac-HD who took it over from @maximkulkin.

This has the following major changes from the point at which it was left off in #776:

* Groups are now correctly supported. We create a cache object for groups that is cleared at the end of the draw for the regex.
* Group if-then-else matches are now correctly supported: We look in the group cache for whether the group has been set and pick the branch appropriately.
* I have about-faced and decided that @Zac-HD was right and hoping to match the full string is a non-starter (I shall explain in detail below), but decided given that, just returning something that starts with a match does not go far enough! The defined semantics are now that the returned regex *contains* a match. i.e. that re.search returns true, and the strategy adds in a bit of padding on each side to make sure that is achieved. If you want the whole string to match, or some prefix or suffix of the string to match, that's what ^ and \Z are for.
* ~~Given the above, I have removed the fact that $ can implicitly add a new line~~ No I haven't. Use \Z for matching the whole string.
* Support for re.MULTILINE in the context of the new re.search based behaviour.
* I've added some more testing and moved some of the testing into nocover.

## match vs search vs whatever

The problem example for me is the regex `.|0+`. This can match any one character string or any number of zeroes. So quite reasonably it can generate the string "00". But if you match that string against the regex, the match you get is just the leading "0", because the "." matches it.

This is easily fixed by adding a \Z to the end, but it shows that expecting the whole string to be the result of re.match leads to very non-intuitive behaviour.

Further, adding a \Z to the end of your regex can always give you the matching the whole string behaviour in its absence, but going the other way is more awkward (you add a ".*\Z" at the end).

*Given that* I think it makes much more sense to be symmetric in "\Z" and "^", because the same is true for the beginning as well as the end. The boundary markers naturally say where in the string the regex should go, and it's up to the user to be explicit for that.