### PR TITLE
Avoid collisions in django models generator with field names

### DIFF
--- a/src/hypothesis/extra/django/models.py
+++ b/src/hypothesis/extra/django/models.py
@@ -164,10 +164,10 @@ def _get_strategy_for_field(f):
     return strategy
 
 
-def models(model, **extra):
+def models(django_model_cls, **extra):
     result = {}
     mandatory = set()
-    for f in model._meta.concrete_fields:
+    for f in django_model_cls._meta.concrete_fields:
         try:
             strategy = _get_strategy_for_field(f)
         except UnmappedFieldError:
@@ -181,12 +181,12 @@ def models(model, **extra):
             u'Missing arguments for mandatory field%s %s for model %s' % (
                 u's' if len(missed) > 1 else u'',
                 u', '.join(missed),
-                model.__name__,
+                django_model_cls.__name__,
             )))
     result.update(extra)
     # Remove default_values so we don't try to generate anything for those.
     result = {k: v for k, v in result.items() if v is not default_value}
-    return ModelStrategy(model, result)
+    return ModelStrategy(django_model_cls, result)
 
 
 class ModelStrategy(SearchStrategy):


### PR DESCRIPTION
The first positional argument to the model generator (``model``) is
the reference to the model to work on. The remaining keyword arguments
passed refer to fields in the django model the caller intends to
override a specific strategy during sampling.

This commit renames the naming of this positional argument to allow
passing the field name 'model' as a keywork argument. Thi prevents the
TypeError raised as a result of multiple values passed with those
additional keywork arguments.