### PR TITLE
Suppress 'too slow' healthcheck for TransactionTest

### DIFF
--- a/docs/django.rst
+++ b/docs/django.rst
@@ -25,6 +25,9 @@ I strongly recommend not using
 unless you really have to.
 Because Hypothesis runs this in a loop the performance problems it normally has
 are significantly exacerbated and your tests will be really slow.
+If you are using :class:`~hypothesis.extra.django.TransactionTestCase`,
+you may need to use ``@settings(suppress_health_check=[HealthCheck.too_slow])``
+to avoid :doc:`errors due to slow example generation </healthchecks>`.
 
 In addition to the above, Hypothesis has some limited support for automatically
 deriving strategies for your model types, which you can then customize further.

--- a/tests/django/toystore/test_basic_configuration.py
+++ b/tests/django/toystore/test_basic_configuration.py
@@ -21,7 +21,7 @@ from unittest import TestCase as VanillaTestCase
 
 from django.db import IntegrityError
 
-from hypothesis import given, settings
+from hypothesis import HealthCheck, given, settings
 from hypothesis.strategies import integers
 from hypothesis.extra.django import TestCase, TransactionTestCase
 from hypothesis.internal.compat import PYPY
@@ -30,6 +30,7 @@ from tests.django.toystore.models import Company
 
 class SomeStuff(object):
 
+    @settings(suppress_health_check=[HealthCheck.too_slow])
     @given(integers())
     def test_is_blank_slate(self, unused):
         Company.objects.create(name=u'MickeyCo')


### PR DESCRIPTION
Closes #846 the easy way, by suppressing the relevant check and suggesting that users do the same thing.