### PR TITLE
Fix #817

### DIFF
--- a/tests/nocover/test_choices.py
+++ b/tests/nocover/test_choices.py
@@ -18,7 +18,7 @@
 from __future__ import division, print_function, absolute_import
 
 import hypothesis.strategies as st
-from hypothesis import given, settings
+from hypothesis import given, settings, unlimited
 from tests.common.utils import raises, capture_out, \
     checks_deprecated_behaviour
 from hypothesis.database import ExampleDatabase
@@ -32,7 +32,7 @@ def test_stability():
         st.choices(),
     )
     @settings(
-        database=ExampleDatabase(), max_shrinks=10**6,
+        database=ExampleDatabase(), max_shrinks=10**6, timeout=unlimited,
     )
     def test_choose_and_then_fail(ls, choice):
         for _ in hrange(100):

--- a/tests/nocover/test_choices.py
+++ b/tests/nocover/test_choices.py
@@ -28,7 +28,7 @@ from hypothesis.internal.compat import hrange
 @checks_deprecated_behaviour
 def test_stability():
     @given(
-        st.lists(st.text(min_size=1, max_size=1), unique=True, min_size=5),
+        st.lists(st.integers(0, 1000), unique=True, min_size=5),
         st.choices(),
     )
     @settings(

--- a/tests/nocover/test_choices.py
+++ b/tests/nocover/test_choices.py
@@ -32,7 +32,7 @@ def test_stability():
         st.choices(),
     )
     @settings(
-        database=ExampleDatabase(),
+        database=ExampleDatabase(), max_shrinks=10**6,
     )
     def test_choose_and_then_fail(ls, choice):
         for _ in hrange(100):


### PR DESCRIPTION
This test has become flaky. It turns out the reason for this is that the shrinker has become slightly slower for this case (which is mostly expected - the recent improvements to example quality have come at some cost to shrink speed), so what was happening is that sometimes the first time the test ran it would not quite finish shrinking, the the second time when it fetched it from the database it would successfully shrink further.

This PR fixes that by giving it the ability to always finish its shrinking. While I'm there, it also makes the elements being used easier to shrink, because there's no point in making them difficulty here.

This fixes #817 