### PR TITLE
Remove debugging stack trace

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This release fixes a bug where test failures that were the result of
+an @example would print an extra stack trace before re-raising the
+exception.

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -245,7 +245,6 @@ def execute_explicit_examples(
                     lambda data: test(*arguments, **example_kwargs)
                 )
         except BaseException:
-            traceback.print_exc()
             report('Falsifying example: ' + example_string)
             for n in b.notes:
                 report(n)


### PR DESCRIPTION
Apparently when an `@example` fails it prints and extra traceback for no obviously good reason. It looks like this is some debugging code I put in there two years ago in 7f0768ad4b66c4eede439754bd98b5ddb5f47f71 and nobody has complained about it since.

Note: I haven't added and tests for this, because I'm a little unsure what a meaningful test for it that would actually catch other problems is. Maybe the right test is to add a line to the review guide that suggests looking for stray debugging code? But we're pretty good at that anyway and this predates our review process by some time.

(This PR also serves as a useful demonstration of the problem with our release process for Github support staff)