### PR TITLE
Don't run rst-lint on RELEASE.rst

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,7 @@ check-fast: lint $(PYPY) $(PY36) $(TOX)
 	$(TOX) -e py36-prettyquick
 
 check-rst: $(RSTLINT) $(FLAKE8)
-	$(RSTLINT) *.rst
+	$(RSTLINT) CONTRIBUTING.rst README.rst
 	$(RSTLINT) guides/*.rst
 	$(FLAKE8) --select=W191,W291,W292,W293,W391 *.rst docs/*.rst
 


### PR DESCRIPTION
As @Zac-HD has pointed out, running rst-lint on RELEASE.rst means we can't use any sphinx cross-referencing features on it.

This is only part of what we need to do, as we also need CI to check that this doesn't break the documentation, but it at least unblocks us from releasing for now.