### PR TITLE
Emit deprecation warnings for use of SQLiteExampleDatabase

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: minor
+
+Hypothesis now emits deprecation warnings if you are using the legacy
+SQLite example database format, or the tool for merging them. These were
+already documented as deprecated, so this doesn't change their deprecation
+status, only that we warn about it.

--- a/src/hypothesis/database.py
+++ b/src/hypothesis/database.py
@@ -23,6 +23,7 @@ import binascii
 import threading
 from contextlib import contextmanager
 
+from hypothesis._settings import note_deprecation
 from hypothesis.internal.compat import FileNotFoundError, sha1, hbytes, \
     b64decode, b64encode
 
@@ -132,6 +133,20 @@ class SQLiteExampleDatabase(ExampleDatabase):
         self.current_connection = threading.local()
         global sqlite3
         import sqlite3
+
+        if path == u':memory:':
+            note_deprecation(
+                'The SQLite database backend has been deprecated. '
+                'Use InMemoryExampleDatabase or set database_file=":memory:" '
+                'instead.'
+            )
+        else:
+            note_deprecation(
+                'The SQLite database backend has been deprecated. '
+                'Set database_file to some path name not ending in .db, '
+                '.sqlite or .sqlite3 to get the new directory based database '
+                'backend instead.'
+            )
 
     def connection(self):
         if not hasattr(self.current_connection, 'connection'):

--- a/src/hypothesis/tools/mergedbs.py
+++ b/src/hypothesis/tools/mergedbs.py
@@ -133,7 +133,7 @@ def main():
 
     print(
         u'The SQLite Hypothesis database format has been deprecated and will '
-        u'Go away in a future version of Hypothesis. Please switch to the '
+        u'go away in a future version of Hypothesis. Please switch to the '
         u'directory based format, which handles merging correctly '
         u'automatically.', file=sys.stderr)
 

--- a/src/hypothesis/tools/mergedbs.py
+++ b/src/hypothesis/tools/mergedbs.py
@@ -131,6 +131,12 @@ def main():
     print(u'%d new entries and %d deletions from merge' % (
         result.inserts, result.deletions))
 
+    print(
+        u'The SQLite Hypothesis database format has been deprecated and will '
+        u'Go away in a future version of Hypothesis. Please switch to the '
+        u'directory based format, which handles merging correctly '
+        u'automatically.', file=sys.stderr)
+
 
 if __name__ == u'__main__':
     main()

--- a/tests/common/utils.py
+++ b/tests/common/utils.py
@@ -18,7 +18,6 @@
 from __future__ import division, print_function, absolute_import
 
 import sys
-import functools
 import traceback
 import contextlib
 from io import BytesIO, StringIO
@@ -88,7 +87,7 @@ def validate_deprecation():
 
 def checks_deprecated_behaviour(func):
     """A decorator for testing deprecated behaviour."""
-    @functools.wraps(func)
+    @proxies(func)
     def _inner(*args, **kwargs):
         with validate_deprecation():
             return func(*args, **kwargs)

--- a/tests/cover/test_database_backend.py
+++ b/tests/cover/test_database_backend.py
@@ -23,6 +23,8 @@ import base64
 import pytest
 
 from hypothesis import given, settings
+from tests.common.utils import validate_deprecation, \
+    checks_deprecated_behaviour
 from hypothesis.database import ExampleDatabase, SQLiteExampleDatabase, \
     InMemoryExampleDatabase, DirectoryBasedExampleDatabase
 from hypothesis.strategies import lists, binary, tuples
@@ -33,7 +35,7 @@ small_settings = settings(max_examples=50)
 @given(lists(tuples(binary(), binary())))
 @small_settings
 def test_backend_returns_what_you_put_in(xs):
-    backend = SQLiteExampleDatabase(':memory:')
+    backend = InMemoryExampleDatabase()
     mapping = {}
     for key, value in xs:
         mapping.setdefault(key, set()).add(value)
@@ -45,6 +47,7 @@ def test_backend_returns_what_you_put_in(xs):
         assert distinct_backend_contents == set(values)
 
 
+@checks_deprecated_behaviour
 def test_does_not_commit_in_error_state():
     backend = SQLiteExampleDatabase(':memory:')
     backend.create_db_if_needed()
@@ -61,6 +64,7 @@ def test_does_not_commit_in_error_state():
     assert list(backend.fetch(b'a')) == []
 
 
+@checks_deprecated_behaviour
 def test_can_double_close():
     backend = SQLiteExampleDatabase(':memory:')
     backend.create_db_if_needed()
@@ -69,13 +73,14 @@ def test_can_double_close():
 
 
 def test_can_delete_keys():
-    backend = SQLiteExampleDatabase(':memory:')
+    backend = InMemoryExampleDatabase()
     backend.save(b'foo', b'bar')
     backend.save(b'foo', b'baz')
     backend.delete(b'foo', b'bar')
     assert list(backend.fetch(b'foo')) == [b'baz']
 
 
+@checks_deprecated_behaviour
 def test_ignores_badly_stored_values():
     backend = SQLiteExampleDatabase(':memory:')
     backend.create_db_if_needed()
@@ -96,6 +101,7 @@ def test_default_on_disk_database_is_dir(tmpdir):
         ExampleDatabase(tmpdir.join('foo')), DirectoryBasedExampleDatabase)
 
 
+@checks_deprecated_behaviour
 def test_selects_sqlite_database_if_name_matches(tmpdir):
     assert isinstance(
         ExampleDatabase(tmpdir.join('foo.db')), SQLiteExampleDatabase)
@@ -111,6 +117,7 @@ def test_selects_directory_based_if_already_directory(tmpdir):
     assert isinstance(ExampleDatabase(path), DirectoryBasedExampleDatabase)
 
 
+@checks_deprecated_behaviour
 def test_selects_sqlite_if_already_sqlite(tmpdir):
     path = str(tmpdir.join('hi'))
     SQLiteExampleDatabase(path).save(b"foo", b"bar")
@@ -127,7 +134,8 @@ def exampledatabase(request, tmpdir):
     if request.param == 'memory':
         return ExampleDatabase()
     if request.param == 'sql':
-        return SQLiteExampleDatabase(str(tmpdir.join('example.db')))
+        with validate_deprecation():
+            return SQLiteExampleDatabase(str(tmpdir.join('example.db')))
     if request.param == 'directory':
         return DirectoryBasedExampleDatabase(str(tmpdir.join('examples')))
     assert False

--- a/tests/nocover/test_database_agreement.py
+++ b/tests/nocover/test_database_agreement.py
@@ -20,6 +20,7 @@ from __future__ import division, print_function, absolute_import
 import os
 import shutil
 import tempfile
+import warnings
 
 import hypothesis.strategies as st
 from hypothesis.database import SQLiteExampleDatabase, \
@@ -36,9 +37,12 @@ class DatabaseComparison(RuleBasedStateMachine):
 
         self.dbs = [
             DirectoryBasedExampleDatabase(exampledir),
-            InMemoryExampleDatabase(), SQLiteExampleDatabase(':memory:'),
+            InMemoryExampleDatabase(),
             DirectoryBasedExampleDatabase(exampledir),
         ]
+
+        with warnings.catch_warnings():
+            self.dbs.append(SQLiteExampleDatabase(':memory:'))
 
     keys = Bundle('keys')
     values = Bundle('values')

--- a/tests/nocover/test_database_agreement.py
+++ b/tests/nocover/test_database_agreement.py
@@ -20,9 +20,9 @@ from __future__ import division, print_function, absolute_import
 import os
 import shutil
 import tempfile
-import warnings
 
 import hypothesis.strategies as st
+from tests.common.utils import validate_deprecation
 from hypothesis.database import SQLiteExampleDatabase, \
     InMemoryExampleDatabase, DirectoryBasedExampleDatabase
 from hypothesis.stateful import Bundle, RuleBasedStateMachine, rule
@@ -41,7 +41,7 @@ class DatabaseComparison(RuleBasedStateMachine):
             DirectoryBasedExampleDatabase(exampledir),
         ]
 
-        with warnings.catch_warnings():
+        with validate_deprecation():
             self.dbs.append(SQLiteExampleDatabase(':memory:'))
 
     keys = Bundle('keys')

--- a/tests/nocover/test_git_merge.py
+++ b/tests/nocover/test_git_merge.py
@@ -22,6 +22,7 @@ from collections import namedtuple
 
 import hypothesis.strategies as s
 from hypothesis import settings
+from tests.common.utils import validate_deprecation
 from hypothesis.database import SQLiteExampleDatabase
 from hypothesis.stateful import GenericStateMachine
 from hypothesis.tools.mergedbs import merge_dbs
@@ -34,7 +35,8 @@ Delete = namedtuple(u'Delete', (u'key', u'value', u'target'))
 class BackendForTesting(SQLiteExampleDatabase):
 
     def __init__(self):
-        super(BackendForTesting, self).__init__()
+        with validate_deprecation():
+            super(BackendForTesting, self).__init__()
         self.create_db_if_needed()
         self.mirror = set()
 


### PR DESCRIPTION
Followup work from #836.

It turns out that the documentation already said this was deprecated, we just weren't emitting the warnings!