### PR TITLE
Set up Mypy and gradual static typing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.pyc
 venv*
 .cache
+.mypy_cache
 .hypothesis
 docs/_build
 *.egg-info

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ env:
         - TASK=lint
         - TASK=check-rst
         - TASK=check-format
+        - TASK=check-types
         - TASK=check-benchmark
         - TASK=check-coverage
         - TASK=check-requirements

--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,9 @@ check-format: format
 	find src tests -name "*.py" | xargs $(TOOL_PYTHON) scripts/check_encoding_header.py
 	git diff --exit-code
 
+check-types: $(TOOL_VIRTUALENV)
+	$(TOOL_PYTHON) -m mypy src/hypothesis
+
 install-core: $(PY27) $(PYPY) $(BEST_PY3) $(TOX)
 
 STACK=$(HOME)/.local/bin/stack

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch adds :PEP:`484` type hints to Hypothesis, on an experimental
+basis.  There should be no user-visible impact whatsoever.

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,4 +1,6 @@
 RELEASE_TYPE: patch
 
-This patch adds :PEP:`484` type hints to Hypothesis, on an experimental
-basis.  There should be no user-visible impact whatsoever.
+This patch adds :PEP:`484` type hints to Hypothesis, on an experimental basis.
+There is no user-visible impact in Hypothesis itself, but if you are using Mypy
+with the ``follow_imports`` option you *might* see better results from
+Hypothesis.

--- a/mypy.ini
+++ b/mypy.ini
@@ -8,6 +8,20 @@ ignore_missing_imports = True
 warn_unused_ignores = True
 warn_unused_configs = True
 warn_redundant_casts = True
+check_untyped_defs = True
 
 [mypy-hypothesis.vendor.*]
 ignore_errors = True
+
+# TODO: remove each of the below and fix any warnings
+[mypy-hypothesis.stateful]
+check_untyped_defs = False
+
+[mypy-hypothesis.extra.*]
+check_untyped_defs = False
+
+[mypy-hypothesis.internal.*]
+check_untyped_defs = False
+
+[mypy-hypothesis.searchstrategy.*]
+check_untyped_defs = False

--- a/mypy.ini
+++ b/mypy.ini
@@ -12,7 +12,3 @@ check_untyped_defs = True
 
 [mypy-hypothesis.vendor.*]
 ignore_errors = True
-
-[mypy-hypothesis.stateful,hypothesis.extra.pandas.impl]
-# Some names (eg Rule, Invariant, column) clash with typeshed/builtins.pyi
-check_untyped_defs = False

--- a/mypy.ini
+++ b/mypy.ini
@@ -16,7 +16,3 @@ ignore_errors = True
 [mypy-hypothesis.stateful,hypothesis.extra.pandas.impl]
 # Some names (eg Rule, Invariant, column) clash with typeshed/builtins.pyi
 check_untyped_defs = False
-
-# TODO: remove each of the below and fix any warnings
-[mypy-hypothesis.internal.conjecture.*]
-check_untyped_defs = False

--- a/mypy.ini
+++ b/mypy.ini
@@ -13,13 +13,11 @@ check_untyped_defs = True
 [mypy-hypothesis.vendor.*]
 ignore_errors = True
 
+[mypy-hypothesis.stateful,hypothesis.extra.pandas.impl]
+# Some names (eg Rule, Invariant, column) clash with typeshed/builtins.pyi
+check_untyped_defs = False
+
 # TODO: remove each of the below and fix any warnings
-[mypy-hypothesis.stateful]
-check_untyped_defs = False
-
-[mypy-hypothesis.extra.*]
-check_untyped_defs = False
-
 [mypy-hypothesis.internal.*]
 check_untyped_defs = False
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -18,7 +18,7 @@ ignore_errors = True
 check_untyped_defs = False
 
 # TODO: remove each of the below and fix any warnings
-[mypy-hypothesis.internal.*]
+[mypy-hypothesis.internal.conjecture.*]
 check_untyped_defs = False
 
 [mypy-hypothesis.searchstrategy.*]

--- a/mypy.ini
+++ b/mypy.ini
@@ -20,6 +20,3 @@ check_untyped_defs = False
 # TODO: remove each of the below and fix any warnings
 [mypy-hypothesis.internal.conjecture.*]
 check_untyped_defs = False
-
-[mypy-hypothesis.searchstrategy.*]
-check_untyped_defs = False

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,13 @@
+[mypy]
+python_version = 3.6
+platform = linux
+cache_dir = /dev/null
+
+follow_imports = silent
+ignore_missing_imports = True
+warn_unused_ignores = True
+warn_unused_configs = True
+warn_redundant_casts = True
+
+[mypy-hypothesis.vendor.*]
+ignore_errors = True

--- a/requirements/tools.in
+++ b/requirements/tools.in
@@ -1,5 +1,6 @@
 flake8
 isort
+mypy
 pip-tools
 pyformat
 pytest

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -25,6 +25,7 @@ isort==4.2.15
 jinja2==2.9.6             # via pyupio, sphinx
 markupsafe==1.0           # via jinja2
 mccabe==0.6.1             # via flake8
+mypy==0.540
 packaging==16.8           # via dparse, pyupio, safety
 pip-tools==1.10.1
 pkginfo==1.4.1            # via twine
@@ -54,6 +55,7 @@ sphinxcontrib-websupport==1.0.1  # via sphinx
 tox==2.9.1
 tqdm==4.19.4              # via pyupio, twine
 twine==1.9.1
+typed-ast==1.1.0          # via mypy
 unify==0.3                # via pyformat
 untokenize==0.1.1         # via docformatter, unify
 urllib3==1.22             # via requests

--- a/src/hypothesis/_settings.py
+++ b/src/hypothesis/_settings.py
@@ -212,7 +212,8 @@ class settings(settingsMeta('settings', (object,), {})):  # type: ignore
         if future_default is not_set:
             future_default = default
 
-        all_settings[name] = Setting(
+        # Mypy is referring to the wrong 'Setting' type here
+        all_settings[name] = Setting(  # type: ignore
             name, description.strip(), default, options, validator,
             future_default, deprecation_message,
         )

--- a/src/hypothesis/_settings.py
+++ b/src/hypothesis/_settings.py
@@ -37,6 +37,9 @@ from hypothesis.configuration import hypothesis_home_dir
 from hypothesis.utils.conventions import UniqueIdentifier, not_set
 from hypothesis.utils.dynamicvariables import DynamicVariable
 
+if False:
+    from typing import Dict, List  # noqa
+
 __all__ = [
     'settings',
 ]
@@ -45,10 +48,10 @@ __all__ = [
 unlimited = UniqueIdentifier('unlimited')
 
 
-all_settings = {}
+all_settings = {}  # type: Dict[str, Setting]
 
 
-_db_cache = {}
+_db_cache = {}  # type: dict
 
 
 class settingsProperty(object):
@@ -108,7 +111,7 @@ class settingsMeta(type):
         default_variable.value = value
 
 
-class settings(settingsMeta('settings', (object,), {})):
+class settings(settingsMeta('settings', (object,), {})):  # type: ignore
 
     """A settings object controls a variety of parameters that are used in
     falsification. These may control both the falsification strategy and the
@@ -123,7 +126,7 @@ class settings(settingsMeta('settings', (object,), {})):
         '_database', '_construction_complete', 'storage'
     ]
     __definitions_are_locked = False
-    _profiles = {}
+    _profiles = {}  # type: dict
 
     def __getattr__(self, name):
         if name in all_settings:
@@ -498,6 +501,11 @@ class Statistics(IntEnum):
 
 
 class Verbosity(object):
+    quiet = None  # type: Verbosity
+    normal = None  # type: Verbosity
+    verbose = None  # type: Verbosity
+    debug = None  # type: Verbosity
+    all = None  # type: List[Verbosity]
 
     def __repr__(self):
         return 'Verbosity.%s' % (self.name,)

--- a/src/hypothesis/control.py
+++ b/src/hypothesis/control.py
@@ -24,6 +24,9 @@ from hypothesis.errors import CleanupFailed, InvalidArgument, \
 from hypothesis.reporting import report
 from hypothesis.utils.dynamicvariables import DynamicVariable
 
+if False:
+    from typing import List, Callable  # noqa
+
 
 def reject():
     raise UnsatisfiedAssumption()
@@ -57,11 +60,11 @@ class BuildContext(object):
 
     def __init__(self, data, is_final=False, close_on_capture=True):
         self.data = data
-        self.tasks = []
+        self.tasks = []  # type: List[Callable[[], None]]
         self.is_final = is_final
         self.close_on_capture = close_on_capture
         self.close_on_del = False
-        self.notes = []
+        self.notes = []  # type: list
 
     def __enter__(self):
         self.assign_variable = _current_build_context.with_value(self)

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -66,6 +66,9 @@ try:
 except ImportError:  # pragma: no cover
     from coverage.collector import FileDisposition
 
+if False:
+    from typing import Any, Dict  # noqa
+
 
 running_under_pytest = False
 global_force_seed = None
@@ -560,7 +563,7 @@ class Arc(object):
         self.target = target
 
 
-ARC_CACHE = {}
+ARC_CACHE = {}  # type: Dict[str, Dict[Any, Dict[Any, Arc]]]
 
 
 def arc(filename, source, target):

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -111,7 +111,10 @@ def example(*args, **kwargs):
     def accept(test):
         if not hasattr(test, 'hypothesis_explicit_examples'):
             test.hypothesis_explicit_examples = []
-        test.hypothesis_explicit_examples.append(Example(tuple(args), kwargs))
+        test.hypothesis_explicit_examples.append(
+            # See https://github.com/python/mypy/issues/4132
+            Example(tuple(args), kwargs)  # type: ignore
+        )
         return test
     return accept
 

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -67,7 +67,7 @@ except ImportError:  # pragma: no cover
     from coverage.collector import FileDisposition
 
 if False:
-    from typing import Any, Dict  # noqa
+    from typing import Any, Set, Dict  # noqa
 
 
 running_under_pytest = False
@@ -629,7 +629,7 @@ class StateForActualGivenExecution(object):
             self.test = timed_test
 
         self.coverage_data = CoverageData()
-        self.files_to_propagate = set()
+        self.files_to_propagate = set()  # type: Set[str]
 
         if settings.use_coverage and not IN_COVERAGE_TESTS:  # pragma: no cover
             if Collector._collectors:

--- a/src/hypothesis/database.py
+++ b/src/hypothesis/database.py
@@ -24,10 +24,14 @@ import threading
 from contextlib import contextmanager
 
 from hypothesis._settings import note_deprecation
-from hypothesis.internal.compat import FileNotFoundError, sha1, hbytes, \
-    b64decode, b64encode
+from hypothesis.internal.compat import PY3, FileNotFoundError, sha1, \
+    hbytes, b64decode, b64encode
 
-sqlite3 = None
+if False:
+    from typing import Any  # noqa
+
+
+sqlite3 = None  # type: Any
 SQLITE_PATH = re.compile(r"\.\(db|sqlite|sqlite3\)$")
 
 
@@ -108,7 +112,7 @@ class ExampleDatabase(
 class InMemoryExampleDatabase(ExampleDatabase):
 
     def __init__(self):
-        self.data = {}
+        self.data = {}  # type: dict
 
     def __repr__(self):
         return 'InMemoryExampleDatabase(%r)' % (self.data,)
@@ -242,7 +246,7 @@ class DirectoryBasedExampleDatabase(ExampleDatabase):
 
     def __init__(self, path):
         self.path = path
-        self.keypaths = {}
+        self.keypaths = {}  # type: dict
 
     def __repr__(self):
         return 'DirectoryBasedExampleDatabase(%r)' % (self.path,)
@@ -278,10 +282,10 @@ class DirectoryBasedExampleDatabase(ExampleDatabase):
     def save(self, key, value):
         path = self._value_path(key, value)
         if not os.path.exists(path):
-            suffix = binascii.hexlify(os.urandom(16))
-            if not isinstance(suffix, str):  # pragma: no branch
-                # On Python 3, binascii.hexlify returns bytes
-                suffix = suffix.decode('ascii')
+            if PY3:
+                suffix = binascii.hexlify(os.urandom(16)).decode('ascii')
+            else:  # pragma: no cover
+                suffix = binascii.hexlify(os.urandom(16))
             tmpname = path + '.' + suffix
             with open(tmpname, 'wb') as o:
                 o.write(value)

--- a/src/hypothesis/database.py
+++ b/src/hypothesis/database.py
@@ -53,7 +53,9 @@ class EDMeta(type):
         return super(EDMeta, self).__call__(*args, **kwargs)
 
 
-class ExampleDatabase(EDMeta('ExampleDatabase', (object,), {})):
+class ExampleDatabase(
+    EDMeta('ExampleDatabase', (object,), {})  # type: ignore
+):
     """Interface class for storage systems.
 
     A key -> multiple distinct values mapping.

--- a/src/hypothesis/extra/django/models.py
+++ b/src/hypothesis/extra/django/models.py
@@ -105,7 +105,7 @@ def validator_to_filter(f):
 
 def _get_strategy_for_field(f):
     if f.choices:
-        choices = []
+        choices = []  # type: list
         for value, name_or_optgroup in f.choices:
             if isinstance(name_or_optgroup, (list, tuple)):
                 choices.extend(key for key, _ in name_or_optgroup)

--- a/src/hypothesis/extra/fakefactory.py
+++ b/src/hypothesis/extra/fakefactory.py
@@ -70,7 +70,7 @@ class FakeFactoryStrategy(SearchStrategy):
         self.source = source
         self.providers = tuple(providers)
         self.locales = tuple(locales)
-        self.factories = {}
+        self.factories = {}  # type: dict
 
     def do_draw(self, data):
         seed = data.draw_bytes(4)

--- a/src/hypothesis/extra/numpy.py
+++ b/src/hypothesis/extra/numpy.py
@@ -128,7 +128,7 @@ class ArrayStrategy(SearchStrategy):
             # generate a fully dense array with a freshly drawn value for each
             # entry.
             if self.unique:
-                seen = set()
+                seen = set()  # type: set
                 elements = cu.many(
                     data,
                     min_size=self.array_size, max_size=self.array_size,

--- a/src/hypothesis/extra/pandas/impl.py
+++ b/src/hypothesis/extra/pandas/impl.py
@@ -321,7 +321,8 @@ def columns(
     except TypeError:
         names = [None] * names_or_number
     return [
-        column(
+        # Mypy can't find __init__; https://github.com/python/mypy/issues/4132
+        column(  # type: ignore
             name=n, dtype=dtype, elements=elements, fill=fill, unique=unique
         ) for n in names
     ]

--- a/src/hypothesis/extra/pandas/impl.py
+++ b/src/hypothesis/extra/pandas/impl.py
@@ -40,6 +40,9 @@ except ImportError:  # pragma: no cover
             return False
         return dt == 'category'
 
+if False:
+    from typing import Any, Dict, List, Optional  # noqa
+
 
 def dtype_for_elements_strategy(s):
     return st.shared(
@@ -116,7 +119,7 @@ class ValueIndexStrategy(st.SearchStrategy):
 
     def do_draw(self, data):
         result = []
-        seen = set()
+        seen = set()  # type: set
 
         iterator = cu.many(
             data, min_size=self.min_size, max_size=self.max_size,
@@ -472,7 +475,7 @@ def data_frames(
     columns = st.try_convert(tuple, columns, 'columns')
 
     rewritten_columns = []
-    column_names = set()
+    column_names = set()  # type: set
 
     for i, c in enumerate(columns):
         st.check_type(column, c, 'columns[%d]' % (i,))
@@ -520,7 +523,8 @@ def data_frames(
             index = draw(index_strategy)
             local_index_strategy = st.just(index)
 
-            data = OrderedDict((c.name, None) for c in rewritten_columns)
+            default = None  # type: pandas.Series
+            data = OrderedDict((c.name, default) for c in rewritten_columns)
 
             # Depending on how the columns are going to be generated we group
             # them differently to get better shrinking. For columns with fill
@@ -545,7 +549,8 @@ def data_frames(
                         index=index,
                     )
                 seen = {
-                    c.name: set() for c in columns_without_fill if c.unique}
+                    c.name: set() for c in columns_without_fill if c.unique
+                }  # type: Dict[str, set]
 
                 for i in hrange(len(index)):
                     for c in columns_without_fill:
@@ -580,13 +585,14 @@ def data_frames(
                 for c in rewritten_columns
             ), index=index)
 
-            fills = {}
+            fills = {}  # type: Dict[int, Any]
 
             any_unique = any(c.unique for c in rewritten_columns)
 
             if any_unique:
                 all_seen = [
-                    set() if c.unique else None for c in rewritten_columns]
+                    set() if c.unique else None for c in rewritten_columns
+                ]  # type: List[Optional[set]]
                 while all_seen[-1] is None:
                     all_seen.pop()
 

--- a/src/hypothesis/extra/pytestplugin.py
+++ b/src/hypothesis/extra/pytestplugin.py
@@ -26,6 +26,9 @@ from hypothesis.statistics import collector
 from hypothesis.internal.compat import OrderedDict, text_type
 from hypothesis.internal.detection import is_hypothesis_test
 
+if False:
+    from typing import List, Text  # noqa
+
 LOAD_PROFILE_OPTION = '--hypothesis-profile'
 PRINT_STATISTICS_OPTION = '--hypothesis-show-statistics'
 SEED_OPTION = '--hypothesis-seed'
@@ -35,7 +38,7 @@ class StoringReporter(object):
 
     def __init__(self, config):
         self.config = config
-        self.results = []
+        self.results = []  # type: List[Text]
 
     def __call__(self, msg):
         if self.config.getoption('capture', 'fd') == 'no':

--- a/src/hypothesis/extra/pytz.py
+++ b/src/hypothesis/extra/pytz.py
@@ -31,6 +31,9 @@ import pytz
 
 import hypothesis.strategies as st
 
+if False:
+    from typing import List  # noqa
+
 __all__ = ['timezones']
 
 
@@ -48,10 +51,12 @@ def timezones():
     # Some timezones have always had a constant offset from UTC.  This makes
     # them simpler than timezones with daylight savings, and the smaller the
     # absolute offset the simpler they are.  Of course, UTC is even simpler!
-    static = [pytz.UTC] + sorted(
-        (t for t in all_timezones if isinstance(t, pytz.tzfile.StaticTzInfo)),
+    timezones = [pytz.UTC]  # type: List[dt.tzinfo]
+    timezones += sorted(
+        (t for t in all_timezones
+         if isinstance(t, pytz.tzfile.StaticTzInfo)),  # type: ignore
         key=lambda tz: abs(tz.utcoffset(dt.datetime(2000, 1, 1)))
     )
     # Timezones which have changed UTC offset; best ordered by name.
-    dynamic = [tz for tz in all_timezones if tz not in static]
-    return st.sampled_from(static + dynamic)
+    timezones += [tz for tz in all_timezones if tz not in timezones]
+    return st.sampled_from(timezones)

--- a/src/hypothesis/internal/cache.py
+++ b/src/hypothesis/internal/cache.py
@@ -19,6 +19,9 @@ from __future__ import division, print_function, absolute_import
 
 import attr
 
+if False:
+    from typing import Any, Dict, List  # noqa
+
 
 @attr.s(slots=True)
 class Entry(object):
@@ -55,12 +58,12 @@ class GenericCache(object):
         self.max_size = max_size
 
         # Implementation: We store a binary heap of Entry objects in self.data,
-        # with the heap property requirnig that a parent's score is <= that of
+        # with the heap property requiring that a parent's score is <= that of
         # its children. keys_to_index then maps keys to their index in the
         # heap. We keep these two in sync automatically - the heap is never
         # reordered without updating the index.
-        self.keys_to_indices = {}
-        self.data = []
+        self.keys_to_indices = {}  # type: Dict[Any, int]
+        self.data = []  # type: List[Entry]
 
     def __len__(self):
         assert len(self.keys_to_indices) == len(self.data)
@@ -80,7 +83,8 @@ class GenericCache(object):
         try:
             i = self.keys_to_indices[key]
         except KeyError:
-            entry = Entry(key, value, self.new_entry(key, value))
+            new_entry = self.new_entry(key, value)
+            entry = Entry(key, value, new_entry)  # type: ignore
             if len(self.data) >= self.max_size:
                 evicted = self.data[0]
                 del self.keys_to_indices[evicted.key]

--- a/src/hypothesis/internal/charmap.py
+++ b/src/hypothesis/internal/charmap.py
@@ -27,6 +27,11 @@ import unicodedata
 from hypothesis.configuration import tmpdir, storage_directory
 from hypothesis.internal.compat import hunichr
 
+if False:
+    from typing import Dict, Tuple
+    intervals = Tuple[Tuple[int, int], ...]
+    cache_type = Dict[Tuple[Tuple[str, ...], int, int, intervals], intervals]
+
 
 def charmap_file():
     return os.path.join(
@@ -207,7 +212,7 @@ def _query_for_key(key):
     return result
 
 
-limited_category_index_cache = {}
+limited_category_index_cache = {}  # type: cache_type
 
 
 def query(

--- a/src/hypothesis/internal/charmap.py
+++ b/src/hypothesis/internal/charmap.py
@@ -28,7 +28,7 @@ from hypothesis.configuration import tmpdir, storage_directory
 from hypothesis.internal.compat import hunichr
 
 if False:
-    from typing import Dict, Tuple
+    from typing import Dict, List, Text, Tuple  # noqa
     intervals = Tuple[Tuple[int, int], ...]
     cache_type = Dict[Tuple[Tuple[str, ...], int, int, intervals], intervals]
 
@@ -40,7 +40,7 @@ def charmap_file():
     )
 
 
-_charmap = None
+_charmap = None  # type: Dict[Text, intervals]
 
 
 def charmap():
@@ -58,11 +58,12 @@ def charmap():
     if _charmap is None:
         f = charmap_file()
         try:
-            with gzip.GzipFile(f, 'rb') as i:
-                _charmap = dict(pickle.load(i))
+            # Mypy does not know that a GzipFile is IO[bytes]
+            with gzip.GzipFile(f, 'rb') as data:
+                _charmap = dict(pickle.load(data))  # type: ignore
 
         except Exception:
-            tmp_charmap = {}
+            tmp_charmap = {}  # type: Dict[Text, List[List[int]]]
             for i in range(0, sys.maxunicode + 1):
                 cat = unicodedata.category(hunichr(i))
                 rs = tmp_charmap.setdefault(cat, [])
@@ -70,8 +71,8 @@ def charmap():
                     rs[-1][-1] += 1
                 else:
                     rs.append([i, i])
-            _charmap = {k: tuple((map(tuple, v)))
-                        for k, v in tmp_charmap.items()}
+            _charmap = {k: tuple((pair[0], pair[1]) for pair in pairs)
+                        for k, pairs in tmp_charmap.items()}
 
             try:
                 # Write the Unicode table atomically
@@ -79,7 +80,8 @@ def charmap():
                 os.close(fd)
                 # Explicitly set the mtime to get reproducible output
                 with gzip.GzipFile(tmpfile, 'wb', mtime=1) as o:
-                    pickle.dump(sorted(_charmap.items()), o,
+                    # Mypy does not know that a GzipFile is IO[bytes]
+                    pickle.dump(sorted(_charmap.items()), o,  # type: ignore
                                 pickle.HIGHEST_PROTOCOL)
                 os.rename(tmpfile, f)
             except Exception:  # pragma: no cover
@@ -88,11 +90,11 @@ def charmap():
     return _charmap
 
 
-_categories = None
+_categories = None  # type: List[str]
 
 
 def categories():
-    """Return a list of Unicode categories in a normalised order.
+    """Return a tuple of Unicode categories in a normalised order.
 
     >>> categories() # doctest: +ELLIPSIS
     ['Zl', 'Zp', 'Co', 'Me', 'Pc', ..., 'Cc', 'Cs']
@@ -112,6 +114,7 @@ def categories():
 
 
 def _union_intervals(x, y):
+    # type: (intervals, intervals) -> intervals
     """Merge two sequences of intervals into a single tuple of intervals.
 
     Any integer bounded by `x` or `y` is also bounded by the result.
@@ -147,6 +150,7 @@ def _union_intervals(x, y):
 
 
 def _intervals(s):
+    # type: (str) -> intervals
     """Return a tuple of intervals, covering the codepoints of characters in
     `s`.
 
@@ -154,13 +158,13 @@ def _intervals(s):
     ((48, 57), (97, 102))
 
     """
-    intervals = [(ord(c), ord(c)) for c in sorted(s)]
+    intervals = tuple((ord(c), ord(c)) for c in sorted(s))
     return _union_intervals(intervals, intervals)
 
 
 category_index_cache = {
     (): (),
-}
+}  # type: Dict[Tuple[str, ...], intervals]
 
 
 def _category_key(exclude, include):
@@ -201,9 +205,8 @@ def _query_for_key(key):
     except KeyError:
         pass
     assert key
-    cs = categories()
-    if len(key) == len(cs):
-        result = ((0, sys.maxunicode),)
+    if set(key) == set(categories()):
+        result = ((0, sys.maxunicode),)  # type: intervals
     else:
         result = _union_intervals(
             _query_for_key(key[:-1]), charmap()[key[-1]]
@@ -249,13 +252,11 @@ def query(
     except KeyError:
         pass
     base = _query_for_key(catkey)
-    result = []
+    tmp = []  # type: List[Tuple[int, int]]
     for u, v in base:
         if v >= min_codepoint and u <= max_codepoint:
-            result.append((
-                max(u, min_codepoint), min(v, max_codepoint)
-            ))
-    result = tuple(result)
+            tmp.append((max(u, min_codepoint), min(v, max_codepoint)))
+    result = tuple(tmp)
     result = _union_intervals(result, character_intervals)
     limited_category_index_cache[qkey] = result
     return result

--- a/src/hypothesis/internal/compat.py
+++ b/src/hypothesis/internal/compat.py
@@ -439,7 +439,7 @@ class compatbytes(bytearray):
         return compatbytes(bytearray.__rmul__(self, value))
 
     def __getitem__(self, *args, **kwargs):
-        r = bytearray.__getitem__(self, *args, **kwargs)
+        r = bytearray.__getitem__(self, *args, **kwargs)  # type: ignore
         if isinstance(r, bytearray):
             return compatbytes(r)
         else:

--- a/src/hypothesis/internal/compat.py
+++ b/src/hypothesis/internal/compat.py
@@ -38,7 +38,7 @@ except ImportError:  # pragma: no cover
     from counter import Counter  # type: ignore
 
 if False:
-    from typing import Type  # noqa
+    from typing import Type, Tuple  # noqa
 
 
 PY2 = sys.version_info[0] == 2
@@ -73,7 +73,7 @@ if PY3:
     binary_type = bytes
     hrange = range
     ARG_NAME_ATTRIBUTE = 'arg'
-    integer_types = (int,)
+    integer_types = (int,)  # type: Tuple[type]
     hunichr = chr
     from functools import reduce
 

--- a/src/hypothesis/internal/compat.py
+++ b/src/hypothesis/internal/compat.py
@@ -34,8 +34,11 @@ from collections import namedtuple
 try:
     from collections import OrderedDict, Counter
 except ImportError:  # pragma: no cover
-    from ordereddict import OrderedDict
-    from counter import Counter
+    from ordereddict import OrderedDict  # type: ignore
+    from counter import Counter  # type: ignore
+
+if False:
+    from typing import Type  # noqa
 
 
 PY2 = sys.version_info[0] == 2
@@ -499,7 +502,7 @@ def implements_iterator(it):
 
 
 if PY3:
-    FileNotFoundError = FileNotFoundError
+    FileNotFoundError = FileNotFoundError  # type: Type[IOError]
 else:
     FileNotFoundError = IOError
 
@@ -507,7 +510,7 @@ else:
 # an existing file where you're not allowed to. This is rather less consistent
 # between versions than might be hoped.
 if PY3:
-    FileExistsError = FileExistsError
+    FileExistsError = FileExistsError  # type: Type[IOError]
 
 elif WINDOWS:
     FileExistsError = WindowsError

--- a/src/hypothesis/internal/conjecture/data.py
+++ b/src/hypothesis/internal/conjecture/data.py
@@ -25,6 +25,9 @@ from hypothesis.internal.compat import hbytes, hrange, text_type, \
     bit_length, benchmark_time, int_from_bytes, unicode_safe_repr
 from hypothesis.internal.coverage import IN_COVERAGE_TESTS
 
+if False:
+    from typing import Set, Dict, List, Tuple, Union  # noqa
+
 
 class Status(IntEnum):
     OVERRUN = 0
@@ -63,24 +66,24 @@ class ConjectureData(object):
         self._draw_bytes = draw_bytes
         self.overdraw = 0
         self.level = 0
-        self.block_starts = {}
-        self.blocks = []
+        self.block_starts = {}  # type: Dict[int, List[int]]
+        self.blocks = []  # type: List[Tuple[int, int]]
         self.buffer = bytearray()
         self.output = u''
         self.status = Status.VALID
         self.frozen = False
-        self.intervals_by_level = []
-        self.intervals = []
-        self.interval_stack = []
+        self.intervals_by_level = []  # type: List[Tuple[int, int]]
+        self.intervals = []  # type: List[Tuple[int, int]]
+        self.interval_stack = []  # type: List[int]
         global global_test_counter
         self.testcounter = global_test_counter
         global_test_counter += 1
         self.start_time = benchmark_time()
-        self.events = set()
-        self.forced_indices = set()
-        self.capped_indices = {}
+        self.events = set()  # type: set
+        self.forced_indices = set()  # type: Set[int]
+        self.capped_indices = {}  # type: Dict[int, int]
         self.interesting_origin = None
-        self.tags = set()
+        self.tags = set()  # type: Union[set, frozenset]
 
     def __assert_not_frozen(self, name):
         if self.frozen:
@@ -191,9 +194,9 @@ class ConjectureData(object):
             mask = (1 << (n % 8)) - 1
             buf[0] &= mask
             self.capped_indices[self.index] = mask
-            buf = hbytes(buf)
-            self.__write(buf)
-            result = int_from_bytes(buf)
+            buffer = hbytes(buf)
+            self.__write(buffer)
+            result = int_from_bytes(buffer)
         assert bit_length(result) <= n
         return result
 

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -24,8 +24,8 @@ from random import Random, getrandbits
 from weakref import WeakKeyDictionary
 from collections import defaultdict
 
-from hypothesis import settings as Settings
-from hypothesis import Phase
+from hypothesis import settings as Settings  # type: ignore
+from hypothesis import Phase  # type: ignore
 from hypothesis.reporting import debug_report
 from hypothesis.internal.compat import EMPTY_BYTES, Counter, ceil, \
     hbytes, hrange, int_to_text, int_to_bytes, bytes_from_list, \
@@ -34,6 +34,9 @@ from hypothesis.utils.conventions import UniqueIdentifier
 from hypothesis.internal.conjecture.data import MAX_DEPTH, Status, \
     StopTest, ConjectureData
 from hypothesis.internal.conjecture.minimizer import minimize
+
+if False:
+    from typing import Any, Dict  # noqa
 
 
 class ExitReason(Enum):
@@ -1140,7 +1143,7 @@ class Negated(object):
         self.tag = tag
 
 
-NEGATED_CACHE = {}
+NEGATED_CACHE = {}  # type: Dict[Negated, Any]
 
 
 def negated(tag):

--- a/src/hypothesis/internal/conjecture/minimizer.py
+++ b/src/hypothesis/internal/conjecture/minimizer.py
@@ -25,6 +25,9 @@ from hypothesis.internal.compat import ceil, floor, hbytes, hrange, \
 from hypothesis.internal.conjecture.floats import is_simple, \
     float_to_lex, lex_to_float
 
+if False:
+    from typing import Set  # noqa
+
 
 """
 This module implements a lexicographic minimizer for blocks of bytes.
@@ -54,7 +57,7 @@ class Minimizer(object):
         self.random = random
         self.full = full
         self.changes = 0
-        self.seen = set()
+        self.seen = set()  # type: Set[hbytes]
 
     def incorporate(self, buffer):
         """Consider this buffer as a possible replacement for the current best

--- a/src/hypothesis/internal/conjecture/utils.py
+++ b/src/hypothesis/internal/conjecture/utils.py
@@ -26,6 +26,9 @@ from hypothesis.internal.compat import floor, hbytes, bit_length, \
     int_from_bytes
 from hypothesis.internal.floats import int_to_float
 
+if False:
+    from typing import List  # noqa
+
 
 def integer_range(data, lower, upper, center=None):
     assert lower <= upper
@@ -220,6 +223,7 @@ class Sampler(object):
     """
 
     def __init__(self, weights):
+        # type: (Sequence[float]) -> None
         # We consider each weight expressed in terms of the average weight,
         # say t. We write the weight of i as nt + f, where n is an integer and
         # 0 <= f < 1. We then store n items for this weight which correspond
@@ -235,9 +239,9 @@ class Sampler(object):
         # and are sorted in order of decreasing acceptance probaility. This
         # ensures that shrinking lexicographically always results in drawing
         # less data.
-        self.table = []
-        self.extras = []
-        self.acceptance = []
+        self.table = []  # type: List[int]
+        self.extras = []  # type: List[int]
+        self.acceptance = []  # type: List[float]
         total = sum(weights)
         n = len(weights)
         for i, x in enumerate(weights):

--- a/src/hypothesis/internal/coverage.py
+++ b/src/hypothesis/internal/coverage.py
@@ -24,6 +24,9 @@ from contextlib import contextmanager
 
 from hypothesis.internal.reflection import proxies
 
+if False:
+    from typing import Set, Dict, Tuple  # noqa
+
 """
 This module implements a custom coverage system that records conditions and
 then validates that every condition has been seen to be both True and False
@@ -37,7 +40,7 @@ When not running with a magic environment variable set, this module disables
 itself and has essentially no overhead.
 """
 
-pretty_file_name_cache = {}
+pretty_file_name_cache = {}  # type: Dict[str, str]
 
 
 def pretty_file_name(f):
@@ -58,7 +61,7 @@ IN_COVERAGE_TESTS = os.getenv('HYPOTHESIS_INTERNAL_COVERAGE') == 'true'
 
 if IN_COVERAGE_TESTS:
     log = open('branch-check', 'w')
-    written = set()
+    written = set()  # type: Set[Tuple[str, bool]]
 
     def record_branch(name, value):
         key = (name, value)

--- a/src/hypothesis/internal/coverage.py
+++ b/src/hypothesis/internal/coverage.py
@@ -114,7 +114,9 @@ else:
     def check_function(f):
         return f
 
-    @contextmanager
+    # Mypy incorrectly reports 'Name already defined', due to the decorator
+    # Issue:  https://github.com/python/mypy/issues/4117
+    @contextmanager  # type: ignore
     def check(name):
         yield
 

--- a/src/hypothesis/internal/escalation.py
+++ b/src/hypothesis/internal/escalation.py
@@ -27,6 +27,9 @@ from hypothesis.errors import DeadlineExceeded
 from hypothesis.internal.compat import text_type, binary_type, \
     encoded_filepath
 
+if False:
+    from typing import Dict  # noqa
+
 
 def belongs_to(package):
     root = os.path.dirname(package.__file__)
@@ -47,7 +50,7 @@ def belongs_to(package):
 
 PREVENT_ESCALATION = os.getenv('HYPOTHESIS_DO_NOT_ESCALATE') == 'true'
 
-FILE_CACHE = {}
+FILE_CACHE = {}  # type: Dict[bytes, bool]
 
 
 is_hypothesis_file = belongs_to(hypothesis)

--- a/src/hypothesis/internal/escalation.py
+++ b/src/hypothesis/internal/escalation.py
@@ -28,12 +28,14 @@ from hypothesis.internal.compat import text_type, binary_type, \
     encoded_filepath
 
 if False:
-    from typing import Dict  # noqa
+    from typing import Any, Dict, Union  # noqa
 
 
 def belongs_to(package):
     root = os.path.dirname(package.__file__)
-    cache = {text_type: {}, binary_type: {}}
+    cache = {
+        text_type: {}, binary_type: {}
+    }  # type: Dict[type, Dict[Union[binary_type, text_type], bool]]
 
     def accept(filepath):
         try:

--- a/src/hypothesis/internal/reflection.py
+++ b/src/hypothesis/internal/reflection.py
@@ -390,7 +390,7 @@ def eval_directory():
     return storage_directory('eval_source')
 
 
-eval_cache = {}
+eval_cache = {}  # type: dict
 
 
 def source_exec_as_module(source):

--- a/src/hypothesis/internal/reflection.py
+++ b/src/hypothesis/internal/reflection.py
@@ -316,10 +316,9 @@ def extract_lambda_source(f):
             parsed = ast.parse(source[:i])
             assert len(parsed.body) == 1
             assert parsed.body
-            if not isinstance(parsed.body[0].value, ast.Lambda):
-                continue
-            source = source[:i]
-            break
+            if isinstance(parsed.body[0].value, ast.Lambda):  # type: ignore
+                source = source[:i]
+                break
         except SyntaxError:
             pass
     lines = source.split('\n')

--- a/src/hypothesis/searchstrategy/collections.py
+++ b/src/hypothesis/searchstrategy/collections.py
@@ -169,7 +169,7 @@ class UniqueListStrategy(SearchStrategy):
             min_size=self.min_size, max_size=self.max_size,
             average_size=self.average_size
         )
-        seen = set()
+        seen = set()  # type: set
         result = []
 
         while elements.more():

--- a/src/hypothesis/searchstrategy/datetime.py
+++ b/src/hypothesis/searchstrategy/datetime.py
@@ -61,11 +61,11 @@ class DatetimeStrategy(SearchStrategy):
             cap_high = cap_high and val == high
         tz = data.draw(self.tz_strat)
         try:
-            result = dt.datetime(**result)
+            example = dt.datetime(**result)
             if is_pytz_timezone(tz):
                 # Can't just construct; see http://pytz.sourceforge.net
-                return tz.normalize(tz.localize(result))
-            return result.replace(tzinfo=tz)
+                return tz.normalize(tz.localize(example))
+            return example.replace(tzinfo=tz)
         except (ValueError, OverflowError):
             return None
 

--- a/src/hypothesis/searchstrategy/lazy.py
+++ b/src/hypothesis/searchstrategy/lazy.py
@@ -17,7 +17,7 @@
 
 from __future__ import division, print_function, absolute_import
 
-from hypothesis.internal.compat import hrange, getfullargspec
+from hypothesis.internal.compat import getfullargspec
 from hypothesis.internal.reflection import arg_string, \
     convert_keyword_arguments, convert_positional_arguments
 from hypothesis.searchstrategy.strategies import SearchStrategy
@@ -52,16 +52,19 @@ def unwrap_strategies(s):
     try:
         unwrap_depth += 1
         try:
-            result = unwrap_strategies(s.wrapped_strategy)
+            # SearchStrategy has some super-dynamic attributes, and Mypy
+            # freaks out.  We do catch all the AttributeErrors, though!
+            result = unwrap_strategies(s.wrapped_strategy)  # type: ignore
             unwrap_cache[s] = result
             try:
                 assert result.force_has_reusable_values == \
-                    s.force_has_reusable_values
+                    s.force_has_reusable_values  # type: ignore
             except AttributeError:
                 pass
 
             try:
-                result.force_has_reusable_values = s.force_has_reusable_values
+                result.force_has_reusable_values = \
+                    s.force_has_reusable_values  # type: ignore
             except AttributeError:
                 pass
             return result
@@ -147,8 +150,9 @@ class LazyStrategy(SearchStrategy):
             argspec = getfullargspec(self.__function)
             defaults = dict(argspec.kwonlydefaults or {})
             if argspec.defaults is not None:
-                for k in hrange(1, len(argspec.defaults) + 1):
-                    defaults[argspec.args[-k]] = argspec.defaults[-k]
+                for name, value in zip(reversed(argspec.args),
+                                       reversed(argspec.defaults)):
+                    defaults[name] = value
             if len(argspec.args) > 1 or argspec.defaults:
                 _args, _kwargs = convert_positional_arguments(
                     self.__function, _args, _kwargs)

--- a/src/hypothesis/searchstrategy/lazy.py
+++ b/src/hypothesis/searchstrategy/lazy.py
@@ -22,6 +22,9 @@ from hypothesis.internal.reflection import arg_string, \
     convert_keyword_arguments, convert_positional_arguments
 from hypothesis.searchstrategy.strategies import SearchStrategy
 
+if False:
+    from typing import Dict  # noqa
+
 
 def tupleize(x):
     if isinstance(x, (tuple, list)):
@@ -30,7 +33,7 @@ def tupleize(x):
         return x
 
 
-unwrap_cache = {}
+unwrap_cache = {}  # type: Dict[SearchStrategy, SearchStrategy]
 unwrap_depth = 0
 
 

--- a/src/hypothesis/searchstrategy/regex.py
+++ b/src/hypothesis/searchstrategy/regex.py
@@ -51,12 +51,12 @@ BYTES_DIGIT = set(b for b in BYTES_ALL if re.match(b'\\d', b))
 BYTES_SPACE = set(b for b in BYTES_ALL if re.match(b'\\s', b))
 BYTES_WORD = set(b for b in BYTES_ALL if re.match(b'\\w', b))
 BYTES_LOOKUP = {
-    sre.CATEGORY_DIGIT: BYTES_DIGIT,
-    sre.CATEGORY_SPACE: BYTES_SPACE,
-    sre.CATEGORY_WORD: BYTES_WORD,
-    sre.CATEGORY_NOT_DIGIT: BYTES_ALL - BYTES_DIGIT,
-    sre.CATEGORY_NOT_SPACE: BYTES_ALL - BYTES_SPACE,
-    sre.CATEGORY_NOT_WORD: BYTES_ALL - BYTES_WORD,
+    sre.CATEGORY_DIGIT: BYTES_DIGIT,  # type: ignore
+    sre.CATEGORY_SPACE: BYTES_SPACE,  # type: ignore
+    sre.CATEGORY_WORD: BYTES_WORD,  # type: ignore
+    sre.CATEGORY_NOT_DIGIT: BYTES_ALL - BYTES_DIGIT,  # type: ignore
+    sre.CATEGORY_NOT_SPACE: BYTES_ALL - BYTES_SPACE,  # type: ignore
+    sre.CATEGORY_NOT_WORD: BYTES_ALL - BYTES_WORD,  # type: ignore
 }
 
 # On Python < 3.4 (including 2.7), the following unicode chars are weird.

--- a/src/hypothesis/searchstrategy/regex.py
+++ b/src/hypothesis/searchstrategy/regex.py
@@ -20,12 +20,18 @@ from __future__ import division, print_function, absolute_import
 import re
 import sys
 import operator
-import sre_parse as sre
+import sre_parse
 
 import hypothesis.strategies as st
 from hypothesis import reject
 from hypothesis.internal.compat import PY3, hrange, hunichr, text_type, \
     int_to_byte
+
+if False:
+    from typing import Any, Set, Text  # noqa
+
+# TODO: contribute stubs with sre_parse attributes to Typeshed
+sre = sre_parse  # type: Any
 
 HAS_SUBPATTERN_FLAGS = sys.version_info[:2] >= (3, 6)
 
@@ -51,12 +57,12 @@ BYTES_DIGIT = set(b for b in BYTES_ALL if re.match(b'\\d', b))
 BYTES_SPACE = set(b for b in BYTES_ALL if re.match(b'\\s', b))
 BYTES_WORD = set(b for b in BYTES_ALL if re.match(b'\\w', b))
 BYTES_LOOKUP = {
-    sre.CATEGORY_DIGIT: BYTES_DIGIT,  # type: ignore
-    sre.CATEGORY_SPACE: BYTES_SPACE,  # type: ignore
-    sre.CATEGORY_WORD: BYTES_WORD,  # type: ignore
-    sre.CATEGORY_NOT_DIGIT: BYTES_ALL - BYTES_DIGIT,  # type: ignore
-    sre.CATEGORY_NOT_SPACE: BYTES_ALL - BYTES_SPACE,  # type: ignore
-    sre.CATEGORY_NOT_WORD: BYTES_ALL - BYTES_WORD,  # type: ignore
+    sre.CATEGORY_DIGIT: BYTES_DIGIT,
+    sre.CATEGORY_SPACE: BYTES_SPACE,
+    sre.CATEGORY_WORD: BYTES_WORD,
+    sre.CATEGORY_NOT_DIGIT: BYTES_ALL - BYTES_DIGIT,
+    sre.CATEGORY_NOT_SPACE: BYTES_ALL - BYTES_SPACE,
+    sre.CATEGORY_NOT_WORD: BYTES_ALL - BYTES_WORD,
 }
 
 # On Python < 3.4 (including 2.7), the following unicode chars are weird.
@@ -124,9 +130,9 @@ class CharactersBuilder(object):
     """
 
     def __init__(self, negate=False, flags=0):
-        self._categories = set()
-        self._whitelist_chars = set()
-        self._blacklist_chars = set()
+        self._categories = set()  # type: Set[Text]
+        self._whitelist_chars = set()  # type: Set[Text]
+        self._blacklist_chars = set()  # type: Set[Text]
         self._negate = negate
         self._ignorecase = flags & re.IGNORECASE
         self._unicode = not bool(flags & re.ASCII) \
@@ -196,8 +202,8 @@ class CharactersBuilder(object):
 class BytesBuilder(CharactersBuilder):
 
     def __init__(self, negate=False, flags=0):
-        self._whitelist_chars = set()
-        self._blacklist_chars = set()
+        self._whitelist_chars = set()  # type: Set[bytes]
+        self._blacklist_chars = set()  # type: Set[bytes]
         self._negate = negate
         self._ignorecase = flags & re.IGNORECASE
         self.code_to_char = int_to_byte
@@ -328,7 +334,9 @@ def _strategy(codes, context, pattern):
         empty = u''
         to_char = hunichr
     else:
-        empty = b''
+        # Correctly annotating this function to distinguish string and bytes
+        # handling is more trouble than it's worth right now, so ignore it.
+        empty = b''  # type: ignore
         to_char = int_to_byte
         binary_char = st.binary(min_size=1, max_size=1)
 

--- a/src/hypothesis/searchstrategy/strategies.py
+++ b/src/hypothesis/searchstrategy/strategies.py
@@ -23,11 +23,15 @@ import hypothesis.internal.conjecture.utils as cu
 from hypothesis.errors import NoExamples, NoSuchExample, Unsatisfiable, \
     UnsatisfiedAssumption
 from hypothesis.control import assume, reject, _current_build_context
-from hypothesis._settings import note_deprecation
+from hypothesis._settings import Verbosity, settings, note_deprecation
 from hypothesis.internal.compat import hrange
 from hypothesis.utils.conventions import UniqueIdentifier
 from hypothesis.internal.lazyformat import lazyformat
 from hypothesis.internal.reflection import get_pretty_function_description
+
+if False:
+    from typing import Any, Set, Dict, Tuple, FrozenSet, DefaultDict  # noqa
+    listener_type = DefaultDict['SearchStrategy', Set['SearchStrategy']]
 
 calculating = UniqueIdentifier('calculating')
 
@@ -98,7 +102,7 @@ class SearchStrategy(object):
             except AttributeError:
                 pass
 
-            mapping = {}
+            mapping = {}  # type: Dict[SearchStrategy, Any]
             hit_recursion = [False]
 
             # For a first pass we do a direct recursive calculation of the
@@ -138,7 +142,7 @@ class SearchStrategy(object):
                 # the course of calculating its value, then whenveer the
                 # value of B changes we might need to update the value of
                 # A.
-                listeners = defaultdict(set)
+                listeners = defaultdict(set)  # type: listener_type
             else:
                 needs_update = None
 
@@ -158,7 +162,7 @@ class SearchStrategy(object):
                 return recur_inner
 
             count = 0
-            seen = set()
+            seen = set()  # type: Set[FrozenSet[Tuple[SearchStrategy, Any]]]
             while needs_update:
                 count += 1
                 # If we seem to be taking a really long time to stabilize we
@@ -263,12 +267,10 @@ class SearchStrategy(object):
                     '#drawing-interactively-in-tests for more details.'
                 )
 
-        from hypothesis import find, settings, Verbosity
-
         # Conjecture will always try the zero example first. This would result
         # in us producing the same example each time, which is boring, so we
         # deliberately skip the first example it feeds us.
-        first = []
+        first = []  # type: list
 
         def condition(x):
             if first:
@@ -277,7 +279,8 @@ class SearchStrategy(object):
                 first.append(x)
                 return False
         try:
-            return find(
+            import hypothesis
+            return hypothesis.find(
                 self,
                 condition,
                 random=random,
@@ -422,7 +425,7 @@ class OneOfStrategy(SearchStrategy):
                     strategies.extend(
                         [s for s in arg.branches if not s.is_empty])
             pruned = []
-            seen = set()
+            seen = set()  # type: Set[SearchStrategy]
             for s in strategies:
                 if s is self:
                     continue

--- a/src/hypothesis/searchstrategy/types.py
+++ b/src/hypothesis/searchstrategy/types.py
@@ -29,6 +29,11 @@ import hypothesis.strategies as st
 from hypothesis.errors import ResolutionFailed
 from hypothesis.internal.compat import text_type, integer_types
 
+if False:
+    from typing import Dict, Union, Callable  # noqa
+    from hypothesis.strategies import SearchStrategy
+    Result = Union[SearchStrategy, Callable[[type], SearchStrategy]]  # noqa
+
 
 def type_sorting_key(t):
     """Minimise to None, then non-container types, then container types."""
@@ -125,7 +130,7 @@ _global_type_lookup = {
     bytearray: st.binary().map(bytearray),
     memoryview: st.binary().map(memoryview),
     # Pull requests with more types welcome!
-}
+}  # type: Dict[type, Result]
 for t in integer_types:
     _global_type_lookup[t] = st.integers()
 

--- a/src/hypothesis/searchstrategy/types.py
+++ b/src/hypothesis/searchstrategy/types.py
@@ -68,7 +68,7 @@ def from_typing_type(thing):
         if not args:
             raise ResolutionFailed('Cannot resolve Union of no types.')
         return st.one_of([st.from_type(t) for t in args])
-    if isinstance(thing, typing.TupleMeta):
+    if isinstance(thing, typing.TupleMeta):  # type: ignore  # private attr.
         elem_types = getattr(thing, '__tuple_params__', None) or ()
         elem_types += getattr(thing, '__args__', None) or ()
         if getattr(thing, '__tuple_use_ellipsis__', False) or \
@@ -91,7 +91,7 @@ def from_typing_type(thing):
         # instances of type T - and simplify the strategy for abstract types
         # such as Container
         for t in (typing.KeysView, typing.ValuesView, typing.ItemsView):
-            mapping.pop(t, None)
+            mapping.pop(t, None)  # type: ignore  # this does actually work...
     strategies = [v if isinstance(v, st.SearchStrategy) else v(thing)
                   for k, v in mapping.items()
                   if sum(try_issubclass(k, T) for T in mapping) == 1]

--- a/src/hypothesis/searchstrategy/types.py
+++ b/src/hypothesis/searchstrategy/types.py
@@ -152,8 +152,8 @@ except ImportError:  # pragma: no cover
 else:
     _global_type_lookup.update({
         typing.ByteString: st.binary(),
-        typing.io.BinaryIO: st.builds(io.BytesIO, st.binary()),
-        typing.io.TextIO: st.builds(io.StringIO, st.text()),
+        typing.io.BinaryIO: st.builds(io.BytesIO, st.binary()),  # type: ignore
+        typing.io.TextIO: st.builds(io.StringIO, st.text()),  # type: ignore
         typing.Reversible: st.lists(st.integers()),
         typing.SupportsAbs: st.complex_numbers(),
         typing.SupportsComplex: st.complex_numbers(),

--- a/src/hypothesis/stateful.py
+++ b/src/hypothesis/stateful.py
@@ -326,8 +326,10 @@ def rule(targets=(), target=None, **kwargs):
                 Settings.default,
             )
         precondition = getattr(f, PRECONDITION_MARKER, None)
-        rule = Rule(targets=tuple(converted_targets), arguments=kwargs,
-                    function=f, precondition=precondition)
+        # Mypy can't find __init__; https://github.com/python/mypy/issues/4132
+        rule = Rule(  # type: ignore
+            targets=tuple(converted_targets), arguments=kwargs,
+            function=f, precondition=precondition)
 
         @proxies(f)
         def rule_wrapper(*args, **kwargs):
@@ -373,14 +375,17 @@ def precondition(precond):
         if rule is None:
             setattr(precondition_wrapper, PRECONDITION_MARKER, precond)
         else:
-            new_rule = Rule(targets=rule.targets, arguments=rule.arguments,
-                            function=rule.function, precondition=precond)
+            # Again, see https://github.com/python/mypy/issues/4132
+            new_rule = Rule(  # type: ignore
+                targets=rule.targets, arguments=rule.arguments,
+                function=rule.function, precondition=precond)
             setattr(precondition_wrapper, RULE_MARKER, new_rule)
 
         invariant = getattr(f, INVARIANT_MARKER, None)
         if invariant is not None:
-            new_invariant = Invariant(function=invariant.function,
-                                      precondition=precond)
+            # Again, see https://github.com/python/mypy/issues/4132
+            new_invariant = Invariant(  # type: ignore
+                function=invariant.function, precondition=precond)
             setattr(precondition_wrapper, INVARIANT_MARKER, new_invariant)
 
         return precondition_wrapper
@@ -416,7 +421,8 @@ def invariant():
                 Settings.default,
             )
         precondition = getattr(f, PRECONDITION_MARKER, None)
-        rule = Invariant(function=f, precondition=precondition)
+        # Again, see https://github.com/python/mypy/issues/4132
+        rule = Invariant(function=f, precondition=precondition)  # type: ignore
 
         @proxies(f)
         def invariant_wrapper(*args, **kwargs):
@@ -529,7 +535,8 @@ class RuleBasedStateMachine(GenericStateMachine):
             target = cls._base_rules_per_class.setdefault(cls, [])
 
         return target.append(
-            Rule(
+            # Again, see https://github.com/python/mypy/issues/4132
+            Rule(  # type: ignore
                 targets, function, converted_arguments, precondition,
             )
         )
@@ -598,7 +605,10 @@ class RuleBasedStateMachine(GenericStateMachine):
                 id(result), lambda obj, p, cycle: p.text(name),
             )
             for target in rule.targets:
-                self.bundle(target).append(VarReference(name))
+                self.bundle(target).append(
+                    # Again, see https://github.com/python/mypy/issues/4132
+                    VarReference(name)  # type: ignore
+                )
 
     def check_invariants(self):
         for invar in self.invariants():

--- a/src/hypothesis/stateful.py
+++ b/src/hypothesis/stateful.py
@@ -51,6 +51,9 @@ from hypothesis.searchstrategy.strategies import SearchStrategy
 from hypothesis.searchstrategy.collections import TupleStrategy, \
     FixedKeysDictStrategy
 
+if False:
+    from typing import Any, Dict, List, Text  # noqa
+
 
 class TestCaseProperty(object):  # pragma: no cover
 
@@ -138,6 +141,7 @@ class GenericStateMachine(object):
     sequence of example choices demonstrating that.
 
     """
+    find_breaking_runner = None  # type: classmethod
 
     def steps(self):
         """Return a SearchStrategy instance the defines the available next
@@ -170,7 +174,7 @@ class GenericStateMachine(object):
         """Called after initializing and after executing each step."""
         pass
 
-    _test_case_cache = {}
+    _test_case_cache = {}  # type: dict
 
     TestCase = TestCaseProperty()
 
@@ -191,8 +195,8 @@ class GenericStateMachine(object):
         def runTest(self):
             run_state_machine_as_test(state_machine_class)
 
-        runTest.is_hypothesis_test = True
-        StateMachineTestCase.runTest = runTest
+        runTest.is_hypothesis_test = True  # type: ignore
+        StateMachineTestCase.runTest = runTest  # type: ignore
         base_name = state_machine_class.__name__
         StateMachineTestCase.__name__ = str(
             base_name + u'.TestCase'
@@ -441,18 +445,18 @@ class RuleBasedStateMachine(GenericStateMachine):
     executed.
 
     """
-    _rules_per_class = {}
-    _invariants_per_class = {}
-    _base_rules_per_class = {}
+    _rules_per_class = {}  # type: Dict[type, List[classmethod]]
+    _invariants_per_class = {}  # type: Dict[type, List[classmethod]]
+    _base_rules_per_class = {}  # type: Dict[type, List[classmethod]]
 
     def __init__(self):
         if not self.rules():
             raise InvalidDefinition(u'Type %s defines no rules' % (
                 type(self).__name__,
             ))
-        self.bundles = {}
+        self.bundles = {}  # type: Dict[Text, list]
         self.name_counter = 1
-        self.names_to_values = {}
+        self.names_to_values = {}  # type: Dict[Text, Any]
         self.__stream = CUnicodeIO()
         self.__printer = RepresentationPrinter(self.__stream)
 

--- a/src/hypothesis/types.py
+++ b/src/hypothesis/types.py
@@ -23,6 +23,10 @@ from itertools import islice
 
 from hypothesis.errors import InvalidArgument
 
+if False:
+    from typing import List, TypeVar, Iterable, Optional  # noqa
+    T = TypeVar('T')
+
 
 class RandomWithSeed(Random):
 
@@ -66,12 +70,13 @@ class Stream(object):
     """
 
     def __init__(self, generator=None):
+        # type: (Optional[Iterable[T]]) -> None
         if generator is None:
             generator = iter(())
         elif not inspect.isgenerator(generator):
             generator = iter(generator)
         self.generator = generator
-        self.fetched = []
+        self.fetched = []  # type: List[T]
 
     def map(self, f):
         return Stream(f(v) for v in self)


### PR DESCRIPTION
This is a starting point for #200, focusing on static typing as another check in our own tests.  This has already caught a bug (#943), and found a module that was no longer used at all (`hypothesis.internal.classpath`).  

In this pull, I aim to:

- [x] Set up Mypy checking as a make task and add it to our Travis config
- [x] Make the build pass with default settings
- [x] Enable `check_untyped_defs` for all modules and make the build pass again
- [x] Split the workarounds for Mypy bugs into separate commits for easy reverting later

Further work after that could go in several directions based on what we feel is worth doing - from going as static as possible and locking that down, to the minimal route of leaving it as a glorified linter.  **This is a discussion I'd love to have in the comments!**

Finally, a few words on tooling choices.  I've settled on using type comments - stub files are really an all-or-nothing option, while supporting Python 2 means we can't use inline annotations.  While I would love to ship type hints to users - and use them from the other side - the packaging story is being worked on but remains terrible.  I suggest we simply use type hints internally and wait for the ecosystem to mature, at which point we'll hopefully have something worth distributing.