### PR TITLE
Display all slipped errors found during shrinking

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,7 +1,7 @@
-RELEASE_TYPE: patch
+RELEASE_TYPE: minor
 
 This release changes how Hypothesis shrinks and replays examples to take into
-account that it can encounter new bugs while shrinking. It now attempts to
-identify whether the test failure is the same as the one it started with and
-avoids shrinking into it (but still saves it for next time). This helps avoid
-a phenomenon where rare bugs get shrunk into more common ones.
+account that it can encounter new bugs while shrinking the bug it originally
+found. Previously it would end up replacing the originally found bug with the
+new bug and show you only that one. Now it is (often) able to recognise when
+two bugs are distinct and when it finds more than one will show both.

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This release changes how Hypothesis shrinks and replays examples to take into
+account that it can encounter new bugs while shrinking. It now attempts to
+identify whether the test failure is the same as the one it started with and
+avoids shrinking into it (but still saves it for next time). This helps avoid
+a phenomenon where rare bugs get shrunk into more common ones.

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -678,7 +678,7 @@ class StateForActualGivenExecution(object):
                 flaky += 1
 
         # If we only have one example then we should have raised an error or
-        # flaky preior to that point.
+        # flaky prior to this point.
         assert len(self.falsifying_examples) > 1
 
         if flaky > 0:

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -571,8 +571,8 @@ class StateForActualGivenExecution(object):
             return
         if runner.interesting_examples:
             self.falsifying_examples = sorted(
-                [d.buffer for d in runner.interesting_examples.values()],
-                key=sort_key, reverse=True
+                [d for d in runner.interesting_examples.values()],
+                key=lambda d: sort_key(d.buffer), reverse=True
             )
         else:
             if timed_out:
@@ -625,7 +625,7 @@ class StateForActualGivenExecution(object):
             try:
                 with self.settings:
                     self.test_runner(
-                        ConjectureData.for_buffer(falsifying_example),
+                        ConjectureData.for_buffer(falsifying_example.buffer),
                         reify_and_execute(
                             self.search_strategy, self.test,
                             print_example=True, is_final=True
@@ -659,7 +659,7 @@ class StateForActualGivenExecution(object):
 
                 try:
                     self.test_runner(
-                        ConjectureData.for_buffer(self.falsifying_example),
+                        ConjectureData.for_buffer(falsifying_example.buffer),
                         reify_and_execute(
                             self.search_strategy,
                             test_is_flaky(

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -548,8 +548,9 @@ class StateForActualGivenExecution(object):
             error_class, _, tb = sys.exc_info()
 
             origin = traceback.extract_tb(tb)[-1]
-            data.mark_interesting(
-                (error_class, origin.filename, origin.lineno))
+            filename = origin[0]
+            lineno = origin[1]
+            data.mark_interesting((error_class, filename, lineno))
 
     def run(self):
         # Tell pytest to omit the body of this function from tracebacks

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -684,12 +684,12 @@ class StateForActualGivenExecution(object):
         if flaky > 0:
             raise Flaky((
                 'Hypothesis found %d distinct failures, but %d of them '
-                'exhibited some sort of flaky behaviour. See above for '
-                'details.') % (len(self.falsifying_examples), flaky))
+                'exhibited some sort of flaky behaviour.') % (
+                    len(self.falsifying_examples), flaky))
         else:
             raise MultipleFailures((
-                'Hypothesis found %d distinct failures '
-                '(see above for details)') % (len(self.falsifying_examples,)))
+                'Hypothesis found %d distinct failures.') % (
+                    len(self.falsifying_examples,)))
 
     def __flaky(self, message):
         if len(self.falsifying_examples) <= 1:

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -20,6 +20,7 @@
 
 from __future__ import division, print_function, absolute_import
 
+import sys
 import time
 import functools
 import traceback
@@ -543,7 +544,12 @@ class StateForActualGivenExecution(object):
             escalate_hypothesis_internal_error()
             self.last_exception = traceback.format_exc()
             verbose_report(self.last_exception)
-            data.mark_interesting()
+
+            error_class, _, tb = sys.exc_info()
+
+            origin = traceback.extract_tb(tb)[-1]
+            data.mark_interesting(
+                (error_class, origin.filename, origin.lineno))
 
     def run(self):
         # Tell pytest to omit the body of this function from tracebacks

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -29,7 +29,7 @@ from collections import namedtuple
 
 import hypothesis.strategies as st
 from hypothesis.errors import Flaky, Timeout, NoSuchExample, \
-    Unsatisfiable, InvalidArgument, FailedHealthCheck, \
+    Unsatisfiable, InvalidArgument, MultipleFailures, FailedHealthCheck, \
     UnsatisfiedAssumption, HypothesisDeprecationWarning
 from hypothesis.control import BuildContext
 from hypothesis._settings import settings as Settings
@@ -52,7 +52,7 @@ from hypothesis.internal.conjecture.data import Status, StopTest, \
     ConjectureData
 from hypothesis.searchstrategy.strategies import SearchStrategy
 from hypothesis.internal.conjecture.engine import ExitReason, \
-    ConjectureRunner, uniform
+    ConjectureRunner, uniform, sort_key
 
 
 def new_random():
@@ -509,7 +509,8 @@ class StateForActualGivenExecution(object):
         self.at_least_one_success = False
         self.last_exception = None
         self.repr_for_last_exception = None
-        self.falsifying_example = None
+        self.falsifying_examples = ()
+        self.__was_flaky = False
         self.random = random
 
     def evaluate_test_data(self, data):
@@ -542,8 +543,8 @@ class StateForActualGivenExecution(object):
             raise
         except Exception:
             escalate_hypothesis_internal_error()
-            self.last_exception = traceback.format_exc()
-            verbose_report(self.last_exception)
+            data.__expected_exception = traceback.format_exc()
+            verbose_report(data.__expected_exception)
 
             error_class, _, tb = sys.exc_info()
 
@@ -568,8 +569,11 @@ class StateForActualGivenExecution(object):
         timed_out = runner.exit_reason == ExitReason.timeout
         if runner.last_data is None:
             return
-        if runner.last_data.status == Status.INTERESTING:
-            self.falsifying_example = runner.last_data.buffer
+        if runner.interesting_examples:
+            self.falsifying_examples = sorted(
+                [d.buffer for d in runner.interesting_examples.values()],
+                key=sort_key, reverse=True
+            )
         else:
             if timed_out:
                 note_deprecation((
@@ -610,50 +614,89 @@ class StateForActualGivenExecution(object):
                         get_pretty_function_description(self.test),
                         runner.valid_examples,))
 
-        if self.falsifying_example is None:
+        if not self.falsifying_examples:
             return
 
-        assert self.last_exception is not None
+        flaky = 0
 
-        try:
-            with self.settings:
-                self.test_runner(
-                    ConjectureData.for_buffer(self.falsifying_example),
-                    reify_and_execute(
-                        self.search_strategy, self.test,
-                        print_example=True, is_final=True
-                    ))
-        except (UnsatisfiedAssumption, StopTest):
-            report(traceback.format_exc())
-            raise Flaky(
-                'Unreliable assumption: An example which satisfied '
-                'assumptions on the first run now fails it.'
-            )
+        for falsifying_example in self.falsifying_examples:
+            self.__was_flaky = False
+            raised_exception = False
+            try:
+                with self.settings:
+                    self.test_runner(
+                        ConjectureData.for_buffer(falsifying_example),
+                        reify_and_execute(
+                            self.search_strategy, self.test,
+                            print_example=True, is_final=True
+                        ))
+            except (UnsatisfiedAssumption, StopTest):
+                report(traceback.format_exc())
+                self.__flaky(
+                    'Unreliable assumption: An example which satisfied '
+                    'assumptions on the first run now fails it.'
+                )
+            except:
+                if len(self.falsifying_examples) <= 1:
+                    raise
+                raised_exception = True
+                report(traceback.format_exc())
 
-        report(
-            'Failed to reproduce exception. Expected: \n' +
-            self.last_exception,
-        )
+            if not raised_exception:
+                report(
+                    'Failed to reproduce exception. Expected: \n' +
+                    falsifying_example.__expected_exception,
+                )
 
-        filter_message = (
-            'Unreliable test data: Failed to reproduce a failure '
-            'and then when it came to recreating the example in '
-            'order to print the test data with a flaky result '
-            'the example was filtered out (by e.g. a '
-            'call to filter in your strategy) when we didn\'t '
-            'expect it to be.'
-        )
+                filter_message = (
+                    'Unreliable test data: Failed to reproduce a failure '
+                    'and then when it came to recreating the example in '
+                    'order to print the test data with a flaky result '
+                    'the example was filtered out (by e.g. a '
+                    'call to filter in your strategy) when we didn\'t '
+                    'expect it to be.'
+                )
 
-        try:
-            self.test_runner(
-                ConjectureData.for_buffer(self.falsifying_example),
-                reify_and_execute(
-                    self.search_strategy,
-                    test_is_flaky(self.test, self.repr_for_last_exception),
-                    print_example=True, is_final=True
-                ))
-        except (UnsatisfiedAssumption, StopTest):
-            raise Flaky(filter_message)
+                try:
+                    self.test_runner(
+                        ConjectureData.for_buffer(self.falsifying_example),
+                        reify_and_execute(
+                            self.search_strategy,
+                            test_is_flaky(
+                                self.test, self.repr_for_last_exception),
+                            print_example=True, is_final=True
+                        ))
+                except (UnsatisfiedAssumption, StopTest):
+                    self.__flaky(filter_message)
+                except Flaky as e:
+                    if len(self.falsifying_examples) > 1:
+                        self.__flaky(e.args[0])
+                    else:
+                        raise
+
+            if self.__was_flaky:
+                flaky += 1
+
+        # If we only have one example then we should have raised an error or
+        # flaky preior to that point.
+        assert len(self.falsifying_examples) > 1
+
+        if flaky > 0:
+            raise Flaky((
+                'Hypothesis found %d distinct failures, but %d of them '
+                'exhibited some sort of flaky behaviour. See above for '
+                'details.') % (len(self.falsifying_examples), flaky))
+        else:
+            raise MultipleFailures((
+                'Hypothesis found %d distinct failures '
+                '(see above for details)') % (len(self.falsifying_examples,)))
+
+    def __flaky(self, message):
+        if len(self.falsifying_examples) <= 1:
+            raise Flaky(message)
+        else:
+            self.__was_flaky = True
+            report('Flaky example! ' + message)
 
 
 def given(*given_arguments, **given_kwargs):

--- a/src/hypothesis/database.py
+++ b/src/hypothesis/database.py
@@ -80,6 +80,7 @@ class ExampleDatabase(EDMeta('ExampleDatabase', (object,), {})):
 
     def move(self, key1, key2, value):
         if key1 == key2:
+            self.save(key1, value)
             return
         self.delete(key1, value)
         self.save(key2, value)
@@ -267,6 +268,7 @@ class DirectoryBasedExampleDatabase(ExampleDatabase):
 
     def move(self, key1, key2, value):
         if key1 == key2:
+            self.save(key1, value)
             return
         try:
             os.rename(

--- a/src/hypothesis/database.py
+++ b/src/hypothesis/database.py
@@ -78,6 +78,12 @@ class ExampleDatabase(EDMeta('ExampleDatabase', (object,), {})):
         """
         raise NotImplementedError('%s.delete' % (type(self).__name__))
 
+    def move(self, key1, key2, value):
+        if key1 == key2:
+            return
+        self.delete(key1, value)
+        self.save(key2, value)
+
     def fetch(self, key):
         """Return all values matching this key."""
         raise NotImplementedError('%s.fetch' % (type(self).__name__))
@@ -258,6 +264,16 @@ class DirectoryBasedExampleDatabase(ExampleDatabase):
             except OSError:  # pragma: no cover
                 os.unlink(tmpname)
             assert not os.path.exists(tmpname)
+
+    def move(self, key1, key2, value):
+        if key1 == key2:
+            return
+        try:
+            os.rename(
+                self._value_path(key1, value), self._value_path(key2, value))
+        except OSError:
+            self.delete(key1, value)
+            self.save(key2, value)
 
     def delete(self, key, value):
         try:

--- a/src/hypothesis/database.py
+++ b/src/hypothesis/database.py
@@ -78,12 +78,12 @@ class ExampleDatabase(EDMeta('ExampleDatabase', (object,), {})):
         """
         raise NotImplementedError('%s.delete' % (type(self).__name__))
 
-    def move(self, key1, key2, value):
-        if key1 == key2:
-            self.save(key1, value)
+    def move(self, src, dest, value):
+        if src == dest:
+            self.save(src, value)
             return
-        self.delete(key1, value)
-        self.save(key2, value)
+        self.delete(src, value)
+        self.save(dest, value)
 
     def fetch(self, key):
         """Return all values matching this key."""
@@ -266,16 +266,16 @@ class DirectoryBasedExampleDatabase(ExampleDatabase):
                 os.unlink(tmpname)
             assert not os.path.exists(tmpname)
 
-    def move(self, key1, key2, value):
-        if key1 == key2:
-            self.save(key1, value)
+    def move(self, src, dest, value):
+        if src == dest:
+            self.save(src, value)
             return
         try:
             os.rename(
-                self._value_path(key1, value), self._value_path(key2, value))
+                self._value_path(src, value), self._value_path(dest, value))
         except OSError:
-            self.delete(key1, value)
-            self.save(key2, value)
+            self.delete(src, value)
+            self.save(dest, value)
 
     def delete(self, key, value):
         try:

--- a/src/hypothesis/database.py
+++ b/src/hypothesis/database.py
@@ -79,6 +79,14 @@ class ExampleDatabase(EDMeta('ExampleDatabase', (object,), {})):
         raise NotImplementedError('%s.delete' % (type(self).__name__))
 
     def move(self, src, dest, value):
+        """Move value from key src to key dest. Equivalent to delete(src,
+        value) followed by save(src, value) but may have a more efficient
+        implementation.
+
+        Note that value will be inserted at dest regardless of whether
+        it is currently present at src.
+
+        """
         if src == dest:
             self.save(src, value)
             return

--- a/src/hypothesis/errors.py
+++ b/src/hypothesis/errors.py
@@ -186,3 +186,8 @@ class Frozen(HypothesisException):
 
     """Raised when a mutation method has been called on a ConjectureData object
     after freeze() has been called."""
+
+
+class MultipleFailures(HypothesisException):
+    """Indicates that Hypothesis found more than one distinct bug when testing
+    your code."""

--- a/src/hypothesis/internal/conjecture/data.py
+++ b/src/hypothesis/internal/conjecture/data.py
@@ -77,6 +77,7 @@ class ConjectureData(object):
         self.events = set()
         self.forced_indices = set()
         self.capped_indices = {}
+        self.interesting_origin = None
 
     def __assert_not_frozen(self, name):
         if self.frozen:
@@ -210,8 +211,9 @@ class ConjectureData(object):
         self.__write(result)
         return hbytes(result)
 
-    def mark_interesting(self):
+    def mark_interesting(self, interesting_origin=None):
         self.__assert_not_frozen('mark_interesting')
+        self.interesting_origin = interesting_origin
         self.status = Status.INTERESTING
         self.freeze()
         raise StopTest(self.testcounter)

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -241,9 +241,7 @@ class ConjectureRunner(object):
         return True
 
     def save_buffer(self, buffer, key=None):
-        if (
-            self.settings.database is not None
-        ):
+        if self.settings.database is not None:
             if key is None:
                 key = self.database_key
             if key is None:

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -241,8 +241,8 @@ class ConjectureRunner(object):
         if data.status == Status.INTERESTING:
             if (
                 self.last_data is None or
-                self.last_data.status != Status.INTERESTING
-                or self.last_data.interesting_origin == data.interesting_origin
+                self.last_data.status != Status.INTERESTING or
+                self.last_data.interesting_origin == data.interesting_origin
             ):
                 self.save_buffer(data.buffer)
             else:

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -191,6 +191,8 @@ class ConjectureRunner(object):
         )
 
         if data.status == Status.INTERESTING:
+            first_call = len(self.interesting_examples) == 0
+
             key = data.interesting_origin
             changed = False
             try:
@@ -207,7 +209,7 @@ class ConjectureRunner(object):
             if changed:
                 self.interesting_examples[key] = data
                 self.shrunk_examples.discard(key)
-                if last_data_is_interesting:
+                if last_data_is_interesting and not first_call:
                     self.shrinks += 1
 
             if not last_data_is_interesting or (

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -267,7 +267,8 @@ class ConjectureRunner(object):
         status = unicode_safe_repr(data.status)
 
         if data.status == Status.INTERESTING:
-            status += u' (%r)' % (data.interesting_origin,)
+            status = u'%s (%s)' % (
+                status, unicode_safe_repr(data.interesting_origin,))
 
         self.debug(u'%d bytes %s -> %s, %s' % (
             data.index,

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -234,8 +234,7 @@ class ConjectureRunner(object):
 
     @property
     def secondary_key(self):
-        if self.database_key is not None:
-            return b'.'.join((self.database_key, b"secondary"))
+        return b'.'.join((self.database_key, b"secondary"))
 
     def note_details(self, data):
         if data.status == Status.INTERESTING:

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -268,7 +268,7 @@ class ConjectureRunner(object):
         status = unicode_safe_repr(data.status)
 
         if data.status == Status.INTERESTING:
-            status += ' (%r)' % (data.interesting_origin,)
+            status += u' (%r)' % (data.interesting_origin,)
 
         self.debug(u'%d bytes %s -> %s, %s' % (
             data.index,

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -191,6 +191,7 @@ class ConjectureRunner(object):
         )
 
         if data.status == Status.INTERESTING:
+            first_example = len(self.interesting_examples) == 0
             key = data.interesting_origin
             changed = False
             try:
@@ -207,7 +208,7 @@ class ConjectureRunner(object):
             if changed:
                 self.interesting_examples[key] = data
                 self.shrunk_examples.discard(key)
-                if last_data_is_interesting:
+                if last_data_is_interesting and not first_example:
                     self.shrinks += 1
 
             if not last_data_is_interesting or (
@@ -251,7 +252,10 @@ class ConjectureRunner(object):
             self.settings.database.save(key, hbytes(buffer))
 
     def downgrade_buffer(self, buffer):
-        if self.settings.database is not None:
+        if (
+            self.settings.database is not None and
+            self.database_key is not None
+        ):
             self.settings.database.move(
                 self.database_key, self.secondary_key, buffer)
 
@@ -596,7 +600,7 @@ class ConjectureRunner(object):
                 if len(secondary_corpus) <= shortfall:
                     extra = secondary_corpus
                 else:
-                    extra = self.random.sample(extra, shortfall)
+                    extra = self.random.sample(secondary_corpus, shortfall)
                 extra.sort(key=sort_key)
                 corpus.extend(extra)
 

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -606,6 +606,8 @@ class ConjectureRunner(object):
                 else:
                     self.settings.database.delete(
                         self.database_key, existing)
+                    self.settings.database.delete(
+                        self.secondary_key, existing)
 
     def exit_with(self, reason):
         self.exit_reason = reason

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -198,8 +198,6 @@ class ConjectureRunner(object):
             try:
                 existing = self.interesting_examples[key]
             except KeyError:
-                self.interesting_examples[key] = data
-                self.shrunk_examples.discard(key)
                 changed = True
             else:
                 if sort_key(data.buffer) < sort_key(existing.buffer):
@@ -732,10 +730,6 @@ class ConjectureRunner(object):
             self.exit_reason = ExitReason.finished
             return
         assert isinstance(data.output, text_type)
-
-        if self.settings.max_shrinks <= 0:
-            self.exit_reason = ExitReason.max_shrinks
-            return
 
         if Phase.shrink not in self.settings.phases:
             self.exit_reason = ExitReason.finished

--- a/tests/common/utils.py
+++ b/tests/common/utils.py
@@ -93,3 +93,7 @@ def checks_deprecated_behaviour(func):
         with validate_deprecation():
             return func(*args, **kwargs)
     return _inner
+
+
+def all_values(db):
+    return set(v for vs in db.data.values() for v in vs)

--- a/tests/cover/test_database_backend.py
+++ b/tests/cover/test_database_backend.py
@@ -160,6 +160,16 @@ def test_class_name_is_in_repr(exampledatabase):
     exampledatabase.close()
 
 
+def test_an_absent_value_is_present_after_it_moves(exampledatabase):
+    exampledatabase.move(b"a", b"b", b"c")
+    assert next(exampledatabase.fetch(b"b")) == b'c'
+
+
+def test_an_absent_value_is_present_after_it_moves_to_self(exampledatabase):
+    exampledatabase.move(b"a", b"a", b"b")
+    assert next(exampledatabase.fetch(b"a")) == b'b'
+
+
 def test_two_directory_databases_can_interact(tmpdir):
     path = str(tmpdir)
     db1 = DirectoryBasedExampleDatabase(path)

--- a/tests/cover/test_slippage.py
+++ b/tests/cover/test_slippage.py
@@ -1,0 +1,57 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2017 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+from hypothesis import given
+import hypothesis.strategies as st
+import pytest
+
+
+def test_does_not_slip_into_other_exception_type():
+    target = [None]
+
+    @given(st.integers())
+    def test(i):
+        if abs(i) < 1000:
+            return
+        if target[0] is None:
+            target[0] = i
+        exc_class = TypeError if target[0] == i else ValueError
+        raise exc_class()
+
+    with pytest.raises(TypeError):
+        test()
+
+
+def test_does_not_slip_into_other_exception_location():
+    target = [None]
+
+    @given(st.integers())
+    def test(i):
+        if abs(i) < 1000:
+            return
+        if target[0] is None:
+            target[0] = i
+        if target[0] == i:
+            raise ValueError("loc 1")
+        else:
+            raise ValueError("loc 2")
+
+    with pytest.raises(ValueError) as e:
+        test()
+    assert e.value.args[0] == "loc 1"

--- a/tests/cover/test_stateful.py
+++ b/tests/cover/test_stateful.py
@@ -507,11 +507,11 @@ def test_can_explicitly_pass_settings():
 
 
 def test_saves_failing_example_in_database():
-    db = ExampleDatabase()
+    db = ExampleDatabase(':memory:')
     with raises(AssertionError):
         run_state_machine_as_test(
             SetStateMachine, Settings(database=db))
-    assert len(list(db.data.keys())) == 1
+    assert len(list(db.data.keys())) == 2
 
 
 def test_can_run_with_no_db():

--- a/tests/nocover/test_database_agreement.py
+++ b/tests/nocover/test_database_agreement.py
@@ -61,14 +61,21 @@ class DatabaseComparison(RuleBasedStateMachine):
         for db in self.dbs:
             db.delete(k, v)
 
+    @rule(k1=keys, k2=keys, v=values)
+    def move(self, k1, k2, v):
+        for db in self.dbs:
+            db.move(k1, k2, v)
+
     @rule(k=keys)
     def values_agree(self, k):
         last = None
+        last_db = None
         for db in self.dbs:
             keys = set(db.fetch(k))
             if last is not None:
-                assert last == keys
+                assert last == keys, (last_db, db)
             last = keys
+            last_db = db
 
     def teardown(self):
         for d in self.dbs:


### PR DESCRIPTION
There's a phenomenon often called "slippage" where when shrinking a bug results in finding another bug. This often happens with rarer bugs shrinking to more common ones.

This isn't a huge problem in practice for Hypothesis because the example database still saves the original failures and will replay them, but it's annoying. I ran into at least one example of it in debugging #785, which reminded me that I've been meaning to do some work on trying to avoid the problem.

So this is that work. It adds a notion of `interestingness_origin` to ConjectureData and forces the engine to shrink subject to the additional constraint that the origin is preserved.

For tests we use the somewhat imprecise but probably good enough partitioning that two failures are "the same bug" if they throw the same exception type from the same line. We *could* use a more precise notion based on the entire stack trace, but it's likely that would be too precise (even after normalising to account for recursion).

This then has a bunch of knock-on effects for database management: We absolutely want to save all these examples that we're finding but not slipping to, but if we do that under the current scheme then when we rerun the test we might get a slipped example rather than the previous test failure. So we split the storage into two segments, primary and secondary. Primary is where everything that was an actual target bug goes, secondary is where all other bugs we find go. We then make sure to replay primary failures first (see mini-essay comment inline in the code for more details of logic here).

As well as the actual feature this is for, the two main implementation details of this pull request are also useful stepping stones in my sinister long term plans for ~~world domination~~ better testing tools. In particular:

* Being able to distinguish different types of failure is pretty vital for the use of Hypothesis as a long-running fuzzer tool. We don't currently have a workflow or implementation that supports that, so this is just step one, but it's a vital step and it will be useful to see how well this works in the wild.
* The primary/secondary corpus thing is a split I've been meaning to make for a while. Once Hypothesis starts growing coverage features we'll need somewhere to stash a corpus of non-failures that produce interesting coverage results.