### PR TITLE
[WIP] Switch travis config to use build stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,51 +26,46 @@ env:
         - BUILD_RUNTIMES=$HOME/.runtimes
         - FORMAT_ALL=true
 
-    matrix:
-        # Core tests that we want to run first.
-        - TASK=check-pyup-yml
-        - TASK=check-release-file
-        - TASK=check-shellcheck
-        - TASK=documentation
-        - TASK=lint
-        - TASK=doctest
-        - TASK=check-rst
-        - TASK=check-format
-        - TASK=check-coverage
-        - TASK=check-requirements
-        - TASK=check-pypy
-        - TASK=check-py27
-        - TASK=check-py36
-        - TASK=check-quality
+jobs:
+# Only two stages (test & deploy), for maximum throughput
+  include:
+    - stage: tests
+    # Quick, static analysis jobs to run first
+      script: python scripts/run_travis_make_task.py TASK=check-release-file
+    - script: python scripts/run_travis_make_task.py TASK=check-shellcheck
+    - script: python scripts/run_travis_make_task.py TASK=documentation
+    - script: python scripts/run_travis_make_task.py TASK=lint
+    - script: python scripts/run_travis_make_task.py TASK=check-rst
+    - script: python scripts/run_travis_make_task.py TASK=check-format
+    - script: python scripts/run_travis_make_task.py TASK=check-requirements
 
-        # Less important tests that will probably
-        # pass whenever the above do but are still
-        # worth testing.
-        - TASK=check-unicode
-        - TASK=check-ancient-pip
-        - TASK=check-pure-tracer
-        - TASK=check-py273
-        - TASK=check-py27-typing
-        - TASK=check-py34
-        - TASK=check-py35
-        - TASK=check-nose
-        - TASK=check-pytest28
-        - TASK=check-faker070
-        - TASK=check-faker-latest
-        - TASK=check-django20
-        - TASK=check-django18
-        - TASK=check-django111
-        - TASK=check-pandas19
-        - TASK=check-pandas20
-        - TASK=check-pandas21
-        - TASK=check-pandas22
-        - TASK=deploy
+    # Important checks that we want to run on most builds, but skip if the
+    # prechecks failed.
+    - script: python scripts/run_travis_make_task.py TASK=check-coverage
+    - script: python scripts/run_travis_make_task.py TASK=check-pypy
+    - script: python scripts/run_travis_make_task.py TASK=check-py27
+    - script: python scripts/run_travis_make_task.py TASK=check-py36
+    - script: python scripts/run_travis_make_task.py TASK=check-quality
 
-script:
-    - python scripts/run_travis_make_task.py
+    # Less important tests that will probably pass whenever the above do
+    # but are still worth testing.
+    - script: python scripts/run_travis_make_task.py TASK=check-unicode
+    - script: python scripts/run_travis_make_task.py TASK=check-ancient-pip
+    - script: python scripts/run_travis_make_task.py TASK=check-py273
+    - script: python scripts/run_travis_make_task.py TASK=check-py27-typing
+    - script: python scripts/run_travis_make_task.py TASK=check-py34
+    - script: python scripts/run_travis_make_task.py TASK=check-py35
+    - script: python scripts/run_travis_make_task.py TASK=check-nose
+    - script: python scripts/run_travis_make_task.py TASK=check-pytest28
+    - script: python scripts/run_travis_make_task.py TASK=check-faker070
+    - script: python scripts/run_travis_make_task.py TASK=check-faker071
+    - script: python scripts/run_travis_make_task.py TASK=check-django18
+    - script: python scripts/run_travis_make_task.py TASK=check-django110
+    - script: python scripts/run_travis_make_task.py TASK=check-django111
 
-matrix:
-    fast_finish: true
+    # Do the deploy (doesn't do anything if not on master).
+    - stage: deploy
+      script: python scripts/run_travis_make_task.py TASK=deploy
 
 notifications:
   email:

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -73,59 +73,6 @@ if __name__ == '__main__':
         print('Not deploying due to no release')
         sys.exit(0)
 
-    start_time = time()
-
-    prev_pending = None
-
-    # We time out after an hour, which is a stupidly long time and it should
-    # never actually take that long: A full Travis run only takes about 20-30
-    # minutes! This is really just here as a guard in case something goes
-    # wrong and we're not paying attention so as to not be too mean to Travis..
-    while time() <= start_time + 60 * 60:
-        jobs = tools.build_jobs()
-
-        failed_jobs = [
-            (k, v)
-            for k, vs in jobs.items()
-            if k not in PENDING_STATUS + ('passed',)
-            for v in vs
-        ]
-
-        if failed_jobs:
-            print('Failing this due to failure of jobs %s' % (
-                ', '.join('%s(%s)' % (s, j) for j, s in failed_jobs),
-            ))
-            sys.exit(1)
-        else:
-            pending = [j for s in PENDING_STATUS for j in jobs.get(s, ())]
-            try:
-                # This allows us to test the deploy job for a build locally.
-                pending.remove('deploy')
-            except ValueError:
-                pass
-            if pending:
-                still_pending = set(pending)
-                if prev_pending is None:
-                    print('Waiting for the following jobs to complete:')
-                    for p in sorted(still_pending):
-                        print(' * %s' % (p,))
-                    print()
-                else:
-                    completed = prev_pending - still_pending
-                    if completed:
-                        print('%s completed since last check.' % (
-                            ', '.join(sorted(completed)),))
-                prev_pending = still_pending
-                naptime = 10.0 * (2 + random.random())
-                print('Waiting %.2fs for %d more job%s to complete' % (
-                    naptime, len(pending), 's' if len(pending) > 1 else '',))
-                sleep(naptime)
-            else:
-                break
-    else:
-        print("We've been waiting for an hour. That seems bad. Failing now.")
-        sys.exit(1)
-
     print('Looks good to release!')
 
     if os.environ.get('TRAVIS_SECURE_ENV_VARS', None) != 'true':


### PR DESCRIPTION
[Build stages are a thing now](https://docs.travis-ci.com/user/build-stages/) so lets use them.

This has two effects:

* We no longer need our hacky use of the Travis API in our deploy script
* We can partition our tests so that the build fails fast and doesn't run the whole damn thing if the early tests are all failing.