### PR TITLE
Speculative attempt to fix recursion errors in tests

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This release will fix some extremely specific circumstances that probably have
+never occurred in the wild where users of
+:func:`~hypothesis.searchstrategy.deferred` might have seen a RuntimeError from
+too much recursion, usually in cases where no valid example could have been
+generated anyway.

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,6 +1,6 @@
 RELEASE_TYPE: patch
 
-This release will fix some extremely specific circumstances that probably have
+This release fixes some extremely specific circumstances that probably have
 never occurred in the wild where users of
 :func:`~hypothesis.searchstrategy.deferred` might have seen a RuntimeError from
 too much recursion, usually in cases where no valid example could have been

--- a/src/hypothesis/searchstrategy/deferred.py
+++ b/src/hypothesis/searchstrategy/deferred.py
@@ -83,4 +83,4 @@ class DeferredStrategy(SearchStrategy):
             )
 
     def do_draw(self, data):
-        return self.wrapped_strategy.do_draw(data)
+        return data.draw(self.wrapped_strategy)

--- a/src/hypothesis/searchstrategy/recursive.py
+++ b/src/hypothesis/searchstrategy/recursive.py
@@ -46,7 +46,7 @@ class LimitedStrategy(SearchStrategy):
         if self.marker <= 0:
             raise LimitReached()
         self.marker -= 1
-        return self.base_strategy.do_draw(data)
+        return data.draw(self.base_strategy)
 
     @contextmanager
     def capped(self, max_templates):

--- a/src/hypothesis/searchstrategy/shared.py
+++ b/src/hypothesis/searchstrategy/shared.py
@@ -44,5 +44,5 @@ class SharedStrategy(SearchStrategy):
         sharing = getattr(data, SHARED_STRATEGY_ATTRIBUTE)
         key = self.key or self
         if key not in sharing:
-            sharing[key] = self.base.do_draw(data)
+            sharing[key] = data.draw(self.base)
         return sharing[key]

--- a/src/hypothesis/searchstrategy/strategies.py
+++ b/src/hypothesis/searchstrategy/strategies.py
@@ -277,7 +277,7 @@ class OneOfStrategy(SearchStrategy):
         if n == 0:
             data.mark_invalid()
         elif n == 1:
-            return self.element_strategies[0].do_draw(data)
+            return data.draw(self.element_strategies[0])
         elif self.sampler is None:
             i = cu.integer_range(data, 0, n - 1)
         else:
@@ -343,7 +343,7 @@ class MappedSearchStrategy(SearchStrategy):
         for _ in range(3):
             i = data.index
             try:
-                return self.pack(self.mapped_strategy.do_draw(data))
+                return self.pack(data.draw(self.mapped_strategy))
             except UnsatisfiedAssumption:
                 if data.index == i:
                     raise

--- a/src/hypothesis/searchstrategy/wrappers.py
+++ b/src/hypothesis/searchstrategy/wrappers.py
@@ -47,4 +47,4 @@ class WrapperStrategy(SearchStrategy):
         self.wrapped_strategy.validate()
 
     def do_draw(self, data):
-        return self.wrapped_strategy.do_draw(data)
+        return data.draw(self.wrapped_strategy)


### PR DESCRIPTION
This is an attempt at #799. It's not a very good attempt, but I think it will work.

You will note the absence of tests. This is because based on a bunch of investigation just now, this is a *really* hard problem to reproduce. I've not been able to get a test to reliably reproduce the problem despite some trying.

Based on this I'm 99% certain that the reason for this is that this is not an infinite recursion error, just a lots recursion error, and the difficulty with reproducing comes from there being less on the stack when I try, but working around that is fiddly.

Based on further investigation of what is on the stack at the time of this happening, I came to the conclusion that the reason this was happening is that in some highly specific circumstances we call `do_draw` directly rather than going through `draw`. This means that we're putting a bunch of extra stack frames in there without incrementing the depth counter on the data object. This means that since #756 raised the max depth, we sometimes put enough on the stack that we overflow the recursion limit.

So this PR just implements plan "don't do that then" and replaces the `do_draw` calls with draw calls. I've been running the flaky test from #799 in a loop for a while now and haven't seen any failures of it, so I'm reasonably confident that this works despite the absence of testing.