### PR TITLE
Turn off 32-bit builds in appveyor for now

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,25 +10,13 @@ environment:
       secure: TpmpMHwgS4xxcbbzROle2xyb3i+VPP8cT5ZL4dF/UrA=
 
   matrix:
-    - PYTHON: "C:\\Python27"
-      PYTHON_VERSION: "2.7.13"
-      PYTHON_ARCH: "32"
-
     - PYTHON: "C:\\Python27-x64"
       PYTHON_VERSION: "2.7.13"
       PYTHON_ARCH: "64"
 
-    - PYTHON: "C:\\Python35"
-      PYTHON_VERSION: "3.5.3"
-      PYTHON_ARCH: "32"
-
     - PYTHON: "C:\\Python35-x64"
       PYTHON_VERSION: "3.5.3"
       PYTHON_ARCH: "64"
-
-    - PYTHON: "C:\\Python36"
-      PYTHON_VERSION: "3.6.1"
-      PYTHON_ARCH: "32"
 
     - PYTHON: "C:\\Python36-x64"
       PYTHON_VERSION: "3.6.1"


### PR DESCRIPTION
As @Zac-HD points out, appveyor builds are one of the slowest part of our CI, and half or more of that time is 32-bit builds. This turns them off.

It *might* be worth having a 32-bit specific build on Linux or something, but at the moment the set of things we do that could break specifically on 32-bit is extremely small. I don't think this has ever caught something useful for us.

When we start building native extensions we might have to turn this back on, sadly.