### PR TITLE
Add unique flag to arrays

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,6 @@ $(PYPY):
 	scripts/retry.sh scripts/install.sh pypy
 
 $(TOOL_VIRTUALENV): $(BEST_PY3)
-	rm -rf $(BUILD_RUNTIMES)/virtualenvs/tools-*
 	$(BEST_PY3) -m virtualenv $(TOOL_VIRTUALENV)
 	$(TOOL_PIP) install -r requirements/tools.txt
 

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: minor
+
+This release adds a ``unique`` argument to :func:`~hypothesis.extra.numpy.arrays`
+which behaves the same ways as the corresponding one for
+:func:`~hypothesis.strategies.lists`, requiring all of the elements in the
+generated array to be distinct.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,6 +68,7 @@ todo_include_todos = False
 
 intersphinx_mapping = {
     'python': ('http://docs.python.org/3/', None),
+    'numpy': ('http://docs.scipy.org/doc/numpy/', None),
 }
 
 autodoc_mock_imports = ['numpy']

--- a/src/hypothesis/extra/numpy.py
+++ b/src/hypothesis/extra/numpy.py
@@ -211,26 +211,31 @@ def arrays(
     draw, dtype, shape, elements=None, fill=None, unique=False
 ):
     """
+    Returns a strategy for generating
+    :class:`numpy's ndarrays <numpy.ndarray>`.
 
-        * `dtype` may be any valid input to ``np.dtype`` (this includes
-          ``np.dtype`` objects), or a strategy that generates such values.
-        * `shape` may be an integer >= 0, a tuple of length >= of such integers
-          or a strategy that generates such values.
-        * `elements` is a strategy for generating values to put in the array.
-          If it is None a suitable value will be inferred based on the dtype,
-          which may give any legal value (including eg ``NaN`` for floats).
-          If you have more specific requirements, you should supply your own
-          elements strategy.
-        * `fill` is a strategy that may be used to generate a single background
-          value for the array. If None a suitable default will be inferred
-          based on the other arguments. If set to ``st.nothing()`` the fill
-          behaviour will be disabled entirely.
-        * `unique` specifies if the elements of the array should all be
-          distinct from one another. Note that in this case multiple NaN values
-          may still be allowed. If fill is also set, the only valid values for
-          it to return are NaN values (anything for which np.isnan returns
-          True. So e.g. for complex numbers (nan+1j) is a valid fill). Note
-          that if unique is set to True the generated values must be hashable
+    * ``dtype`` may be any valid input to :class:`numpy.dtype <numpy.dtype>`
+      (this includes ``dtype`` objects), or a strategy that generates such
+      values.
+    * `shape` may be an integer >= 0, a tuple of length >= 0 of such
+      integers, or a strategy that generates such values.
+    * `elements` is a strategy for generating values to put in the array.
+      If it is None a suitable value will be inferred based on the dtype,
+      which may give any legal value (including eg ``NaN`` for floats).
+      If you have more specific requirements, you should supply your own
+      elements strategy.
+    * `fill` is a strategy that may be used to generate a single background
+      value for the array. If None, a suitable default will be inferred
+      based on the other arguments. If set to
+      :func:`st.nothing() <hypothesis.strategies.nothing>` behaviour will be
+      disabled entirely.
+    * `unique` specifies if the elements of the array should all be
+      distinct from one another. Note that in this case multiple NaN values
+      may still be allowed. If fill is also set, the only valid values for
+      it to return are NaN values (anything for which
+      :func:`numpy.isnan <numpy.isnan>` returns True. So e.g. for complex
+      numbers (nan+1j) is also a valid fill). Note that if unique is set to
+      True the generated values must be hashable.
 
     Arrays of specified `dtype` and `shape` are generated for example
     like this:

--- a/src/hypothesis/extra/numpy.py
+++ b/src/hypothesis/extra/numpy.py
@@ -210,8 +210,8 @@ class ArrayStrategy(SearchStrategy):
 def arrays(
     draw, dtype, shape, elements=None, fill=None, unique=False
 ):
-    """
-    Returns a strategy for generating
+    """Returns a strategy for generating.
+
     :class:`numpy's ndarrays <numpy.ndarray>`.
 
     * ``dtype`` may be any valid input to :class:`numpy.dtype <numpy.dtype>`

--- a/src/hypothesis/extra/numpy.py
+++ b/src/hypothesis/extra/numpy.py
@@ -210,9 +210,8 @@ class ArrayStrategy(SearchStrategy):
 def arrays(
     draw, dtype, shape, elements=None, fill=None, unique=False
 ):
-    """Returns a strategy for generating.
-
-    :class:`numpy's ndarrays <numpy.ndarray>`.
+    """Returns a strategy for generating :class:`numpy's
+    ndarrays<numpy.ndarray>`.
 
     * ``dtype`` may be any valid input to :class:`numpy.dtype <numpy.dtype>`
       (this includes ``dtype`` objects), or a strategy that generates such
@@ -227,8 +226,9 @@ def arrays(
     * `fill` is a strategy that may be used to generate a single background
       value for the array. If None, a suitable default will be inferred
       based on the other arguments. If set to
-      :func:`st.nothing() <hypothesis.strategies.nothing>` behaviour will be
-      disabled entirely.
+      :func:`st.nothing() <hypothesis.strategies.nothing>` then filling
+      behaviour will be disabled entirely and every element will be generated
+      independently.
     * `unique` specifies if the elements of the array should all be
       distinct from one another. Note that in this case multiple NaN values
       may still be allowed. If fill is also set, the only valid values for

--- a/tests/numpy/test_gen_data.py
+++ b/tests/numpy/test_gen_data.py
@@ -238,10 +238,31 @@ def test_may_fill_with_nan_when_unique_is_set():
     )
 
 
+def test_is_still_unique_with_nan_fill():
+    @given(nps.arrays(
+           dtype=float, elements=st.floats(allow_nan=False), shape=10,
+           unique=True, fill=st.just(float('nan'))))
+    def test(xs):
+        assert len(set(xs)) == len(xs)
+
+    test()
+
+
 def test_may_not_fill_with_non_nan_when_unique_is_set():
     @given(nps.arrays(
         dtype=float, elements=st.floats(allow_nan=False), shape=10,
         unique=True, fill=st.just(0.0)))
+    def test(arr):
+        pass
+
+    with pytest.raises(InvalidArgument):
+        test()
+
+
+def test_may_not_fill_with_non_nan_when_unique_is_set_and_type_is_not_number():
+    @given(nps.arrays(
+        dtype=bytes, shape=10,
+        unique=True, fill=st.just(b'')))
     def test(arr):
         pass
 


### PR DESCRIPTION
As part of #785 I'm doing a bunch of work with uniqueness.  I realised it would be *much* easier if the underlying numpy strategies supported uniqueness and would let me push some complexity down a level.

So this PR implements that. It adds a `unique` flag to the arrays strategy which behaves identically to the corresponding flag for `lists`.

Things to note:

* If a user sets `unique=True` given a non-hashable type, they will see a raw `TypeError`. Given that all of the common numpy types are hashable and the same is currently true for lists, I don't have a huge problem with this.
* It doesn't currently allow `unique_by` as lists do. I figured the use case for that was much less obvious with numpy arrays, but we could easily add it if desired.