### PR TITLE
Extract datetime resolution fix from #826

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This release fixes a bug with generating numpy datetime and timedelta types:
+When inferring the strategy from the dtype, datetime and timedelta dtypes with
+sub-second precision would always produce examples with one second resolution.
+Inferring a strategy from a time dtype will now always produce example with the
+same precision.

--- a/src/hypothesis/extra/numpy.py
+++ b/src/hypothesis/extra/numpy.py
@@ -63,9 +63,11 @@ def from_dtype(dtype):
     elif dtype.kind == u'U':
         result = st.text()
     elif dtype.kind in (u'm', u'M'):
-        res = st.just(dtype.str[-2]) if '[' in dtype.str else \
-            st.sampled_from(TIME_RESOLUTIONS)
-        result = st.builds(dtype.type, st.integers(1 - 2**63, 2**63 - 1), res)
+        if '[' in dtype.str:
+            res = st.just(dtype.str.split('[')[-1][:-1])
+        else:
+            res = st.sampled_from(TIME_RESOLUTIONS)
+        result = st.builds(dtype.type, st.integers(-2**63, 2**63 - 1), res)
     else:
         raise InvalidArgument(u'No strategy inference for {}'.format(dtype))
     return result.map(dtype.type)

--- a/tests/numpy/test_gen_data.py
+++ b/tests/numpy/test_gen_data.py
@@ -262,3 +262,14 @@ def test_may_not_fill_with_non_nan_when_unique_is_set_and_type_is_not_number():
 
     with pytest.raises(InvalidArgument):
         test()
+
+
+@given(st.data(),
+       st.builds('{}[{}]'.format,
+                 st.sampled_from(('datetime64', 'timedelta64')),
+                 st.sampled_from(nps.TIME_RESOLUTIONS)
+                 ).map(np.dtype)
+       )
+def test_inferring_from_time_dtypes_gives_same_dtype(data, dtype):
+    ex = data.draw(nps.from_dtype(dtype))
+    assert dtype == ex.dtype


### PR DESCRIPTION
This is just a very small extraction from #826 - it doesn't contain all of the fixes, just the ones for the datetime and timedelta resolution problems, as those were causing problems in testing #785.

All the correct part of this are @Zac-HD's, but I take full blame for any the mistakes. 😉 