### PR TITLE
Fix RST errors in changelog

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -27,7 +27,7 @@ information to the contrary.
 
 This release fixes some minor bugs in argument validation:
 
-    * `hypothesis.extra.numpy <hypothesis-numpy>` dtype strategies would raise an internal error
+    * :ref:`hypothesis.extra.numpy <hypothesis-numpy>` dtype strategies would raise an internal error
       instead of an InvalidArgument exception when passed an invalid
       endianness specification.
     * :func:`~hypothesis.strategies.fractions` would raise an internal error instead of an InvalidArgument
@@ -61,7 +61,7 @@ by using :func:`simplefilter('error', HypothesisDeprecationWarning) <python:warn
 -------------------
 
 This release renames the relevant arguments on the
-:func:`~hypothesis.strategies.datetimes`, func:`~hypothesis.strategies.dates`,
+:func:`~hypothesis.strategies.datetimes`, :func:`~hypothesis.strategies.dates`,
 func:`~hypothesis.strategies.times`, and func:`~hypothesis.strategies.timedeltas`
 strategies to ``min_value`` and ``max_value``, to make them consistent with the
 other strategies in the module.
@@ -79,7 +79,7 @@ handles shrinking.
 
 This should mostly be visible in terms of getting better examples for tests
 which make heavy use of :func:`~hypothesis.strategies.composite`,
-:ref`data <interactive-draw>` or :ref`flatmap <flatmap>` where the data
+:ref:`data <interactive-draw>` or :ref:`flatmap <flatmap>` where the data
 drawn depends a lot on previous choices, especially where size parameters are
 affected. Previously Hypothesis would have struggled to reliably produce
 good examples here. Now it should do much better. Performance should also be

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -86,6 +86,8 @@ wanted pairs of integers (x,y) such that x < y you could do the following:
   ... lambda x: tuple(sorted(x))).filter(lambda x: x[0] != x[1]).example()
   (180, 241)
 
+.. _flatmap:
+
 ----------------------------
 Chaining strategies together
 ----------------------------

--- a/guides/review.rst
+++ b/guides/review.rst
@@ -107,9 +107,11 @@ src then it counts.
    the second (minor) for things that do but are backwards compatible, and
    the first (major) changes for things that aren't backwards compatible.
    See the section on API changes for the latter two.
-5. The changelog should be kept up to date, clearly describing the change
-   and including the current date (remember: This will be released as soon
-   as it's merged).
+5. The changelog should be kept up to date by creating a RELEASE.rst file in
+   the root of the repository. Make sure you build the documentation and
+   manually inspect the resulting changelog to see that it looks good - there
+   are a lot of syntax mistakes possible in RST that don't result in a
+   compilation error.
 
 ~~~~~~~~~~~
 API Changes

--- a/scripts/build-documentation.sh
+++ b/scripts/build-documentation.sh
@@ -11,9 +11,10 @@ HERE="$(dirname "$0")"
 
 cd "$HERE"/..
 
-trap "git checkout docs/changes.rst src/hypothesis/version.py" EXIT
-
-$PYTHON scripts/update-changelog-for-docs.py
+if [ -e RELEASE.rst ] ; then
+    trap "git checkout docs/changes.rst src/hypothesis/version.py" EXIT
+    $PYTHON scripts/update-changelog-for-docs.py
+fi
 
 export PYTHONPATH=src 
 


### PR DESCRIPTION
A bunch of broken refs and funcs have snuck in over the last couple of releases (almost entirely my fault I think but I haven't checked). This PR does three things:

1. Fix the specific mistakes we've made.
2. Fix the documentation building so that it doesn't try to undo your changes while you're editing the changelog (or, rather, so that it doesn't if you don't have a release file).
3. Update the review guide to highlight this issue and recommend manual inspection.