### PR TITLE
Partial fix for our current pyup mess

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -2,9 +2,12 @@ requirements:
   - requirements/tools.txt
       updates: all
       pin: True
+      schedule: "every week on monday"
   - requirements/test.txt
       updates: all
       pin: True
+      schedule: "every week on monday"
   - requirements/benchmark.txt
       updates: all
       pin: True
+      schedule: "every week on monday"

--- a/Makefile
+++ b/Makefile
@@ -211,6 +211,12 @@ compile-requirements: $(PIPCOMPILE)
 	$(PIPCOMPILE) requirements/tools.in --output-file requirements/tools.txt
 	$(PIPCOMPILE) requirements/typing.in --output-file requirements/typing.txt
 
+upgrade-requirements:
+	$(PIPCOMPILE) --upgrade requirements/benchmark.in --output-file requirements/benchmark.txt
+	$(PIPCOMPILE) --upgrade requirements/test.in --output-file requirements/test.txt
+	$(PIPCOMPILE) --upgrade requirements/tools.in --output-file requirements/tools.txt
+	$(PIPCOMPILE) --upgrade requirements/typing.in --output-file requirements/typing.txt
+
 check-requirements: compile-requirements
 	git diff --exit-code
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,6 +10,7 @@ flaky==3.4.0
 mock==2.0.0
 pbr==3.1.1                # via mock
 py==1.4.34                # via pytest
-pytest-xdist==1.18.2
+pytest-forked==0.2        # via pytest-xdist
+pytest-xdist==1.20.0
 pytest==3.2.1
 six==1.10.0               # via mock

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -7,15 +7,15 @@
 alabaster==0.7.10         # via sphinx
 autoflake==0.7            # via pyformat
 autopep8==1.3.2           # via pyformat
-babel==2.4.0              # via sphinx
+babel==2.5.0              # via sphinx
 certifi==2017.7.27.1      # via requests
 chardet==3.0.4            # via requests
 click==6.7                # via pip-tools
 docformatter==0.8         # via pyformat
-docutils==0.13.1          # via restructuredtext-lint, sphinx
+docutils==0.14            # via restructuredtext-lint, sphinx
 first==2.0.1              # via pip-tools
 flake8==3.4.1
-idna==2.5                 # via requests
+idna==2.6                 # via requests
 imagesize==0.7.1          # via sphinx
 isort==4.2.15
 jinja2==2.9.6             # via sphinx


### PR DESCRIPTION
This makes the following changes:

* Updates all of our requirements
* Adds a Make task to do that
* Downgrades pyup pull requests to weekly.

check-requirements isn't sufficient on its own, because it won't actually upgrade existing libraries, so we still need pyup, but this should significantly reduce the noise level until we have a better solution.