### PR TITLE
Rename strategy arguments to min/max value for consistency

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,11 @@
+RELEASE_TYPE: minor
+
+This release renames the relevant arguments on the
+:func:`~hypothesis.strategies.datetimes`, func:`~hypothesis.strategies.dates`,
+func:`~hypothesis.strategies.times`, and func:`~hypothesis.strategies.timedeltas`
+strategies to ``min_value`` and ``max_value``, to make them consistent with the
+other strategies in the module.
+
+The old argument names are still supported but will emit a deprecation warning
+when used explicitly as keyword arguments. Arguments passed positionally will
+go to the new argument names and are not deprecated.

--- a/src/hypothesis/internal/renaming.py
+++ b/src/hypothesis/internal/renaming.py
@@ -1,0 +1,56 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2017 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+from hypothesis._settings import note_deprecation
+from hypothesis.internal.reflection import proxies
+
+
+def renamed_arguments(**rename_mapping):
+    """Helper function for deprecating arguments that have been renamed to a
+    new form."""
+    assert len(set(rename_mapping.values())) == len(rename_mapping)
+
+    def accept(f):
+        @proxies(f)
+        def with_name_check(**kwargs):
+            for k, v in list(kwargs.items()):
+                if k in rename_mapping and v is not None:
+                    t = rename_mapping[k]
+                    note_deprecation((
+                        'The argument %s has been renamed to %s. The old '
+                        'name will go away in a future version of '
+                        'Hypothesis.') % (k, t))
+                    kwargs[t] = kwargs.pop(k)
+            return f(**kwargs)
+
+        with_name_check.__doc__ += '\n'.join((
+            '', '',
+            'The following arguments have been renamed:',
+            '',
+        ) + tuple(
+            '  * %s has been renamed to %s' % s
+            for s in rename_mapping.items()
+        ) + (
+            '',
+            'Use of the old names has been deprecated and will be removed',
+            'in a future version of Hypothesis.'
+        )
+        )
+        return with_name_check
+    return accept

--- a/src/hypothesis/searchstrategy/datetime.py
+++ b/src/hypothesis/searchstrategy/datetime.py
@@ -34,15 +34,15 @@ def is_pytz_timezone(tz):
 
 class DatetimeStrategy(SearchStrategy):
 
-    def __init__(self, min_datetime, max_datetime, timezones_strat):
-        assert isinstance(min_datetime, dt.datetime)
-        assert isinstance(max_datetime, dt.datetime)
-        assert min_datetime.tzinfo is None
-        assert max_datetime.tzinfo is None
-        assert min_datetime <= max_datetime
+    def __init__(self, min_value, max_value, timezones_strat):
+        assert isinstance(min_value, dt.datetime)
+        assert isinstance(max_value, dt.datetime)
+        assert min_value.tzinfo is None
+        assert max_value.tzinfo is None
+        assert min_value <= max_value
         assert isinstance(timezones_strat, SearchStrategy)
-        self.min_dt = min_datetime
-        self.max_dt = max_datetime
+        self.min_dt = min_value
+        self.max_dt = max_value
         self.tz_strat = timezones_strat
 
     def _attempt_one_draw(self, data):
@@ -82,27 +82,27 @@ class DatetimeStrategy(SearchStrategy):
 
 class DateStrategy(SearchStrategy):
 
-    def __init__(self, min_date, max_date):
-        assert isinstance(min_date, dt.date)
-        assert isinstance(max_date, dt.date)
-        assert min_date < max_date
-        self.min_date = min_date
-        self.days_apart = (max_date - min_date).days
-        self.center = (dt.date(2000, 1, 1) - min_date).days
+    def __init__(self, min_value, max_value):
+        assert isinstance(min_value, dt.date)
+        assert isinstance(max_value, dt.date)
+        assert min_value < max_value
+        self.min_value = min_value
+        self.days_apart = (max_value - min_value).days
+        self.center = (dt.date(2000, 1, 1) - min_value).days
 
     def do_draw(self, data):
-        return self.min_date + dt.timedelta(days=utils.centered_integer_range(
+        return self.min_value + dt.timedelta(days=utils.centered_integer_range(
             data, 0, self.days_apart, center=self.center))
 
 
 class TimedeltaStrategy(SearchStrategy):
 
-    def __init__(self, min_delta, max_delta):
-        assert isinstance(min_delta, dt.timedelta)
-        assert isinstance(max_delta, dt.timedelta)
-        assert min_delta < max_delta
-        self.min_delta = min_delta
-        self.max_delta = max_delta
+    def __init__(self, min_value, max_value):
+        assert isinstance(min_value, dt.timedelta)
+        assert isinstance(max_value, dt.timedelta)
+        assert min_value < max_value
+        self.min_value = min_value
+        self.max_value = max_value
 
     def do_draw(self, data):
         result = dict()
@@ -110,9 +110,9 @@ class TimedeltaStrategy(SearchStrategy):
         high_bound = True
         for name in ('days', 'seconds', 'microseconds'):
             low = getattr(
-                self.min_delta if low_bound else dt.timedelta.min, name)
+                self.min_value if low_bound else dt.timedelta.min, name)
             high = getattr(
-                self.max_delta if high_bound else dt.timedelta.max, name)
+                self.max_value if high_bound else dt.timedelta.max, name)
             val = utils.centered_integer_range(data, low, high, 0)
             result[name] = val
             low_bound = low_bound and val == low

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -34,6 +34,7 @@ from hypothesis.internal.compat import gcd, ceil, floor, hrange, \
     implements_iterator
 from hypothesis.internal.floats import is_negative, float_to_int, \
     int_to_float, count_between_floats
+from hypothesis.internal.renaming import renamed_arguments
 from hypothesis.utils.conventions import infer, not_set
 from hypothesis.internal.reflection import proxies, required_args
 from hypothesis.searchstrategy.reprwrapper import ReprWrapperStrategy
@@ -1231,8 +1232,15 @@ def permutations(values):
 
 
 @defines_strategy
-def datetimes(min_datetime=dt.datetime.min, max_datetime=dt.datetime.max,
-              timezones=none()):
+@renamed_arguments(
+    min_datetime='min_value',
+    max_datetime='max_value',
+)
+def datetimes(
+    min_value=dt.datetime.min, max_value=dt.datetime.max,
+    timezones=none(),
+    min_datetime=None, max_datetime=None,
+):
     """A strategy for generating datetimes, which may be timezone-aware.
 
     This strategy works by drawing a naive datetime between ``min_datetime``
@@ -1270,67 +1278,88 @@ def datetimes(min_datetime=dt.datetime.min, max_datetime=dt.datetime.max,
     # more complex API for all users and a useful feature for very few.
     from hypothesis.searchstrategy.datetime import DatetimeStrategy
 
-    check_type(dt.datetime, min_datetime, 'min_datetime')
-    check_type(dt.datetime, max_datetime, 'max_datetime')
-    if min_datetime.tzinfo is not None:
-        raise InvalidArgument('min_datetime=%r must not have tzinfo'
-                              % (min_datetime,))
-    if max_datetime.tzinfo is not None:
-        raise InvalidArgument('max_datetime=%r must not have tzinfo'
-                              % (max_datetime,))
-    check_valid_interval(min_datetime, max_datetime,
-                         'min_datetime', 'max_datetime')
+    check_type(dt.datetime, min_value, 'min_value')
+    check_type(dt.datetime, max_value, 'max_value')
+    if min_value.tzinfo is not None:
+        raise InvalidArgument('min_value=%r must not have tzinfo'
+                              % (min_value,))
+    if max_value.tzinfo is not None:
+        raise InvalidArgument('max_value=%r must not have tzinfo'
+                              % (max_value,))
+    check_valid_interval(min_value, max_value,
+                         'min_value', 'max_value')
     if not isinstance(timezones, SearchStrategy):
         raise InvalidArgument(
             'timezones=%r must be a SearchStrategy that can provide tzinfo '
             'for datetimes (either None or dt.tzinfo objects)' % (timezones,))
-    return DatetimeStrategy(min_datetime, max_datetime, timezones)
+    return DatetimeStrategy(min_value, max_value, timezones)
 
 
 @defines_strategy
-def dates(min_date=dt.date.min, max_date=dt.date.max):
+@renamed_arguments(
+    min_date='min_value',
+    max_date='max_value',
+)
+def dates(
+    min_value=dt.date.min, max_value=dt.date.max,
+    min_date=None, max_date=None,
+):
     """A strategy for dates between ``min_date`` and ``max_date``."""
     from hypothesis.searchstrategy.datetime import DateStrategy
 
-    check_type(dt.date, min_date, 'min_date')
-    check_type(dt.date, max_date, 'max_date')
-    check_valid_interval(min_date, max_date, 'min_date', 'max_date')
-    if min_date == max_date:
-        return just(min_date)
-    return DateStrategy(min_date, max_date)
+    check_type(dt.date, min_value, 'min_value')
+    check_type(dt.date, max_value, 'max_value')
+    check_valid_interval(min_value, max_value, 'min_value', 'max_value')
+    if min_value == max_value:
+        return just(min_value)
+    return DateStrategy(min_value, max_value)
 
 
 @defines_strategy
-def times(min_time=dt.time.min, max_time=dt.time.max, timezones=none()):
+@renamed_arguments(
+    min_time='min_value',
+    max_time='max_value',
+)
+def times(
+    min_value=dt.time.min, max_value=dt.time.max, timezones=none(),
+    min_time=None, max_time=None,
+):
     """A strategy for times between ``min_time`` and ``max_time``.
 
     The ``timezones`` argument is handled as for :py:func:`datetimes`.
 
     """
-    check_type(dt.time, min_time, 'min_time')
-    check_type(dt.time, max_time, 'max_time')
-    if min_time.tzinfo is not None:
-        raise InvalidArgument('min_time=%r must not have tzinfo' % min_time)
-    if max_time.tzinfo is not None:
-        raise InvalidArgument('max_time=%r must not have tzinfo' % max_time)
-    check_valid_interval(min_time, max_time, 'min_time', 'max_time')
+    check_type(dt.time, min_value, 'min_value')
+    check_type(dt.time, max_value, 'max_value')
+    if min_value.tzinfo is not None:
+        raise InvalidArgument('min_value=%r must not have tzinfo' % min_value)
+    if max_value.tzinfo is not None:
+        raise InvalidArgument('max_value=%r must not have tzinfo' % max_value)
+    check_valid_interval(min_value, max_value, 'min_value', 'max_value')
     day = dt.date(2000, 1, 1)
-    return datetimes(min_datetime=dt.datetime.combine(day, min_time),
-                     max_datetime=dt.datetime.combine(day, max_time),
+    return datetimes(min_value=dt.datetime.combine(day, min_value),
+                     max_value=dt.datetime.combine(day, max_value),
                      timezones=timezones).map(lambda t: t.timetz())
 
 
 @defines_strategy
-def timedeltas(min_delta=dt.timedelta.min, max_delta=dt.timedelta.max):
-    """A strategy for timedeltas between ``min_delta`` and ``max_delta``."""
+@renamed_arguments(
+    min_delta='min_value',
+    max_delta='max_value',
+)
+def timedeltas(
+    min_value=dt.timedelta.min, max_value=dt.timedelta.max,
+    min_delta=None, max_delta=None
+):
+    """A strategy for timedeltas between ``min_value`` and ``max_value``."""
     from hypothesis.searchstrategy.datetime import TimedeltaStrategy
 
-    check_type(dt.timedelta, min_delta, 'min_delta')
-    check_type(dt.timedelta, max_delta, 'max_delta')
-    check_valid_interval(min_delta, max_delta, 'min_delta', 'max_delta')
-    if min_delta == max_delta:
-        return just(min_delta)
-    return TimedeltaStrategy(min_delta=min_delta, max_delta=max_delta)
+    check_type(dt.timedelta, min_value, 'min_value')
+    check_type(dt.timedelta, max_value, 'max_value')
+    check_valid_interval(min_value, max_value, 'min_value', 'max_value')
+    if min_value == max_value:
+        return just(min_value)
+    return TimedeltaStrategy(min_value=min_value, max_value=max_value)
 
 
 @cacheable

--- a/tests/cover/test_datetimes.py
+++ b/tests/cover/test_datetimes.py
@@ -24,6 +24,7 @@ from flaky import flaky
 
 from hypothesis import find, given, settings, unlimited
 from tests.common.debug import minimal
+from tests.common.utils import checks_deprecated_behaviour
 from hypothesis.strategies import none, dates, times, binary, datetimes, \
     timedeltas
 from hypothesis.strategytests import strategy_test_suite
@@ -40,7 +41,7 @@ def test_can_find_positive_delta():
 
 
 def test_can_find_negative_delta():
-    assert minimal(timedeltas(max_delta=dt.timedelta(10**6)),
+    assert minimal(timedeltas(max_value=dt.timedelta(10**6)),
                    lambda x: x.days < 0) == dt.timedelta(-1)
 
 
@@ -58,11 +59,11 @@ def test_simplifies_towards_zero_delta():
 
 
 def test_min_value_is_respected():
-    assert minimal(timedeltas(min_delta=dt.timedelta(days=10))).days == 10
+    assert minimal(timedeltas(min_value=dt.timedelta(days=10))).days == 10
 
 
 def test_max_value_is_respected():
-    assert minimal(timedeltas(max_delta=dt.timedelta(days=-10))).days == -10
+    assert minimal(timedeltas(max_value=dt.timedelta(days=-10))).days == -10
 
 
 @given(timedeltas())
@@ -128,11 +129,11 @@ def test_can_find_each_month():
 
 
 def test_min_year_is_respected():
-    assert minimal(dates(min_date=dt.date.min.replace(2003))).year == 2003
+    assert minimal(dates(min_value=dt.date.min.replace(2003))).year == 2003
 
 
 def test_max_year_is_respected():
-    assert minimal(dates(max_date=dt.date.min.replace(1998))).year == 1998
+    assert minimal(dates(max_value=dt.date.min.replace(1998))).year == 1998
 
 
 @given(dates())
@@ -171,3 +172,8 @@ def test_can_generate_naive_time():
 @given(times())
 def test_naive_times_are_naive(dt):
     assert dt.tzinfo is None
+
+
+@checks_deprecated_behaviour
+def test_deprecated_min_date_is_respected():
+    assert minimal(dates(min_date=dt.date.min.replace(2003))).year == 2003

--- a/tests/datetime/test_timezones.py
+++ b/tests/datetime/test_timezones.py
@@ -53,7 +53,7 @@ def test_timezone_aware_datetimes_are_timezone_aware(dt):
     assert dt.tzinfo is not None
 
 
-@given(sampled_from(['min_datetime', 'max_datetime']),
+@given(sampled_from(['min_value', 'max_value']),
        datetimes(timezones=timezones()))
 def test_datetime_bounds_must_be_naive(name, val):
     with pytest.raises(InvalidArgument):
@@ -62,14 +62,14 @@ def test_datetime_bounds_must_be_naive(name, val):
 
 def test_underflow_in_simplify():
     # we shouldn't trigger a pytz bug when we're simplifying
-    minimal(datetimes(max_datetime=dt.datetime.min + dt.timedelta(days=3),
+    minimal(datetimes(max_value=dt.datetime.min + dt.timedelta(days=3),
                       timezones=timezones()),
             lambda x: x.tzinfo != pytz.UTC)
 
 
 def test_overflow_in_simplify():
     # we shouldn't trigger a pytz bug when we're simplifying
-    minimal(datetimes(min_datetime=dt.datetime.max - dt.timedelta(days=3),
+    minimal(datetimes(min_value=dt.datetime.max - dt.timedelta(days=3),
                       timezones=timezones()),
             lambda x: x.tzinfo != pytz.UTC)
 
@@ -93,7 +93,7 @@ def test_can_generate_non_utc():
     ).example()
 
 
-@given(sampled_from(['min_time', 'max_time']), times(timezones=timezones()))
+@given(sampled_from(['min_value', 'max_value']), times(timezones=timezones()))
 def test_time_bounds_must_be_naive(name, val):
     with pytest.raises(InvalidArgument):
         times(**{name: val}).example()


### PR DESCRIPTION
So as part of #811 I realised that argument naming conventions in the new date and time strategies were inconsistent with other strategies in hypothesis.strategies, and in the spirit of #812 I thought I'd fix that so that the bounds were all `min_value` and `max_value`.

This takes the slightly unprecedented for Hypothesis step of making a change to a function signature that isn't just appending something to the end, however I believe it to be fully backwards compatible.

The cases we have to worry about:

* An argument may be passed positionally. This is fine: It goes to the new, non-deprecated, argument which has an identical function to the old argument in that position.
* An argument may be passed as a keyword, in which case it is passed to the old, deprecated, argument.