### PR TITLE
[RFC] Continue generating examples after we find the first bug 

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This release extends Hypothesis's multiple bug discovery functionality to be
+able to find multiple bugs during test case generation. It will now not stop
+generating on the first bug, but will continue generating for a little while
+(not necessarily the full number of examples it would have run if it hadn't
+found a bug) and see if it discovers any new bugs.

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -240,8 +240,23 @@ class ConjectureRunner(object):
                 self.last_data = data
 
             if self.shrinks >= self.settings.max_shrinks:
-                self.exit_reason = ExitReason.max_shrinks
-                raise RunIsComplete()
+                self.exit_with(ExitReason.max_shrinks)
+        if (
+            self.settings.timeout > 0 and
+            time.time() >= self.start_time + self.settings.timeout
+        ):
+            self.exit_with(ExitReason.timeout)
+
+        if not self.interesting_examples:
+            if self.valid_examples >= self.settings.max_examples:
+                self.exit_with(ExitReason.max_examples)
+            if self.call_count >= max(
+                self.settings.max_iterations, self.settings.max_examples
+            ):
+                self.exit_with(ExitReason.max_iterations)
+
+        if self.__tree_is_exhausted():
+            self.exit_with(ExitReason.finished)
 
     def consider_new_test_data(self, data):
         # Transition rules:
@@ -367,12 +382,6 @@ class ConjectureRunner(object):
     def incorporate_new_buffer(self, buffer):
         assert self.last_data.status == Status.INTERESTING
         start = self.last_data.interesting_origin
-        if (
-            self.settings.timeout > 0 and
-            time.time() >= self.start_time + self.settings.timeout
-        ):
-            self.exit_reason = ExitReason.timeout
-            raise RunIsComplete()
 
         buffer = hbytes(buffer[:self.last_data.index])
         assert sort_key(buffer) < sort_key(self.last_data.buffer)
@@ -599,6 +608,7 @@ class ConjectureRunner(object):
 
         """
         if self.has_existing_examples():
+            self.debug('Reusing examples from database')
             # We have to do some careful juggling here. We have two database
             # corpora: The primary and secondary. The primary corpus is a
             # small set of minimized examples each of which has at one point
@@ -633,144 +643,121 @@ class ConjectureRunner(object):
                     corpus.extend(extra)
 
             for existing in corpus:
-                if self.valid_examples >= self.settings.max_examples:
-                    self.exit_with(ExitReason.max_examples)
-                if self.call_count >= max(
-                    self.settings.max_iterations, self.settings.max_examples
-                ):
-                    self.exit_with(ExitReason.max_iterations)
                 self.last_data = ConjectureData.for_buffer(existing)
-                self.test_function(self.last_data)
-                if self.last_data.status != Status.INTERESTING:
-                    self.settings.database.delete(
-                        self.database_key, existing)
-                    self.settings.database.delete(
-                        self.secondary_key, existing)
+                try:
+                    self.test_function(self.last_data)
+                finally:
+                    if self.last_data.status != Status.INTERESTING:
+                        self.settings.database.delete(
+                            self.database_key, existing)
+                        self.settings.database.delete(
+                            self.secondary_key, existing)
 
     def exit_with(self, reason):
         self.exit_reason = reason
         raise RunIsComplete()
 
-    def _run(self):
-        self.last_data = None
-        mutations = 0
-        start_time = time.time()
-
-        self.reuse_existing_examples()
+    def generate_new_examples(self):
+        if Phase.generate not in self.settings.phases:
+            return
 
         if (
-            Phase.generate in self.settings.phases and not
-            self.__tree_is_exhausted()
+            self.last_data is None or
+            self.last_data.status < Status.INTERESTING
         ):
-            if (
-                self.last_data is None or
-                self.last_data.status < Status.INTERESTING
-            ):
-                self.new_buffer()
+            self.new_buffer()
 
-            mutator = self._new_mutator()
+        self.debug('Generating new examples')
 
-            zero_bound_queue = []
+        mutations = 0
+        mutator = self._new_mutator()
 
-            while (
-                self.last_data.status != Status.INTERESTING and
-                not self.__tree_is_exhausted()
-            ):
-                if self.valid_examples >= self.settings.max_examples:
-                    self.exit_reason = ExitReason.max_examples
-                    return
-                if self.call_count >= max(
-                    self.settings.max_iterations, self.settings.max_examples
-                ):
-                    self.exit_reason = ExitReason.max_iterations
-                    return
-                if (
-                    self.settings.timeout > 0 and
-                    time.time() >= start_time + self.settings.timeout
-                ):
-                    self.exit_reason = ExitReason.timeout
-                    return
-                if zero_bound_queue:
-                    # Whenever we generated an example and it hits a bound
-                    # which forces zero blocks into it, this creates a weird
-                    # distortion effect by making certain parts of the data
-                    # stream (especially ones to the right) much more likely
-                    # to be zero. We fix this by redistributing the generated
-                    # data by shuffling it randomly. This results in the
-                    # zero data being spread evenly throughout the buffer.
-                    # Hopefully the shrinking this causes will cause us to
-                    # naturally fail to hit the bound.
-                    # If it doesn't then we will queue the new version up again
-                    # (now with more zeros) and try again.
-                    overdrawn = zero_bound_queue.pop()
-                    buffer = bytearray(overdrawn.buffer)
+        zero_bound_queue = []
 
-                    # These will have values written to them that are different
-                    # from what's in them anyway, so the value there doesn't
-                    # really "count" for distributional purposes, and if we
-                    # leave them in then they can cause the fraction of non
-                    # zero bytes to increase on redraw instead of decrease.
-                    for i in overdrawn.forced_indices:
-                        buffer[i] = 0
+        while not self.interesting_examples:
+            if zero_bound_queue:
+                # Whenever we generated an example and it hits a bound
+                # which forces zero blocks into it, this creates a weird
+                # distortion effect by making certain parts of the data
+                # stream (especially ones to the right) much more likely
+                # to be zero. We fix this by redistributing the generated
+                # data by shuffling it randomly. This results in the
+                # zero data being spread evenly throughout the buffer.
+                # Hopefully the shrinking this causes will cause us to
+                # naturally fail to hit the bound.
+                # If it doesn't then we will queue the new version up again
+                # (now with more zeros) and try again.
+                overdrawn = zero_bound_queue.pop()
+                buffer = bytearray(overdrawn.buffer)
 
-                    self.random.shuffle(buffer)
-                    buffer = hbytes(buffer)
+                # These will have values written to them that are different
+                # from what's in them anyway, so the value there doesn't
+                # really "count" for distributional purposes, and if we
+                # leave them in then they can cause the fraction of non
+                # zero bytes to increase on redraw instead of decrease.
+                for i in overdrawn.forced_indices:
+                    buffer[i] = 0
 
-                    if buffer == overdrawn.buffer:
-                        continue
+                self.random.shuffle(buffer)
+                buffer = hbytes(buffer)
 
-                    def draw_bytes(data, n):
-                        result = buffer[data.index:data.index + n]
-                        if len(result) < n:
-                            result += hbytes(n - len(result))
-                        return self.__rewrite(data, result)
+                if buffer == overdrawn.buffer:
+                    continue
 
-                    data = ConjectureData(
-                        draw_bytes=draw_bytes,
-                        max_length=self.settings.buffer_size,
-                    )
-                    self.test_function(data)
-                    data.freeze()
-                elif mutations >= self.settings.max_mutations:
-                    mutations = 0
-                    data = self.new_buffer()
-                    mutator = self._new_mutator()
+                def draw_bytes(data, n):
+                    result = buffer[data.index:data.index + n]
+                    if len(result) < n:
+                        result += hbytes(n - len(result))
+                    return self.__rewrite(data, result)
+
+                data = ConjectureData(
+                    draw_bytes=draw_bytes,
+                    max_length=self.settings.buffer_size,
+                )
+                self.test_function(data)
+                data.freeze()
+            elif mutations >= self.settings.max_mutations:
+                mutations = 0
+                data = self.new_buffer()
+                mutator = self._new_mutator()
+            else:
+                data = ConjectureData(
+                    draw_bytes=mutator,
+                    max_length=self.settings.buffer_size
+                )
+                self.test_function(data)
+                data.freeze()
+                prev_data = self.last_data
+                if self.consider_new_test_data(data):
+                    self.last_data = data
+                    if data.status > prev_data.status:
+                        mutations = 0
                 else:
-                    data = ConjectureData(
-                        draw_bytes=mutator,
-                        max_length=self.settings.buffer_size
-                    )
-                    self.test_function(data)
-                    data.freeze()
-                    prev_data = self.last_data
-                    if self.consider_new_test_data(data):
-                        self.last_data = data
-                        if data.status > prev_data.status:
-                            mutations = 0
-                    else:
-                        mutator = self._new_mutator()
-                if getattr(data, 'hit_zero_bound', False):
-                    zero_bound_queue.append(data)
-                mutations += 1
+                    mutator = self._new_mutator()
+            if getattr(data, 'hit_zero_bound', False):
+                zero_bound_queue.append(data)
+            mutations += 1
 
-        if self.__tree_is_exhausted():
-            self.exit_reason = ExitReason.finished
-            return
+    def _run(self):
+        self.last_data = None
+        self.start_time = time.time()
+
+        self.reuse_existing_examples()
+        self.generate_new_examples()
 
         data = self.last_data
         if data is None:
-            self.exit_reason = ExitReason.finished
+            self.exit_with(ExitReason.finished)
             return
         assert isinstance(data.output, text_type)
 
         if Phase.shrink not in self.settings.phases:
-            self.exit_reason = ExitReason.finished
-            return
+            self.exit_with(ExitReason.finished)
 
         data = ConjectureData.for_buffer(self.last_data.buffer)
         self.test_function(data)
         if data.status != Status.INTERESTING:
-            self.exit_reason = ExitReason.flaky
+            self.exit_with(ExitReason.flaky)
             return
 
         while len(self.shrunk_examples) < len(self.interesting_examples):
@@ -784,6 +771,7 @@ class ConjectureRunner(object):
             assert self.last_data.interesting_origin == target
             self.shrink()
             self.shrunk_examples.add(target)
+        self.exit_reason = ExitReason.finished
 
     def try_buffer_with_rewriting_from(self, initial_attempt, v):
         initial_data = None
@@ -1002,7 +990,6 @@ class ConjectureRunner(object):
             not any(self.last_data.buffer) or
             self.incorporate_new_buffer(hbytes(len(self.last_data.buffer)))
         ):
-            self.exit_reason = ExitReason.finished
             return
 
         if self.has_existing_examples():
@@ -1040,8 +1027,6 @@ class ConjectureRunner(object):
             self.minimize_individual_blocks()
             self.reorder_blocks()
             self.greedy_interval_deletion()
-
-        self.exit_reason = ExitReason.finished
 
     def event_to_string(self, event):
         if isinstance(event, str):

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -752,11 +752,12 @@ class ConjectureRunner(object):
         if Phase.shrink not in self.settings.phases:
             self.exit_with(ExitReason.finished)
 
-        data = ConjectureData.for_buffer(self.last_data.buffer)
-        self.test_function(data)
-        if data.status != Status.INTERESTING:
-            self.exit_with(ExitReason.flaky)
-            return
+        for previous in self.interesting_examples.values():
+            data = ConjectureData.for_buffer(previous.buffer)
+            self.test_function(data)
+            if data.status != Status.INTERESTING:
+                self.exit_with(ExitReason.flaky)
+                return
 
         while len(self.shrunk_examples) < len(self.interesting_examples):
             target, d = min([

--- a/tests/cover/test_conjecture_engine.py
+++ b/tests/cover/test_conjecture_engine.py
@@ -380,17 +380,16 @@ def test_max_shrinks_can_disable_shrinking():
 
 
 def test_phases_can_disable_shrinking():
-    seen = set()
+    slow = slow_shrinker()
 
-    def f(data):
-        seen.add(hbytes(data.draw_bytes(32)))
-        data.mark_interesting()
+    max_examples = 10
 
-    runner = ConjectureRunner(f, settings=settings(
+    runner = ConjectureRunner(slow, settings=settings(
         database=None, phases=(Phase.reuse, Phase.generate),
+        max_shrinks=10**6, max_examples=max_examples
     ))
     runner.run()
-    assert len(seen) == 1
+    runner.valid_examples <= max_examples
 
 
 def test_saves_data_while_shrinking():

--- a/tests/cover/test_conjecture_engine.py
+++ b/tests/cover/test_conjecture_engine.py
@@ -478,7 +478,8 @@ def test_garbage_collects_the_database():
 
     assert len(in_db()) == n + 1
     runner = ConjectureRunner(
-        lambda data: None, settings=local_settings, database_key=key)
+        lambda data: data.draw_bytes(8),
+        settings=local_settings, database_key=key)
     runner.run()
     assert 0 < len(in_db()) < n
 

--- a/tests/cover/test_conjecture_engine.py
+++ b/tests/cover/test_conjecture_engine.py
@@ -42,8 +42,8 @@ def run_to_buffer(f):
         database=None,
     ))
     runner.run()
-    assert runner.last_data.status == Status.INTERESTING
-    return hbytes(runner.last_data.buffer)
+    assert len(runner.interesting_examples) == 1
+    return hbytes(runner.interesting_examples[None].buffer)
 
 
 def test_can_index_results():
@@ -389,7 +389,7 @@ def test_phases_can_disable_shrinking():
         max_shrinks=10**6, max_examples=max_examples
     ))
     runner.run()
-    runner.valid_examples <= max_examples
+    assert runner.valid_examples <= max_examples
 
 
 def test_saves_data_while_shrinking():

--- a/tests/cover/test_conjecture_engine.py
+++ b/tests/cover/test_conjecture_engine.py
@@ -593,3 +593,21 @@ def test_can_cover_without_a_database_key():
     runner = ConjectureRunner(tagged, settings=settings(), database_key=None)
     runner.run()
     assert len(runner.covering_examples) == 1
+
+
+def test_bails_out_quickly_if_not_finding_new_bugs():
+    seen = [None]
+
+    def tf(data):
+        b = data.draw_bytes(4)
+        if seen[0] is None:
+            seen[0] = b
+        if b == seen[0]:
+            data.mark_interesting()
+
+    runner = ConjectureRunner(tf, settings=settings(
+        database=None, phases=(Phase.reuse, Phase.generate),
+        max_examples=10**6,
+    ))
+    runner.run()
+    runner.valid_examples <= 200


### PR DESCRIPTION
Attempt at #847. Implements the "Try up until twice the number of examples it took you to discover the last new bug" heuristic.

It seems to work OK? I struggled a lot to get good testing of this at first. I feel like I want to:

* [ ] Think about the heuristics a bit more
* [ ] Think about the failure modes a lot more
* [ ] See if anything horrendous breaks on the build

Before I commit to this approach. So it might be that this might be actually very close to the final version, or I might end up rewriting the whole thing. Commentary on any or all of the above would also be useful.