### PR TITLE
Add deadline feature to make slow tests an error

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -4,7 +4,7 @@ This release introduces a :attr:`~hypothesis.settings.deadline`
 setting to Hypothesis.
 
 When set this turns slow tests into errors. By default it is unset but will
-warn if you exceed 300ms, which will become the default value in a future
+warn if you exceed 200ms, which will become the default value in a future
 release.
 
 This work was funded by `Smarkets <https://smarkets.com/>`_.

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,10 @@
+RELEASE_TYPE: minor
+
+This release introduces a :attr:`~hypothesis.settings.deadline`
+setting to Hypothesis.
+
+When set this turns slow tests into errors. By default it is unset but will
+warn if you exceed 500ms, which will become the default value in a future
+release.
+
+This work was funded by `Smarkets <https://smarkets.com/>`_.

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -4,7 +4,7 @@ This release introduces a :attr:`~hypothesis.settings.deadline`
 setting to Hypothesis.
 
 When set this turns slow tests into errors. By default it is unset but will
-warn if you exceed 500ms, which will become the default value in a future
+warn if you exceed 300ms, which will become the default value in a future
 release.
 
 This work was funded by `Smarkets <https://smarkets.com/>`_.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -44,7 +44,7 @@ Available settings
     :members: max_examples, max_iterations, min_satisfying_examples,
         max_shrinks, timeout, strict, database_file, stateful_step_count,
         database, perform_health_check, suppress_health_check, buffer_size,
-        phases
+        phases, deadline
 
 .. _phases:
 

--- a/src/hypothesis/_settings.py
+++ b/src/hypothesis/_settings.py
@@ -631,7 +631,7 @@ smaller units of time) that a test is not allowed to exceed. Tests which take
 longer than that will be converted into errors. Set this to None to disable
 this behaviour entirely.
 
-In future this will default to 500. For now, a
+In future this will default to 200. For now, a
 HypothesisDeprecationWarning will be emitted if you exceed that default
 deadline and have not explicitly set a deadline yourself.
 """

--- a/src/hypothesis/_settings.py
+++ b/src/hypothesis/_settings.py
@@ -622,6 +622,21 @@ attempting to actually execute your test.
 """
 )
 
+settings.define_setting(
+    'deadline',
+    default=not_set,
+    description=u"""
+If set, a time in milliseconds (which may be a float to express
+smaller units of time) that a test is not allowed to exceed. Tests which take
+longer than that will be converted into errors. Set this to None to disable
+this behaviour entirely.
+
+In future this will default to 500. For now, a
+HypothesisDeprecationWarning will be emitted if you exceed that default
+deadline and have not explicitly set a deadline yourself.
+"""
+)
+
 settings.lock_further_definitions()
 
 settings.register_profile('default', settings())

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -524,12 +524,12 @@ class StateForActualGivenExecution(object):
                 if self.settings.deadline is not_set:
                     if (
                         not self.__warned_deadline and
-                        runtime >= 500
+                        runtime >= 200
                     ):
                         self.__warned_deadline = True
                         note_deprecation((
                             'Test took %.2fms to run. In future the default '
-                            'deadline setting will be 500ms, which will '
+                            'deadline setting will be 200ms, which will '
                             'make this an error. You can set deadline to '
                             'an explicit value of e.g. %d to turn tests '
                             'slower than this into an error, or you can set '

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -539,9 +539,7 @@ class StateForActualGivenExecution(object):
                 elif runtime >= self.settings.deadline:
                     raise DeadlineExceeded((
                         'Test took %.2fms, which exceeds the deadline of '
-                        '%.2fms') % (
-                            runtime, self.settings.deadline,
-                    )
+                        '%.2fms') % (runtime, self.settings.deadline)
                     )
                 return result
             self.test = timed_test

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -29,8 +29,9 @@ from collections import namedtuple
 
 import hypothesis.strategies as st
 from hypothesis.errors import Flaky, Timeout, NoSuchExample, \
-    Unsatisfiable, InvalidArgument, MultipleFailures, FailedHealthCheck, \
-    UnsatisfiedAssumption, HypothesisDeprecationWarning
+    Unsatisfiable, InvalidArgument, DeadlineExceeded, MultipleFailures, \
+    FailedHealthCheck, UnsatisfiedAssumption, \
+    HypothesisDeprecationWarning
 from hypothesis.control import BuildContext
 from hypothesis._settings import settings as Settings
 from hypothesis._settings import Phase, Verbosity, HealthCheck, \
@@ -39,13 +40,13 @@ from hypothesis.executors import new_style_executor, \
     default_new_style_executor
 from hypothesis.reporting import report, verbose_report, current_verbosity
 from hypothesis.statistics import note_engine_for_statistics
-from hypothesis.internal.compat import str_to_bytes, get_type_hints, \
-    getfullargspec
-from hypothesis.utils.conventions import infer
+from hypothesis.internal.compat import ceil, str_to_bytes, \
+    get_type_hints, getfullargspec
+from hypothesis.utils.conventions import infer, not_set
 from hypothesis.internal.escalation import \
     escalate_hypothesis_internal_error
-from hypothesis.internal.reflection import is_mock, nicerepr, arg_string, \
-    impersonate, function_digest, fully_qualified_name, \
+from hypothesis.internal.reflection import is_mock, proxies, nicerepr, \
+    arg_string, impersonate, function_digest, fully_qualified_name, \
     define_function_signature, convert_positional_arguments, \
     get_pretty_function_description
 from hypothesis.internal.conjecture.data import Status, StopTest, \
@@ -504,7 +505,6 @@ class StateForActualGivenExecution(object):
     def __init__(self, test_runner, search_strategy, test, settings, random):
         self.test_runner = test_runner
         self.search_strategy = search_strategy
-        self.test = test
         self.settings = settings
         self.at_least_one_success = False
         self.last_exception = None
@@ -512,6 +512,39 @@ class StateForActualGivenExecution(object):
         self.falsifying_examples = ()
         self.__was_flaky = False
         self.random = random
+        self.__warned_deadline = False
+        if self.settings.deadline is None:
+            self.test = test
+        else:
+            @proxies(test)
+            def timed_test(*args, **kwargs):
+                start = time.time()
+                result = test(*args, **kwargs)
+                runtime = (time.time() - start) * 1000
+                if self.settings.deadline is not_set:
+                    if (
+                        not self.__warned_deadline and
+                        runtime >= 500
+                    ):
+                        self.__warned_deadline = True
+                        note_deprecation((
+                            'Test took %.2fms to run. In future the default '
+                            'deadline setting will be 500ms, which will '
+                            'make this an error. You can set deadline to '
+                            'an explicit value of e.g. %d to turn tests '
+                            'slower than this into an error, or you can set '
+                            'it to None to disable this check entirely.') % (
+                                runtime, ceil(runtime / 100) * 100,
+                        ))
+                elif runtime >= self.settings.deadline:
+                    raise DeadlineExceeded((
+                        'Test took %.2fms, which exceeds the deadline of '
+                        '%.2fms') % (
+                            runtime, self.settings.deadline,
+                    )
+                    )
+                return result
+            self.test = timed_test
 
     def evaluate_test_data(self, data):
         if (

--- a/src/hypothesis/errors.py
+++ b/src/hypothesis/errors.py
@@ -191,3 +191,7 @@ class Frozen(HypothesisException):
 class MultipleFailures(HypothesisException):
     """Indicates that Hypothesis found more than one distinct bug when testing
     your code."""
+
+
+class DeadlineExceeded(HypothesisException):
+    """Raised when an individual test body has taken too long to run."""

--- a/src/hypothesis/internal/escalation.py
+++ b/src/hypothesis/internal/escalation.py
@@ -20,6 +20,8 @@ from __future__ import division, print_function, absolute_import
 import os
 import sys
 
+from hypothesis.errors import DeadlineExceeded
+
 INTERNAL_PACKAGE_DIR = os.path.dirname(os.path.abspath(__file__))
 HYPOTHESIS_ROOT = os.path.dirname(INTERNAL_PACKAGE_DIR)
 
@@ -40,5 +42,7 @@ def escalate_hypothesis_internal_error():
     error_type, _, tb = sys.exc_info()
     import traceback
     filepath = traceback.extract_tb(tb)[-1][0]
-    if is_hypothesis_file(filepath):
+    if is_hypothesis_file(filepath) and not issubclass(
+        error_type, DeadlineExceeded
+    ):
         raise

--- a/tests/cover/test_conjecture_engine.py
+++ b/tests/cover/test_conjecture_engine.py
@@ -314,7 +314,9 @@ def test_stops_after_max_examples_when_generating():
 
 
 @given(st.random_module())
-@settings(max_shrinks=0, min_satisfying_examples=1, max_examples=2)
+@settings(
+    max_shrinks=0, min_satisfying_examples=1, max_examples=2, deadline=None
+)
 def test_interleaving_engines(rnd):
     @run_to_buffer
     def x(data):

--- a/tests/cover/test_deadline.py
+++ b/tests/cover/test_deadline.py
@@ -1,0 +1,64 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2017 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import time
+import warnings
+
+import pytest
+
+import hypothesis.strategies as st
+from hypothesis import given, settings
+from hypothesis.errors import DeadlineExceeded, \
+    HypothesisDeprecationWarning
+from tests.common.utils import checks_deprecated_behaviour
+
+
+def test_raises_deadline_on_slow_test():
+    @settings(deadline=500)
+    @given(st.integers())
+    def slow(i):
+        time.sleep(1)
+
+    with pytest.raises(DeadlineExceeded):
+        slow()
+
+
+def test_only_warns_once():
+    @given(st.integers())
+    def slow(i):
+        time.sleep(1)
+    try:
+        warnings.simplefilter('always', HypothesisDeprecationWarning)
+        with warnings.catch_warnings(record=True) as w:
+            slow()
+    finally:
+        warnings.simplefilter('error', HypothesisDeprecationWarning)
+    assert len(w) == 1
+
+
+@checks_deprecated_behaviour
+@given(st.integers())
+def test_slow_tests_are_deprecated_by_default(i):
+    time.sleep(1)
+
+
+@given(st.integers())
+@settings(deadline=None)
+def test_slow_with_none_deadline(i):
+    time.sleep(1)

--- a/tests/cover/test_health_checks.py
+++ b/tests/cover/test_health_checks.py
@@ -179,6 +179,7 @@ def test_returning_non_none_is_forbidden():
 
 def test_a_very_slow_test_will_fail_a_health_check():
     @given(st.integers())
+    @settings(deadline=None)
     def a(x):
         time.sleep(1000)
     with raises(FailedHealthCheck):
@@ -189,7 +190,7 @@ def test_the_slow_test_health_check_can_be_disabled():
     @given(st.integers())
     @settings(suppress_health_check=[
         HealthCheck.hung_test,
-    ])
+    ], deadline=None)
     def a(x):
         time.sleep(1000)
     a()
@@ -197,7 +198,7 @@ def test_the_slow_test_health_check_can_be_disabled():
 
 def test_the_slow_test_health_only_runs_if_health_checks_are_on():
     @given(st.integers())
-    @settings(perform_health_check=False)
+    @settings(perform_health_check=False, deadline=None)
     def a(x):
         time.sleep(1000)
     a()

--- a/tests/cover/test_randomization.py
+++ b/tests/cover/test_randomization.py
@@ -36,7 +36,7 @@ def test_seeds_off_random():
 
 def test_nesting_with_control_passes_health_check():
     @given(st.integers(0, 100), st.random_module())
-    @settings(max_examples=5, database=None)
+    @settings(max_examples=5, database=None, deadline=None)
     def test_blah(x, rnd):
         @given(st.integers())
         @settings(

--- a/tests/nocover/test_deferred_strategies.py
+++ b/tests/nocover/test_deferred_strategies.py
@@ -53,6 +53,7 @@ def mutually_recursive_strategies(draw):
     return strategies
 
 
+@settings(deadline=None)
 @given(mutually_recursive_strategies())
 def test_arbitrary_recursion(strategies):
     for i, s in enumerate(strategies):

--- a/tests/nocover/test_floating.py
+++ b/tests/nocover/test_floating.py
@@ -146,6 +146,7 @@ def test_can_find_floats_that_do_not_round_trip_through_reprs(x):
     assert float(repr(x)) == x
 
 
+@settings(deadline=None)
 @given(floats(), floats(), integers())
 def test_floats_are_in_range(x, y, s):
     assume(not (math.isnan(x) or math.isnan(y)))


### PR DESCRIPTION
Slow tests are a major problem for property-based testing - they both significantly limit its utility and also make us look bad (performance is high up on the list of things I hear complaints about. Some of this is legitimate - Hypothesis data generation performance is quite bad in places - but a lot of it it's actually the tests that are slow).

With the deprecation of timeout (#580) this problem is going to only get worse because it's been made more visible to the user (which was the goal! Long-run this is a clear improvement).

This change is designed to ratchet up that visibility in a way that is actually actionable to users by showing them how slow their tests are and where they are slow. In particular because the deadline participates in the normal shrinking process, users can see whether this is something triggered by a particular example (in which case Hypothesis is giving them ad hoc performance testing! Though I suspect they're more likely to use assume to guide away from that than fix the problem), or whether the test is just intrinsically slow.

It's likely that in a lot of cases the way people will respond here will be to either raise or remove entirely the test deadline, but I think that's OK. Even when they do that it's making it more visible where the problem is, and it at least gives them the capability to debug it even if they choose not to.

## Notes

* This tests the amount of time spent in the test body, not the amount of time spent in test generation. I think that's the correct behaviour, but it also happened to just be easier.
* This gets away with not having to deal with a bunch of annoying edge cases around what happens if you find slow tests while shrinking other examples etc because of #836. As such, it should be merged after that
* The tests for this will not pass until #844 is merged.