### PR TITLE
Don't throw a TypeError if renaming args in a function with no docstring

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,6 +1,5 @@
 RELEASE_TYPE: patch
 
-This release fixes an issue where the decorator used to rename arguments could
-throw a ``TypeError`` if used on a function without a docstring.  This was
-causing issues in the pytest build system (see :issue:`822`), but in practice
-most users should see no change.
+This release fixes an issue where Hypothesis would raise a ``TypeError`` when
+using the datetime-related strategies if running with ``PYTHONOPTIMIZE=2``.
+This bug was introduced in v3.20.0.  (See :issue:`822`)

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This release fixes an issue where the decorator used to rename arguments could
+throw a ``TypeError`` if used on a function without a docstring.  This was
+causing issues in the pytest build system (see :issue:`822`), but in practice
+most users should see no change.

--- a/src/hypothesis/internal/renaming.py
+++ b/src/hypothesis/internal/renaming.py
@@ -39,21 +39,28 @@ def renamed_arguments(**rename_mapping):
                     kwargs[t] = kwargs.pop(k)
             return f(**kwargs)
 
-        if with_name_check.__doc__ is None:
-            with_name_check.__doc__ = ''
+        # This decorates things in the public API, which all have docstrings.
+        # (If they're not in the public API, we don't need a deprecation path.)
+        # But docstrings are stripped when running with PYTHONOPTIMIZE=2.
+        #
+        # If somebody's running with that flag, they don't expect any
+        # docstrings to be present, so this message isn't useful.  Absence of
+        # a docstring is a strong indicator that they're running in this mode,
+        # so skip adding this message if that's the case.
+        if with_name_check.__doc__ is not None:
+            with_name_check.__doc__ += '\n'.join((
+                '', '',
+                'The following arguments have been renamed:',
+                '',
+            ) + tuple(
+                '  * %s has been renamed to %s' % s
+                for s in rename_mapping.items()
+            ) + (
+                '',
+                'Use of the old names has been deprecated and will be removed',
+                'in a future version of Hypothesis.'
+            )
+            )
 
-        with_name_check.__doc__ += '\n'.join((
-            '', '',
-            'The following arguments have been renamed:',
-            '',
-        ) + tuple(
-            '  * %s has been renamed to %s' % s
-            for s in rename_mapping.items()
-        ) + (
-            '',
-            'Use of the old names has been deprecated and will be removed',
-            'in a future version of Hypothesis.'
-        )
-        )
         return with_name_check
     return accept

--- a/src/hypothesis/internal/renaming.py
+++ b/src/hypothesis/internal/renaming.py
@@ -39,6 +39,9 @@ def renamed_arguments(**rename_mapping):
                     kwargs[t] = kwargs.pop(k)
             return f(**kwargs)
 
+        if with_name_check.__doc__ is None:
+            with_name_check.__doc__ = ''
+
         with_name_check.__doc__ += '\n'.join((
             '', '',
             'The following arguments have been renamed:',

--- a/tests/cover/test_renaming.py
+++ b/tests/cover/test_renaming.py
@@ -22,7 +22,7 @@ from hypothesis.internal.renaming import renamed_arguments
 
 def test_can_rename_arguments_in_a_function_with_no_docstring():
     @renamed_arguments(old_arg='new_arg')
-    def f(old_arg, new_arg):
+    def f(new_arg, old_arg):
         return new_arg
 
     new_arg = 'Hello world'

--- a/tests/cover/test_renaming.py
+++ b/tests/cover/test_renaming.py
@@ -22,7 +22,7 @@ from hypothesis.internal.renaming import renamed_arguments
 
 def test_can_rename_arguments_in_a_function_with_no_docstring():
     @renamed_arguments(old_arg='new_arg')
-    def f(new_arg, old_arg):
+    def f(new_arg=None, old_arg=None):
         return new_arg
 
     new_arg = 'Hello world'

--- a/tests/cover/test_renaming.py
+++ b/tests/cover/test_renaming.py
@@ -22,7 +22,7 @@ from hypothesis.internal.renaming import renamed_arguments
 
 def test_can_rename_arguments_in_a_function_with_no_docstring():
     @renamed_arguments(old_arg='new_arg')
-    def f(new_arg):
+    def f(old_arg, new_arg):
         return new_arg
 
     new_arg = 'Hello world'

--- a/tests/cover/test_renaming.py
+++ b/tests/cover/test_renaming.py
@@ -26,5 +26,6 @@ def test_can_rename_arguments_in_a_function_with_no_docstring():
         return new_arg
 
     new_arg = 'Hello world'
+    assert f(old_arg=new_arg) == new_arg
     assert f(new_arg=new_arg) == new_arg
     assert f.__doc__ is None

--- a/tests/cover/test_renaming.py
+++ b/tests/cover/test_renaming.py
@@ -23,6 +23,8 @@ from hypothesis.internal.renaming import renamed_arguments
 def test_can_rename_arguments_in_a_function_with_no_docstring():
     @renamed_arguments(old_arg='new_arg')
     def f(new_arg):
-        print('The value of new_arg is %r' % new_arg)
+        return new_arg
 
-    f('Hello world')
+    new_arg = 'Hello world'
+    assert f(new_arg=new_arg) == new_arg
+    assert f.__doc__ is None

--- a/tests/cover/test_renaming.py
+++ b/tests/cover/test_renaming.py
@@ -17,15 +17,23 @@
 
 from __future__ import division, print_function, absolute_import
 
+from tests.common.utils import checks_deprecated_behaviour
 from hypothesis.internal.renaming import renamed_arguments
 
 
-def test_can_rename_arguments_in_a_function_with_no_docstring():
-    @renamed_arguments(old_arg='new_arg')
-    def f(new_arg=None, old_arg=None):
-        return new_arg
+@renamed_arguments(old_arg='new_arg')
+def f(new_arg=None, old_arg=None):
+    return new_arg
 
-    new_arg = 'Hello world'
-    assert f(old_arg=new_arg) == new_arg
+
+def test_using_new_args():
+    new_arg = 'A number of numbats at night'
     assert f(new_arg=new_arg) == new_arg
+    assert f.__doc__ is None
+
+
+@checks_deprecated_behaviour
+def test_using_old_args():
+    old_arg = 'An order of otters on the Ouse'
+    assert f(old_arg=old_arg) == old_arg
     assert f.__doc__ is None

--- a/tests/cover/test_renaming.py
+++ b/tests/cover/test_renaming.py
@@ -1,0 +1,28 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2017 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+from hypothesis.internal.renaming import renamed_arguments
+
+
+def test_can_rename_arguments_in_a_function_with_no_docstring():
+    @renamed_arguments(old_arg='new_arg')
+    def f(new_arg):
+        print('The value of new_arg is %r' % new_arg)
+
+    f('Hello world')


### PR DESCRIPTION
I’m a little surprised this code doesn’t have any tests around it (or if it does, I couldn’t find any).

Anyway, resolves #822.