### PR TITLE
Update changelog with RELEASE before building docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -275,8 +275,11 @@ clean:
 	find src tests -name "*.pyc" -delete
 	find src tests -name "__pycache__" -delete
 
-documentation: $(SPHINX_BUILD) docs/*.rst
-	PYTHONPATH=src $(SPHINX_BUILD) -W -b html -d docs/_build/doctrees docs docs/_build/html
+.PHONY: RELEASE.rst
+RELEASE.rst:
+
+documentation: $(SPHINX_BUILD) docs/*.rst RELEASE.rst
+	scripts/build-documentation.sh $(SPHINX_BUILD) $(PY36)
 
 doctest: $(SPHINX_BUILD) docs/*.rst
 	PYTHONPATH=src $(SPHINX_BUILD) -W -b doctest -d docs/_build/doctrees docs docs/_build/html

--- a/scripts/build-documentation.sh
+++ b/scripts/build-documentation.sh
@@ -7,7 +7,7 @@ set -x
 SPHINX_BUILD=$1
 PYTHON=$2
 
-HERE="$(dirname $0)"
+HERE="$(dirname "$0")"
 
 cd "$HERE"/..
 

--- a/scripts/build-documentation.sh
+++ b/scripts/build-documentation.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+set -x
+
+SPHINX_BUILD=$1
+PYTHON=$2
+
+HERE="$(dirname $0)"
+
+cd "$HERE"/..
+
+trap "git checkout docs/changes.rst src/hypothesis/version.py" EXIT
+
+$PYTHON scripts/update-changelog-for-docs.py
+
+export PYTHONPATH=src 
+
+$SPHINX_BUILD -W -b html -d docs/_build/doctrees docs docs/_build/html

--- a/scripts/hypothesistooling.py
+++ b/scripts/hypothesistooling.py
@@ -124,6 +124,12 @@ def has_source_changes(version=None):
     ]) != 0
 
 
+def has_uncommitted_changes(filename):
+    return subprocess.call([
+        'git', 'diff', '--exit-code', filename
+    ]) != 0
+
+
 def git(*args):
     subprocess.check_call(('git',) + args)
 
@@ -247,7 +253,7 @@ def parse_release_file():
     return release_type, release_contents
 
 
-def update_for_pending_release():
+def update_changelog_and_version():
     global __version_info__
     global __version__
 
@@ -313,10 +319,14 @@ def update_for_pending_release():
     with open(CHANGELOG_FILE, 'w') as o:
         o.write('\n'.join(new_changelog_parts))
 
+
+def update_for_pending_release():
+    update_changelog_and_version()
+
     git('rm', RELEASE_FILE)
     git('add', CHANGELOG_FILE, VERSION_FILE)
 
     git(
         'commit',
-        '-m', 'Bump version to %s and update changelog' % (new_version_string,)
+        '-m', 'Bump version to %s and update changelog' % (__version__,)
     )

--- a/scripts/update-changelog-for-docs.py
+++ b/scripts/update-changelog-for-docs.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2017 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import os
+import sys
+
+import hypothesistooling as tools
+
+sys.path.append(os.path.dirname(__file__))  # noqa
+
+
+if __name__ == '__main__':
+    if not tools.has_release():
+        sys.exit(0)
+    if tools.has_uncommitted_changes(tools.CHANGELOG_FILE):
+        print(
+            'Cannot build documentation with uncommitted changes to '
+            'changelog and a pending release. Please commit your changes or '
+            'delete your release file.')
+        sys.exit(1)
+    tools.update_changelog_and_version()


### PR DESCRIPTION
We run just enough of the release process to update the changelog before building documentation, then clean it up afterwards.

This fixes #795.