### PR TITLE
Provide a unified helper for asserting unsatisfiability

### DIFF
--- a/tests/common/debug.py
+++ b/tests/common/debug.py
@@ -20,8 +20,8 @@ from __future__ import division, print_function, absolute_import
 import pytest
 
 from hypothesis import settings as Settings
-from hypothesis import find, given, assume
-from hypothesis.errors import Unsatisfiable
+from hypothesis import find, given
+from hypothesis.errors import NoSuchExample
 
 TIME_INCREMENT = 0.01
 
@@ -91,14 +91,11 @@ def find_any(
 
 
 def assert_no_examples(strategy, condition=None):
-    @Settings(perform_health_check=False, max_examples=1, max_iterations=100)
-    @given(strategy)
-    def test(s):
-        if condition is not None:
-            assume(condition(s))
-
-    with pytest.raises(Unsatisfiable):
-        test()
+    with pytest.raises(NoSuchExample):
+        find(
+            strategy, condition or (lambda x: True),
+            settings=Settings(max_iterations=100, max_shrinks=1)
+        )
 
 
 def assert_all_examples(strategy, predicate):

--- a/tests/common/debug.py
+++ b/tests/common/debug.py
@@ -102,12 +102,10 @@ def assert_no_examples(strategy, condition=None):
 
 
 def assert_all_examples(strategy, predicate):
-    """Checks that there are no examples with given strategy that do not match
-    predicate.
+    """Asserts that all examples of the given strategy match the predicate.
 
     :param strategy: Hypothesis strategy to check
-    :param predicate: (callable) Predicate that takes string example and
-        returns bool
+    :param predicate: (callable) Predicate that takes example and returns bool
 
     """
     @given(strategy)

--- a/tests/common/debug.py
+++ b/tests/common/debug.py
@@ -17,8 +17,6 @@
 
 from __future__ import division, print_function, absolute_import
 
-import pytest
-
 from hypothesis import settings as Settings
 from hypothesis import find, given, assume, reject
 from hypothesis.errors import Unsatisfiable
@@ -96,11 +94,14 @@ def assert_no_examples(strategy, condition=None):
     else:
         def predicate(x): assume(condition(x))
 
-    with pytest.raises(Unsatisfiable):
-        find(
+    try:
+        result = find(
             strategy, predicate,
             settings=Settings(max_iterations=100, max_shrinks=1)
         )
+        assert False, "Expected no results but found %r" % (result,)
+    except Unsatisfiable:
+        pass
 
 
 def assert_all_examples(strategy, predicate):

--- a/tests/common/debug.py
+++ b/tests/common/debug.py
@@ -90,9 +90,11 @@ def find_any(
 
 def assert_no_examples(strategy, condition=None):
     if condition is None:
-        def predicate(x): reject()
+        def predicate(x):
+            reject()
     else:
-        def predicate(x): assume(condition(x))
+        def predicate(x):
+            assume(condition(x))
 
     try:
         result = find(

--- a/tests/common/debug.py
+++ b/tests/common/debug.py
@@ -19,7 +19,7 @@ from __future__ import division, print_function, absolute_import
 
 from hypothesis import settings as Settings
 from hypothesis import find, given, assume, reject
-from hypothesis.errors import Unsatisfiable, NoSuchExample
+from hypothesis.errors import NoSuchExample, Unsatisfiable
 
 TIME_INCREMENT = 0.01
 
@@ -101,7 +101,7 @@ def assert_no_examples(strategy, condition=None):
             strategy, predicate,
             settings=Settings(max_iterations=100, max_shrinks=1)
         )
-        assert False, "Expected no results but found %r" % (result,)
+        assert False, 'Expected no results but found %r' % (result,)
     except (Unsatisfiable, NoSuchExample):
         pass
 

--- a/tests/common/debug.py
+++ b/tests/common/debug.py
@@ -19,7 +19,7 @@ from __future__ import division, print_function, absolute_import
 
 from hypothesis import settings as Settings
 from hypothesis import find, given, assume, reject
-from hypothesis.errors import Unsatisfiable
+from hypothesis.errors import Unsatisfiable, NoSuchExample
 
 TIME_INCREMENT = 0.01
 
@@ -102,7 +102,7 @@ def assert_no_examples(strategy, condition=None):
             settings=Settings(max_iterations=100, max_shrinks=1)
         )
         assert False, "Expected no results but found %r" % (result,)
-    except Unsatisfiable:
+    except (Unsatisfiable, NoSuchExample):
         pass
 
 

--- a/tests/common/debug.py
+++ b/tests/common/debug.py
@@ -20,8 +20,8 @@ from __future__ import division, print_function, absolute_import
 import pytest
 
 from hypothesis import settings as Settings
-from hypothesis import find, given
-from hypothesis.errors import NoSuchExample
+from hypothesis import find, given, assume, reject
+from hypothesis.errors import Unsatisfiable
 
 TIME_INCREMENT = 0.01
 
@@ -91,9 +91,14 @@ def find_any(
 
 
 def assert_no_examples(strategy, condition=None):
-    with pytest.raises(NoSuchExample):
+    if condition is None:
+        def predicate(x): reject()
+    else:
+        def predicate(x): assume(condition(x))
+
+    with pytest.raises(Unsatisfiable):
         find(
-            strategy, condition or (lambda x: True),
+            strategy, predicate,
             settings=Settings(max_iterations=100, max_shrinks=1)
         )
 

--- a/tests/cover/test_deferred_strategies.py
+++ b/tests/cover/test_deferred_strategies.py
@@ -20,9 +20,8 @@ from __future__ import division, print_function, absolute_import
 import pytest
 
 from hypothesis import strategies as st
-from hypothesis import find, settings
-from hypothesis.errors import NoSuchExample, InvalidArgument
-from tests.common.debug import minimal
+from hypothesis.errors import InvalidArgument
+from tests.common.debug import minimal, assert_no_examples
 
 
 def test_binary_tree():
@@ -114,12 +113,12 @@ def test_can_draw_one_of_self():
 
 def test_hidden_self_references_just_result_in_no_example():
     bad = st.deferred(lambda: st.none().flatmap(lambda _: bad))
-    assert_actually_empty(bad)
+    assert_no_examples(bad)
 
 
 def test_self_recursive_flatmap():
     bad = st.deferred(lambda: bad.flatmap(lambda x: st.none()))
-    assert_actually_empty(bad)
+    assert_no_examples(bad)
 
 
 def test_self_reference_through_one_of_can_detect_emptiness():
@@ -127,22 +126,17 @@ def test_self_reference_through_one_of_can_detect_emptiness():
     assert bad.is_empty
 
 
-def assert_actually_empty(s):
-    with pytest.raises(NoSuchExample):
-        find(s, lambda x: True, settings=settings(max_shrinks=0))
-
-
 def test_self_tuple_draws_nothing():
     x = st.deferred(lambda: st.tuples(x))
-    assert_actually_empty(x)
+    assert_no_examples(x)
 
 
 def test_mutually_recursive_tuples_draw_nothing():
     x = st.deferred(lambda: st.tuples(y))
     y = st.tuples(x)
 
-    assert_actually_empty(x)
-    assert_actually_empty(y)
+    assert_no_examples(x)
+    assert_no_examples(y)
 
 
 def test_self_recursive_lists():

--- a/tests/cover/test_example.py
+++ b/tests/cover/test_example.py
@@ -19,8 +19,11 @@ from __future__ import division, print_function, absolute_import
 
 from random import Random
 
+import pytest
+
 import hypothesis.strategies as st
 from hypothesis import find, given, example
+from hypothesis.errors import NoExamples
 from hypothesis.control import _current_build_context
 from tests.common.utils import checks_deprecated_behaviour
 
@@ -37,6 +40,11 @@ def test_does_not_always_give_the_same_example():
     assert len(set(
         s.example() for _ in range(100)
     )) >= 10
+
+
+def test_raises_on_no_examples():
+    with pytest.raises(NoExamples):
+        st.nothing().example()
 
 
 @checks_deprecated_behaviour

--- a/tests/cover/test_map.py
+++ b/tests/cover/test_map.py
@@ -17,11 +17,9 @@
 
 from __future__ import division, print_function, absolute_import
 
-import pytest
-
 from hypothesis import strategies as st
 from hypothesis import given, assume
-from hypothesis.errors import NoExamples
+from tests.common.debug import assert_no_examples
 
 
 @given(st.integers().map(lambda x: assume(x % 3 != 0) and x))
@@ -30,5 +28,4 @@ def test_can_assume_in_map(x):
 
 
 def test_assume_in_just_raises_immediately():
-    with pytest.raises(NoExamples):
-        st.just(1).map(lambda x: assume(x == 2)).example()
+    assert_no_examples(st.just(1).map(lambda x: assume(x == 2)))

--- a/tests/cover/test_nothing.py
+++ b/tests/cover/test_nothing.py
@@ -21,7 +21,8 @@ import pytest
 
 from hypothesis import strategies as st
 from hypothesis import find, given
-from hypothesis.errors import NoExamples, InvalidArgument
+from hypothesis.errors import InvalidArgument
+from tests.common.debug import assert_no_examples
 
 
 def test_resampling():
@@ -62,5 +63,4 @@ def test_fixed_dictionaries_detect_empty_values():
 
 
 def test_no_examples():
-    with pytest.raises(NoExamples):
-        st.nothing().example()
+    assert_no_examples(st.nothing())

--- a/tests/cover/test_one_of.py
+++ b/tests/cover/test_one_of.py
@@ -17,14 +17,11 @@
 
 from __future__ import division, print_function, absolute_import
 
-import pytest
-
 import hypothesis.strategies as st
-from hypothesis.errors import NoExamples
+from tests.common.debug import assert_no_examples
 
 
 def test_one_of_empty():
     e = st.one_of()
     assert e.is_empty
-    with pytest.raises(NoExamples):
-        e.example()
+    assert_no_examples(e)

--- a/tests/cover/test_searchstrategy.py
+++ b/tests/cover/test_searchstrategy.py
@@ -23,7 +23,7 @@ from collections import namedtuple
 import pytest
 
 from hypothesis.types import RandomWithSeed
-from hypothesis.errors import NoExamples
+from tests.common.debug import assert_no_examples
 from hypothesis.strategies import just, tuples, randoms, booleans, integers
 from hypothesis.internal.compat import text_type
 from hypothesis.searchstrategy.strategies import one_of_strategies
@@ -78,8 +78,7 @@ def test_can_map():
 
 
 def test_example_raises_unsatisfiable_when_too_filtered():
-    with pytest.raises(NoExamples):
-        integers().filter(lambda x: False).example()
+    assert_no_examples(integers().filter(lambda x: False))
 
 
 def nameless_const(x):

--- a/tests/cover/test_simple_characters.py
+++ b/tests/cover/test_simple_characters.py
@@ -22,8 +22,8 @@ import unicodedata
 import pytest
 
 from hypothesis import find
-from hypothesis.errors import NoSuchExample, InvalidArgument
-from tests.common.debug import find_any
+from hypothesis.errors import InvalidArgument
+from tests.common.debug import find_any, assert_no_examples
 from hypothesis.strategies import characters
 from hypothesis.internal.compat import text_type
 
@@ -58,8 +58,8 @@ def test_characters_of_specific_groups():
     find(st, lambda c: unicodedata.category(c) == 'Lu')
     find(st, lambda c: unicodedata.category(c) == 'Nd')
 
-    with pytest.raises(NoSuchExample):
-        find(st, lambda c: unicodedata.category(c) not in ('Lu', 'Nd'))
+    assert_no_examples(
+        st, lambda c: unicodedata.category(c) not in ('Lu', 'Nd'))
 
 
 def test_exclude_characters_of_specific_groups():
@@ -68,8 +68,7 @@ def test_exclude_characters_of_specific_groups():
     find(st, lambda c: unicodedata.category(c) != 'Lu')
     find(st, lambda c: unicodedata.category(c) != 'Nd')
 
-    with pytest.raises(NoSuchExample):
-        find(st, lambda c: unicodedata.category(c) in ('Lu', 'Nd'))
+    assert_no_examples(st, lambda c: unicodedata.category(c) in ('Lu', 'Nd'))
 
 
 def test_find_one():
@@ -82,8 +81,7 @@ def test_find_something_rare():
 
     find(st, lambda c: unicodedata.category(c) == 'Zs')
 
-    with pytest.raises(NoSuchExample):
-        find(st, lambda c: unicodedata.category(c) != 'Zs')
+    assert_no_examples(st, lambda c: unicodedata.category(c) != 'Zs')
 
 
 def test_whitelisted_characters_alone():
@@ -110,8 +108,7 @@ def test_whitelisted_characters_override():
     find_any(st, lambda c: c in good_characters)
     find_any(st, lambda c: c in '0123456789')
 
-    with pytest.raises(NoSuchExample):
-        find_any(st, lambda c: c not in good_characters + '0123456789')
+    assert_no_examples(st, lambda c: c not in good_characters + '0123456789')
 
 
 def test_blacklisted_characters():
@@ -121,8 +118,7 @@ def test_blacklisted_characters():
 
     assert '1' == find(st, lambda c: True)
 
-    with pytest.raises(NoSuchExample):
-        find(st, lambda c: c in bad_chars)
+    assert_no_examples(st, lambda c: c in bad_chars)
 
 
 def test_whitelist_characters_disjoint_blacklist_characters():
@@ -132,5 +128,4 @@ def test_whitelist_characters_disjoint_blacklist_characters():
                     blacklist_characters=bad_chars,
                     whitelist_characters=good_chars)
 
-    with pytest.raises(NoSuchExample):
-        find(st, lambda c: c in bad_chars)
+    assert_no_examples(st, lambda c: c in bad_chars)


### PR DESCRIPTION
I decided to do a trial run of the algorithm for getting coverage time down I proposed in #852, but found that the most expensive tests were ones in test_regex.py for asserting unsatisfiability of certain conditions, and rather than wanting to move these tests to nocover there was just an obvious way to make them faster.

So this is that way. It provides a single unified helper to assert that no examples (possibly of a condition) exist. The main performance improvement comes from the fact that it runs substantially fewer trials than using `example()`, but it's also just nice to have a unified helper for doing this.