### PR TITLE
Don't propagate settings into strategy definitions

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,25 @@
+RELEASE_TYPE: patch
+
+Hypothesis no longer propagates the dynamic scope of settings into strategy
+definitions.
+
+This release is a small change to something that was never part of the public
+API and you will almost certainly not notice any effect unless you're doing
+something surprising, but for example the following code will now give a
+different answer in some circumstances:
+
+.. code-block:: python
+
+    import hypothesis.strategies as st
+    from hypothesis import settings
+
+    CURRENT_SETTINGS = st.builds(lambda: settings.default)
+
+(We don't actually encourage you writing code like this)
+
+Previously this would have generated the settings that were in effect at the
+point of definition of ``CURRENT_SETTINGS``. Now it will generate the settings
+that are used for the current test.
+
+It is very unlikely to be significant enough to be visible, but you may also
+notice a small performance improvement.

--- a/src/hypothesis/searchstrategy/lazy.py
+++ b/src/hypothesis/searchstrategy/lazy.py
@@ -17,7 +17,6 @@
 
 from __future__ import division, print_function, absolute_import
 
-from hypothesis import settings
 from hypothesis.internal.compat import hrange, getfullargspec
 from hypothesis.internal.reflection import arg_string, \
     convert_keyword_arguments, convert_positional_arguments
@@ -80,7 +79,6 @@ class LazyStrategy(SearchStrategy):
         self.__kwargs = dict(
             (k, tupleize(v)) for k, v in kwargs.items()
         )
-        self.__settings = settings.default or settings()
 
     @property
     def supports_find(self):
@@ -95,30 +93,29 @@ class LazyStrategy(SearchStrategy):
     @property
     def wrapped_strategy(self):
         if self.__wrapped_strategy is None:
-            with self.__settings:
-                unwrapped_args = tuple(
-                    unwrap_strategies(s) for s in self.__args)
-                unwrapped_kwargs = {
-                    k: unwrap_strategies(v)
-                    for k, v in self.__kwargs.items()
-                }
+            unwrapped_args = tuple(
+                unwrap_strategies(s) for s in self.__args)
+            unwrapped_kwargs = {
+                k: unwrap_strategies(v)
+                for k, v in self.__kwargs.items()
+            }
 
-                base = self.__function(
-                    *self.__args, **self.__kwargs
-                )
-                if (
-                    unwrapped_args == self.__args and
-                    unwrapped_kwargs == self.__kwargs
-                ):
-                    self.__wrapped_strategy = base
-                else:
-                    self.__wrapped_strategy = self.__function(
-                        *unwrapped_args,
-                        **unwrapped_kwargs)
-                    self.__wrapped_strategy.force_has_reusable_values = \
-                        base.has_reusable_values
-                    assert self.__wrapped_strategy.has_reusable_values == \
-                        base.has_reusable_values
+            base = self.__function(
+                *self.__args, **self.__kwargs
+            )
+            if (
+                unwrapped_args == self.__args and
+                unwrapped_kwargs == self.__kwargs
+            ):
+                self.__wrapped_strategy = base
+            else:
+                self.__wrapped_strategy = self.__function(
+                    *unwrapped_args,
+                    **unwrapped_kwargs)
+                self.__wrapped_strategy.force_has_reusable_values = \
+                    base.has_reusable_values
+                assert self.__wrapped_strategy.has_reusable_values == \
+                    base.has_reusable_values
         return self.__wrapped_strategy
 
     def do_validate(self):

--- a/tests/cover/test_settings.py
+++ b/tests/cover/test_settings.py
@@ -22,7 +22,8 @@ from tempfile import mkdtemp
 
 import pytest
 
-import hypothesis
+import hypothesis.strategies as st
+from hypothesis import given, unlimited
 from hypothesis.errors import InvalidState, InvalidArgument, \
     HypothesisDeprecationWarning
 from tests.common.utils import checks_deprecated_behaviour
@@ -157,7 +158,7 @@ def test_loading_profile_keeps_expected_behaviour():
 
 
 def test_load_non_existent_profile():
-    with pytest.raises(hypothesis.errors.InvalidArgument):
+    with pytest.raises(InvalidArgument):
         settings.get_profile('nonsense')
 
 
@@ -190,7 +191,7 @@ def test_set_deprecated_settings():
 
 
 def test_setting_to_future_value_gives_future_value_and_no_error():
-    assert settings(timeout=hypothesis.unlimited).timeout == -1
+    assert settings(timeout=unlimited).timeout == -1
 
 
 def test_cannot_set_settings():
@@ -233,3 +234,9 @@ def test_does_not_warn_if_quiet():
     with pytest.warns(None) as rec:
         note_deprecation('This is bad', settings(verbosity=Verbosity.quiet))
     assert len(rec) == 0
+
+
+@settings(max_examples=7)
+@given(st.builds(lambda: settings.default))
+def test_settings_in_strategies_are_from_test_scope(s):
+    assert s.max_examples == 7


### PR DESCRIPTION
Our LazyStrategy definition captures the current settings object and propagates it to when it's evaluated. This is mostly a vestigial thing where settings *used* to affect the individual strategies by controlling defaults but no longer does.

I tried to do this a while ago in part of a past pull request (I forget which. One of the deprecation ones I think) and wound up in a complete mess because the strict setting mattered for what happened with deprecation warnings in strategies. But we no longer have strict mode as of #728, so that should no longer matter and we can now remove this.