### PR TITLE
Merge and reorder deploy commands

### DIFF
--- a/scripts/hypothesistooling.py
+++ b/scripts/hypothesistooling.py
@@ -145,16 +145,13 @@ def create_tag_and_push():
     )
     git('tag', __version__)
 
-    for command in [
-        'git push ssh-origin --tags',
-        'git push ssh-origin HEAD:master',
-    ]:
-        subprocess.check_call([
-            'ssh-agent', 'sh', '-c',
-            'chmod 0600 deploy_key && ' +
-            'ssh-add deploy_key && ' +
-            command
-        ])
+    subprocess.check_call([
+        'ssh-agent', 'sh', '-c',
+        'chmod 0600 deploy_key && ' +
+        'ssh-add deploy_key && ' +
+        'git push ssh-origin HEAD:master &&'
+        'git push ssh-origin --tags'
+    ])
 
 
 def build_jobs():


### PR DESCRIPTION
This makes two changes in an attempt to fix #808:

* It tries to push to master first, so if that doesn't work we don't get a half-baked deploy.
* If merges the push and tag into one command. I'm speculatively guessing that running ssh-agent twice in succession might somehow be the source of our problem (given that the push command does work on its own) and that merging it might help. I've no idea why that would be and the fact that for whatever hilarious reason we're not getting any output is not helping.