### PR TITLE
Remove vestigial distribution parameter

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This is a small refactoring release that removes a now-unused parameter to an
+internal API. It shouldn't have any user visible effect.

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -51,7 +51,7 @@ from hypothesis.internal.conjecture.data import Status, StopTest, \
     ConjectureData
 from hypothesis.searchstrategy.strategies import SearchStrategy
 from hypothesis.internal.conjecture.engine import ExitReason, \
-    ConjectureRunner
+    ConjectureRunner, uniform
 
 
 def new_random():
@@ -286,8 +286,7 @@ def perform_health_checks(random, settings, test_runner, search_strategy):
     # of loading unicode data the first time.
     data = ConjectureData(
         max_length=settings.buffer_size,
-        draw_bytes=lambda data, n, distribution:
-        distribution(health_check_random, n)
+        draw_bytes=lambda data, n: uniform(health_check_random, n)
     )
     with Settings(settings, verbosity=Verbosity.quiet):
         try:
@@ -308,8 +307,7 @@ def perform_health_checks(random, settings, test_runner, search_strategy):
         try:
             data = ConjectureData(
                 max_length=settings.buffer_size,
-                draw_bytes=lambda data, n, distribution:
-                distribution(health_check_random, n)
+                draw_bytes=lambda data, n: uniform(health_check_random, n)
             )
             with Settings(settings, verbosity=Verbosity.quiet):
                 test_runner(data, reify_and_execute(


### PR DESCRIPTION
This finishes off something I probably should have done in #710, which is to remove the distribution parameter altogether from the ConjectureData side.

This shouldn't have any impact on behaviour. We were effectively always passing 'uniform' as this parameter, so I've now just removed the parameter and replaced its usage with uniform everywhere.