### PR TITLE
Emit deprecation warnings on misuse of example

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: minor
+
+Hypothesis now emits deprecation warnings if you use example() inside a
+test function or strategy definition (this was never intended to be supported,
+but is sufficiently widespread that it warrants a deprecation path).

--- a/src/hypothesis/searchstrategy/strategies.py
+++ b/src/hypothesis/searchstrategy/strategies.py
@@ -142,7 +142,7 @@ class SearchStrategy(object):
         """
         context = _current_build_context.value
         if context is not None:
-            if context.data.depth > 0:
+            if context.data is not None and context.data.depth > 0:
                 note_deprecation(
                     'Using example() inside a strategy definition is a bad '
                     'idea. It will become an error in a future version of '

--- a/src/hypothesis/searchstrategy/strategies.py
+++ b/src/hypothesis/searchstrategy/strategies.py
@@ -20,7 +20,8 @@ from __future__ import division, print_function, absolute_import
 import hypothesis.internal.conjecture.utils as cu
 from hypothesis.errors import NoExamples, NoSuchExample, Unsatisfiable, \
     UnsatisfiedAssumption
-from hypothesis.control import assume, reject
+from hypothesis.control import assume, reject, _current_build_context
+from hypothesis._settings import note_deprecation
 from hypothesis.internal.compat import hrange
 from hypothesis.internal.lazyformat import lazyformat
 from hypothesis.internal.reflection import get_pretty_function_description
@@ -139,6 +140,34 @@ class SearchStrategy(object):
         This method is part of the public API.
 
         """
+        context = _current_build_context.value
+        if context is not None:
+            if context.data.depth > 0:
+                note_deprecation(
+                    'Using example() inside a strategy definition is a bad '
+                    'idea. It will become an error in a future version of '
+                    "Hypothesis, but it's unlikely that it's doing what you "
+                    'intend even now. Instead consider using '
+                    'hypothesis.strategies.builds() or '
+                    '@hypothesis.strategies.composite to define your strategy.'
+                    ' See '
+                    'https://hypothesis.readthedocs.io/en/latest/data.html'
+                    '#hypothesis.strategies.builds or '
+                    'https://hypothesis.readthedocs.io/en/latest/data.html'
+                    '#composite-strategies for more details.'
+                )
+            else:
+                note_deprecation(
+                    'Using example() inside a test function is a bad '
+                    'idea. It will become an error in a future version of '
+                    "Hypothesis, but it's unlikely that it's doing what you "
+                    'intend even now. Instead consider using '
+                    'hypothesis.strategies.data() to draw '
+                    'more examples during testing. See '
+                    'https://hypothesis.readthedocs.io/en/latest/data.html'
+                    '#drawing-interactively-in-tests for more details.'
+                )
+
         from hypothesis import find, settings, Verbosity
         try:
             return find(

--- a/tests/common/debug.py
+++ b/tests/common/debug.py
@@ -69,8 +69,8 @@ def find_any(
 ):
     settings = Settings(
         settings,
-        max_examples=1000,
-        max_iterations=1000,
+        max_examples=10000,
+        max_iterations=10000,
         max_shrinks=0000,
         database=None,
     )

--- a/tests/cover/test_datetimes.py
+++ b/tests/cover/test_datetimes.py
@@ -23,7 +23,7 @@ import pytest
 from flaky import flaky
 
 from hypothesis import find, given, settings, unlimited
-from tests.common.debug import minimal
+from tests.common.debug import minimal, find_any
 from tests.common.utils import checks_deprecated_behaviour
 from hypothesis.strategies import none, dates, times, binary, datetimes, \
     timedeltas
@@ -46,11 +46,11 @@ def test_can_find_negative_delta():
 
 
 def test_can_find_on_the_second():
-    timedeltas().filter(lambda x: x.seconds == 0).example()
+    find_any(timedeltas(), lambda x: x.seconds == 0)
 
 
 def test_can_find_off_the_second():
-    timedeltas().filter(lambda x: x.seconds != 0).example()
+    find_any(timedeltas(), lambda x: x.seconds != 0)
 
 
 def test_simplifies_towards_zero_delta():
@@ -68,7 +68,7 @@ def test_max_value_is_respected():
 
 @given(timedeltas())
 def test_single_timedelta(val):
-    assert timedeltas(val, val).example() is val
+    assert find_any(timedeltas(val, val)) is val
 
 
 TestStandardDescriptorFeatures_datetimes1 = strategy_test_suite(datetimes())
@@ -125,7 +125,7 @@ def test_can_find_before_the_year_2000():
 
 def test_can_find_each_month():
     for month in hrange(1, 13):
-        dates().filter(lambda x: x.month == month).example()
+        find_any(dates(), lambda x: x.month == month)
 
 
 def test_min_year_is_respected():
@@ -138,14 +138,14 @@ def test_max_year_is_respected():
 
 @given(dates())
 def test_single_date(val):
-    assert dates(val, val).example() is val
+    assert find_any(dates(val, val)) is val
 
 
 TestStandardDescriptorFeatures_times1 = strategy_test_suite(times())
 
 
 def test_can_find_midnight():
-    times().filter(lambda x: x.hour == x.minute == x.second == 0).example()
+    find_any(times(), lambda x: x.hour == x.minute == x.second == 0)
 
 
 def test_can_find_non_midnight():
@@ -153,11 +153,11 @@ def test_can_find_non_midnight():
 
 
 def test_can_find_on_the_minute():
-    times().filter(lambda x: x.second == 0).example()
+    find_any(times(), lambda x: x.second == 0)
 
 
 def test_can_find_off_the_minute():
-    times().filter(lambda x: x.second != 0).example()
+    find_any(times(), lambda x: x.second != 0)
 
 
 def test_simplifies_towards_midnight():
@@ -166,7 +166,7 @@ def test_simplifies_towards_midnight():
 
 
 def test_can_generate_naive_time():
-    times().filter(lambda d: not d.tzinfo).example()
+    find_any(times(), lambda d: not d.tzinfo)
 
 
 @given(times())

--- a/tests/cover/test_example.py
+++ b/tests/cover/test_example.py
@@ -20,13 +20,16 @@ from __future__ import division, print_function, absolute_import
 from random import Random
 
 import hypothesis.strategies as st
-from hypothesis import given
+from hypothesis import find, given
+from hypothesis.control import _current_build_context
+from tests.common.utils import checks_deprecated_behaviour
 
 
 @given(st.integers())
 def test_deterministic_examples_are_deterministic(seed):
-    assert st.lists(st.integers()).example(Random(seed)) == \
-        st.lists(st.integers()).example(Random(seed))
+    with _current_build_context.with_value(None):
+        assert st.lists(st.integers()).example(Random(seed)) == \
+            st.lists(st.integers()).example(Random(seed))
 
 
 def test_does_not_always_give_the_same_example():
@@ -34,3 +37,19 @@ def test_does_not_always_give_the_same_example():
     assert len(set(
         s.example() for _ in range(100)
     )) >= 10
+
+
+@checks_deprecated_behaviour
+@given(st.booleans())
+def test_example_inside_given(b):
+    st.integers().example()
+
+
+@checks_deprecated_behaviour
+def test_example_inside_find():
+    find(st.integers(0, 100), lambda x: st.integers().example())
+
+
+@checks_deprecated_behaviour
+def test_example_inside_strategy():
+    st.booleans().map(lambda x: st.integers().example()).example()

--- a/tests/cover/test_example.py
+++ b/tests/cover/test_example.py
@@ -20,7 +20,7 @@ from __future__ import division, print_function, absolute_import
 from random import Random
 
 import hypothesis.strategies as st
-from hypothesis import find, given
+from hypothesis import find, given, example
 from hypothesis.control import _current_build_context
 from tests.common.utils import checks_deprecated_behaviour
 
@@ -40,6 +40,7 @@ def test_does_not_always_give_the_same_example():
 
 
 @checks_deprecated_behaviour
+@example(False)
 @given(st.booleans())
 def test_example_inside_given(b):
     st.integers().example()

--- a/tests/cover/test_simple_characters.py
+++ b/tests/cover/test_simple_characters.py
@@ -22,7 +22,8 @@ import unicodedata
 import pytest
 
 from hypothesis import find
-from hypothesis.errors import NoExamples, NoSuchExample, InvalidArgument
+from hypothesis.errors import NoSuchExample, InvalidArgument
+from tests.common.debug import find_any
 from hypothesis.strategies import characters
 from hypothesis.internal.compat import text_type
 
@@ -106,11 +107,11 @@ def test_whitelisted_characters_override():
     st = characters(min_codepoint=ord('0'), max_codepoint=ord('9'),
                     whitelist_characters=good_characters)
 
-    st.filter(lambda c: c in good_characters).example()
-    st.filter(lambda c: c in '0123456789').example()
+    find_any(st, lambda c: c in good_characters)
+    find_any(st, lambda c: c in '0123456789')
 
-    with pytest.raises(NoExamples):
-        st.filter(lambda c: c not in good_characters + '0123456789').example()
+    with pytest.raises(NoSuchExample):
+        find_any(st, lambda c: c not in good_characters + '0123456789')
 
 
 def test_blacklisted_characters():

--- a/tests/cover/test_simple_collections.py
+++ b/tests/cover/test_simple_collections.py
@@ -24,7 +24,7 @@ import pytest
 from flaky import flaky
 
 from hypothesis import find, given, settings
-from tests.common.debug import minimal
+from tests.common.debug import minimal, find_any
 from hypothesis.strategies import none, sets, text, lists, builds, \
     tuples, booleans, integers, frozensets, dictionaries, \
     fixed_dictionaries
@@ -249,11 +249,11 @@ def test_can_find_sets_unique_by_incomplete_data():
 
 
 def test_can_draw_empty_list_from_unsatisfiable_strategy():
-    assert lists(integers().filter(lambda s: False)).example() == []
+    assert find_any(lists(integers().filter(lambda s: False))) == []
 
 
 def test_can_draw_empty_set_from_unsatisfiable_strategy():
-    assert sets(integers().filter(lambda s: False)).example() == set()
+    assert find_any(sets(integers().filter(lambda s: False))) == set()
 
 
 small_set = sets(none())

--- a/tests/datetime/test_dates.py
+++ b/tests/datetime/test_dates.py
@@ -17,7 +17,7 @@
 
 from __future__ import division, print_function, absolute_import
 
-from tests.common.debug import minimal
+from tests.common.debug import minimal, find_any
 from tests.common.utils import checks_deprecated_behaviour
 from hypothesis.extra.datetime import dates
 from hypothesis.internal.compat import hrange
@@ -36,7 +36,7 @@ def test_can_find_before_the_year_2000():
 @checks_deprecated_behaviour
 def test_can_find_each_month():
     for month in hrange(1, 13):
-        dates().filter(lambda x: x.month == month).example()
+        find_any(dates(), lambda x: x.month == month)
 
 
 @checks_deprecated_behaviour

--- a/tests/datetime/test_datetime.py
+++ b/tests/datetime/test_datetime.py
@@ -25,7 +25,7 @@ from flaky import flaky
 
 from hypothesis import find, given, assume, settings, unlimited
 from hypothesis.errors import InvalidArgument
-from tests.common.debug import minimal
+from tests.common.debug import minimal, find_any
 from tests.common.utils import checks_deprecated_behaviour
 from hypothesis.extra.datetime import datetimes
 from hypothesis.internal.compat import hrange
@@ -44,7 +44,7 @@ def test_can_find_before_the_year_2000():
 @checks_deprecated_behaviour
 def test_can_find_each_month():
     for month in hrange(1, 13):
-        datetimes().filter(lambda x: x.month == month).example()
+        find_any(datetimes(), lambda x: x.month == month)
 
 
 @checks_deprecated_behaviour
@@ -61,12 +61,12 @@ def test_can_find_non_midnight():
 
 @checks_deprecated_behaviour
 def test_can_find_off_the_minute():
-    datetimes().filter(lambda x: x.second != 0).example()
+    find_any(datetimes(), lambda x: x.second != 0)
 
 
 @checks_deprecated_behaviour
 def test_can_find_on_the_minute():
-    datetimes().filter(lambda x: x.second == 0).example()
+    find_any(datetimes(), lambda x: x.second == 0)
 
 
 @checks_deprecated_behaviour
@@ -80,7 +80,7 @@ def test_simplifies_towards_midnight():
 
 @checks_deprecated_behaviour
 def test_can_generate_naive_datetime():
-    datetimes(allow_naive=True).filter(lambda d: d.tzinfo is None).example()
+    find_any(datetimes(allow_naive=True), lambda d: d.tzinfo is None)
 
 
 @checks_deprecated_behaviour

--- a/tests/datetime/test_times.py
+++ b/tests/datetime/test_times.py
@@ -20,14 +20,14 @@ from __future__ import division, print_function, absolute_import
 import pytz
 
 from hypothesis import given, assume
-from tests.common.debug import minimal
+from tests.common.debug import minimal, find_any
 from tests.common.utils import checks_deprecated_behaviour
 from hypothesis.extra.datetime import times
 
 
 @checks_deprecated_behaviour
 def test_can_find_midnight():
-    times().filter(lambda x: x.hour == x.minute == x.second == 0).example()
+    find_any(times(), lambda x: x.hour == x.minute == x.second == 0)
 
 
 @checks_deprecated_behaviour
@@ -37,12 +37,12 @@ def test_can_find_non_midnight():
 
 @checks_deprecated_behaviour
 def test_can_find_off_the_minute():
-    times().filter(lambda x: x.second != 0).example()
+    find_any(times(), lambda x: x.second != 0)
 
 
 @checks_deprecated_behaviour
 def test_can_find_on_the_minute():
-    times().filter(lambda x: x.second == 0).example()
+    find_any(times(), lambda x: x.second == 0)
 
 
 @checks_deprecated_behaviour
@@ -56,7 +56,7 @@ def test_simplifies_towards_midnight():
 
 @checks_deprecated_behaviour
 def test_can_generate_naive_time():
-    times(allow_naive=True).filter(lambda d: d.tzinfo is not None).example()
+    find_any(times(allow_naive=True), lambda d: d.tzinfo is not None)
 
 
 @checks_deprecated_behaviour

--- a/tests/datetime/test_timezones.py
+++ b/tests/datetime/test_timezones.py
@@ -57,7 +57,7 @@ def test_timezone_aware_datetimes_are_timezone_aware(dt):
        datetimes(timezones=timezones()))
 def test_datetime_bounds_must_be_naive(name, val):
     with pytest.raises(InvalidArgument):
-        datetimes(**{name: val}).example()
+        datetimes(**{name: val}).validate()
 
 
 def test_underflow_in_simplify():
@@ -76,10 +76,10 @@ def test_overflow_in_simplify():
 
 def test_timezones_arg_to_datetimes_must_be_search_strategy():
     with pytest.raises(InvalidArgument):
-        datetimes(timezones=pytz.all_timezones).example()
+        datetimes(timezones=pytz.all_timezones).validate()
     with pytest.raises(InvalidArgument):
         tz = [pytz.timezone(t) for t in pytz.all_timezones]
-        datetimes(timezones=tz).example()
+        datetimes(timezones=tz).validate()
 
 
 @given(times(timezones=timezones()))
@@ -90,10 +90,10 @@ def test_timezone_aware_times_are_timezone_aware(dt):
 def test_can_generate_non_utc():
     times(timezones=timezones()).filter(
         lambda d: assume(d.tzinfo) and d.tzinfo.zone != u'UTC'
-    ).example()
+    ).validate()
 
 
 @given(sampled_from(['min_value', 'max_value']), times(timezones=timezones()))
 def test_time_bounds_must_be_naive(name, val):
     with pytest.raises(InvalidArgument):
-        times(**{name: val}).example()
+        times(**{name: val}).validate()

--- a/tests/nocover/test_recursive.py
+++ b/tests/nocover/test_recursive.py
@@ -23,6 +23,7 @@ from flaky import flaky
 
 import hypothesis.strategies as st
 from hypothesis import find, given, example, settings
+from tests.common.debug import find_any
 from hypothesis.internal.compat import integer_types
 
 
@@ -92,7 +93,7 @@ def test_can_use_recursive_data_in_sets(rnd):
         lambda js: st.frozensets(js, average_size=2.0),
         max_leaves=10
     )
-    nested_sets.example(rnd)
+    find_any(nested_sets, random=rnd)
 
     def flatten(x):
         if isinstance(x, bool):

--- a/tests/nocover/test_strategy_state.py
+++ b/tests/nocover/test_strategy_state.py
@@ -22,10 +22,10 @@ import hashlib
 from random import Random
 
 from hypothesis import Verbosity, seed, given, assume, settings, unlimited
-from hypothesis.errors import NoExamples, FailedHealthCheck
+from hypothesis.errors import FailedHealthCheck
 from hypothesis.database import ExampleDatabase
 from hypothesis.stateful import Bundle, RuleBasedStateMachine, rule
-from hypothesis.strategies import just, none, text, lists, binary, \
+from hypothesis.strategies import data, just, none, text, lists, binary, \
     floats, tuples, booleans, decimals, integers, fractions, \
     float_to_int, int_to_float, sampled_from, complex_numbers
 from hypothesis.internal.compat import PYPY
@@ -205,14 +205,9 @@ class HypothesisSpec(RuleBasedStateMachine):
     def cat_tuples(self, l, r):
         return l + r
 
-    @rule(target=objects, strat=strategies)
-    def get_example(self, strat):
-        try:
-            strat.example()
-        except NoExamples:
-            # Because of filtering some strategies we look for don't actually
-            # have any examples.
-            pass
+    @rule(target=objects, strat=strategies, data=data())
+    def get_example(self, strat, data):
+        data.draw(strat)
 
     @rule(target=strategies, left=integers(), right=integers())
     def integer_range(self, left, right):


### PR DESCRIPTION
As per discussion in https://github.com/HypothesisWorks/hypothesis-python/issues/832, use of `example()` inside tests leads to very confusing behaviour. This is because you're not supposed to use `example()` in tests at all, but the practice is nevertheless widespread.

This PR fixes the issue by causing this use of example to emit a deprecation warning. It's arguable that we could turn this into an error without that, and I'm probably going to be willing to turn it into an error later without bumping a major version, but I figure the deprecation warning gives people some time to adjust.