### PR TITLE
Print seed on test failure to aid reproduction

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,13 @@
+RELEASE_TYPE: minor
+
+This release introduces two new features:
+
+* pytest users can specify a seed to use for ``@given`` based tests by passing
+  the ``--hypothesis-seed`` command line argument.
+* When a test fails, either with a health check failure or a falsifying example,
+  Hypothesis will print out a seed that lead to that failure if the test is not
+  already running with a fixed seed. You can then recreate that failure using either
+  the ``@seed`` decorator or (if you are running pytest) with ``--hypothesis-seed``.
+
+
+This work was funded by `Smarkets <https://smarkets.com/>`_.

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -5,7 +5,7 @@ This release introduces two new features:
 * pytest users can specify a seed to use for ``@given`` based tests by passing
   the ``--hypothesis-seed`` command line argument.
 * When a test fails, either with a health check failure or a falsifying example,
-  Hypothesis will print out a seed that lead to that failure if the test is not
+  Hypothesis will print out a seed that led to that failure, if the test is not
   already running with a fixed seed. You can then recreate that failure using either
   the ``@seed`` decorator or (if you are running pytest) with ``--hypothesis-seed``.
 

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -68,6 +68,7 @@ except ImportError:  # pragma: no cover
 
 
 running_under_pytest = False
+global_force_seed = None
 
 
 def new_random():
@@ -428,6 +429,8 @@ def get_random_for_wrapped_test(test, wrapped_test):
             wrapped_test._hypothesis_internal_use_seed)
     elif settings.derandomize:
         return Random(function_digest(test))
+    elif global_force_seed is not None:
+        return Random(global_force_seed)
     else:
         return new_random()
 

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -67,6 +67,9 @@ except ImportError:  # pragma: no cover
     from coverage.collector import FileDisposition
 
 
+running_under_pytest = False
+
+
 def new_random():
     import random
     return random.Random(random.getrandbits(128))

--- a/src/hypothesis/extra/pytestplugin.py
+++ b/src/hypothesis/extra/pytestplugin.py
@@ -24,6 +24,7 @@ from hypothesis.reporting import with_reporter
 from hypothesis.statistics import collector
 from hypothesis.internal.compat import OrderedDict, text_type
 from hypothesis.internal.detection import is_hypothesis_test
+import hypothesis.core as core
 
 LOAD_PROFILE_OPTION = '--hypothesis-profile'
 PRINT_STATISTICS_OPTION = '--hypothesis-show-statistics'
@@ -59,6 +60,7 @@ def pytest_addoption(parser):
 
 
 def pytest_configure(config):
+    core.running_under_pytest = True
     from hypothesis import settings
     profile = config.getoption(LOAD_PROFILE_OPTION)
     if profile:

--- a/src/hypothesis/extra/pytestplugin.py
+++ b/src/hypothesis/extra/pytestplugin.py
@@ -19,15 +19,16 @@ from __future__ import division, print_function, absolute_import
 
 import pytest
 
+import hypothesis.core as core
 from hypothesis.reporting import default as default_reporter
 from hypothesis.reporting import with_reporter
 from hypothesis.statistics import collector
 from hypothesis.internal.compat import OrderedDict, text_type
 from hypothesis.internal.detection import is_hypothesis_test
-import hypothesis.core as core
 
 LOAD_PROFILE_OPTION = '--hypothesis-profile'
 PRINT_STATISTICS_OPTION = '--hypothesis-show-statistics'
+SEED_OPTION = '--hypothesis-seed'
 
 
 class StoringReporter(object):
@@ -57,6 +58,11 @@ def pytest_addoption(parser):
         help='Configure when statistics are printed',
         default=False
     )
+    group.addoption(
+        SEED_OPTION,
+        action='store',
+        help='Set a seed to use for all Hypothesis tests'
+    )
 
 
 def pytest_configure(config):
@@ -65,6 +71,13 @@ def pytest_configure(config):
     profile = config.getoption(LOAD_PROFILE_OPTION)
     if profile:
         settings.load_profile(profile)
+    seed = config.getoption(SEED_OPTION)
+    if seed is not None:
+        try:
+            seed = int(seed)
+        except ValueError:
+            pass
+        core.global_force_seed = seed
     config.addinivalue_line(
         'markers',
         'hypothesis: Tests which use hypothesis.')

--- a/tests/cover/test_seed_printing.py
+++ b/tests/cover/test_seed_printing.py
@@ -1,0 +1,59 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2017 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+
+from tests.common.utils import capture_out
+from hypothesis import given
+import hypothesis.strategies as st
+import hypothesis.core as core
+import time
+from hypothesis.errors import FailedHealthCheck
+import pytest
+
+
+@pytest.mark.parametrize('in_pytest', [False, True])
+@pytest.mark.parametrize('fail_healthcheck', [False, True])
+def test_prints_seed_on_exception(monkeypatch, in_pytest, fail_healthcheck):
+    monkeypatch.setattr(core, 'running_under_pytest', in_pytest)
+
+    strategy = st.integers()
+    if fail_healthcheck:
+        def slow_map(i):
+            time.sleep(10)
+            return i
+        strategy = strategy.map(slow_map)
+        expected_exc = FailedHealthCheck
+    else:
+        expected_exc = AssertionError
+
+    @given(strategy)
+    def test(i):
+        assert False
+
+    with capture_out() as o:
+        with pytest.raises(expected_exc):
+            test()
+
+    output = o.getvalue()
+
+    seed = test._hypothesis_internal_use_generated_seed
+    assert seed is not None
+    assert '@seed(%d)' % (seed,) in output
+    contains_pytest_instruction = ('--hypothesis-seed=%d' % (seed,)) in output
+    assert contains_pytest_instruction == in_pytest

--- a/tests/cover/test_seed_printing.py
+++ b/tests/cover/test_seed_printing.py
@@ -17,14 +17,15 @@
 
 from __future__ import division, print_function, absolute_import
 
-
-from tests.common.utils import capture_out
-from hypothesis import given
-import hypothesis.strategies as st
-import hypothesis.core as core
 import time
-from hypothesis.errors import FailedHealthCheck
+
 import pytest
+
+import hypothesis.core as core
+import hypothesis.strategies as st
+from hypothesis import given
+from hypothesis.errors import FailedHealthCheck
+from tests.common.utils import capture_out
 
 
 @pytest.mark.parametrize('in_pytest', [False, True])

--- a/tests/cover/test_testdecorators.py
+++ b/tests/cover/test_testdecorators.py
@@ -518,8 +518,7 @@ def test_prints_notes_once_on_failure():
             with raises(ValueError):
                 test()
     lines = out.getvalue().strip().splitlines()
-    assert len(lines) == 2
-    assert 'Hi there' in lines
+    assert lines.count('Hi there') == 1
 
 
 @given(lists(max_size=0))

--- a/tests/pytest/test_pytest_detection.py
+++ b/tests/pytest/test_pytest_detection.py
@@ -18,9 +18,12 @@
 """This module provides the core primitives of Hypothesis, such as given."""
 
 
-import hypothesis.core as core
-import subprocess
+from __future__ import division, print_function, absolute_import
+
 import sys
+import subprocess
+
+import hypothesis.core as core
 
 
 def test_is_running_under_pytest():
@@ -34,6 +37,6 @@ assert not core.running_under_pytest
 
 
 def test_is_not_running_under_pytest(tmpdir):
-    pyfile = tmpdir.join("test.py")
+    pyfile = tmpdir.join('test.py')
     pyfile.write(FILE_TO_RUN)
     subprocess.check_call([sys.executable, pyfile])

--- a/tests/pytest/test_pytest_detection.py
+++ b/tests/pytest/test_pytest_detection.py
@@ -39,4 +39,4 @@ assert not core.running_under_pytest
 def test_is_not_running_under_pytest(tmpdir):
     pyfile = tmpdir.join('test.py')
     pyfile.write(FILE_TO_RUN)
-    subprocess.check_call([sys.executable, pyfile])
+    subprocess.check_call([sys.executable, str(pyfile)])

--- a/tests/pytest/test_pytest_detection.py
+++ b/tests/pytest/test_pytest_detection.py
@@ -1,0 +1,39 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2017 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+"""This module provides the core primitives of Hypothesis, such as given."""
+
+
+import hypothesis.core as core
+import subprocess
+import sys
+
+
+def test_is_running_under_pytest():
+    assert core.running_under_pytest
+
+
+FILE_TO_RUN = """
+import hypothesis.core as core
+assert not core.running_under_pytest
+"""
+
+
+def test_is_not_running_under_pytest(tmpdir):
+    pyfile = tmpdir.join("test.py")
+    pyfile.write(FILE_TO_RUN)
+    subprocess.check_call([sys.executable, pyfile])

--- a/tests/pytest/test_seeding.py
+++ b/tests/pytest/test_seeding.py
@@ -82,11 +82,10 @@ def test_runs_repeatably_when_following_seed_instruction(testdir):
 
     rerun = testdir.runpytest(script, '--verbose', '--strict', match.group(0))
 
-    results = [initial, rerun]
+    for l in rerun.stdout.lines:
+        assert '--hypothesis-seed' not in l
 
-    for r in results:
-        for l in r.stdout.lines:
-            assert '--hypothesis-seed' not in l
+    results = [initial, rerun]
 
     failure_lines = [
         l

--- a/tests/pytest/test_seeding.py
+++ b/tests/pytest/test_seeding.py
@@ -1,0 +1,99 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2017 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import re
+
+import pytest
+
+from hypothesis.internal.compat import hrange
+
+pytest_plugins = str('pytester')
+
+
+TEST_SUITE = """
+from hypothesis import given, settings
+import hypothesis.strategies as st
+
+
+first = None
+
+@settings(database=None)
+@given(st.text(min_size=3))
+def test_fails_once(some_string):
+    global first
+    if first is None:
+        first = some_string
+
+    assert some_string != first
+"""
+
+
+CONTAINS_SEED_INSTRUCTION = re.compile(r"--hypothesis-seed=\d+", re.MULTILINE)
+
+
+@pytest.mark.parametrize('seed', [0, 42, "foo"])
+def test_runs_repeatably_when_seed_is_set(seed, testdir):
+    script = testdir.makepyfile(TEST_SUITE)
+
+    results = [
+        testdir.runpytest(
+            script, '--verbose', '--strict', "--hypothesis-seed", str(seed)
+        )
+        for _ in hrange(2)
+    ]
+
+    for r in results:
+        for l in r.stdout.lines:
+            assert '--hypothesis-seed' not in l
+
+    failure_lines = [
+        l
+        for r in results
+        for l in r.stdout.lines
+        if 'some_string=' in l
+    ]
+
+    assert len(failure_lines) == 2
+    assert failure_lines[0] == failure_lines[1]
+
+
+def test_runs_repeatably_when_following_seed_instruction(testdir):
+    script = testdir.makepyfile(TEST_SUITE)
+    initial = testdir.runpytest(script, '--verbose', '--strict',)
+
+    match = CONTAINS_SEED_INSTRUCTION.search('\n'.join(initial.stdout.lines))
+    assert match is not None
+
+    rerun = testdir.runpytest(script, '--verbose', '--strict', match.group(0))
+
+    results = [initial, rerun]
+
+    for r in results:
+        for l in r.stdout.lines:
+            assert '--hypothesis-seed' not in l
+
+    failure_lines = [
+        l
+        for r in results
+        for l in r.stdout.lines
+        if 'some_string=' in l
+    ]
+
+    assert len(failure_lines) == 2
+    assert failure_lines[0] == failure_lines[1]

--- a/tests/pytest/test_seeding.py
+++ b/tests/pytest/test_seeding.py
@@ -47,13 +47,13 @@ def test_fails_once(some_string):
 CONTAINS_SEED_INSTRUCTION = re.compile(r"--hypothesis-seed=\d+", re.MULTILINE)
 
 
-@pytest.mark.parametrize('seed', [0, 42, "foo"])
+@pytest.mark.parametrize('seed', [0, 42, 'foo'])
 def test_runs_repeatably_when_seed_is_set(seed, testdir):
     script = testdir.makepyfile(TEST_SUITE)
 
     results = [
         testdir.runpytest(
-            script, '--verbose', '--strict', "--hypothesis-seed", str(seed)
+            script, '--verbose', '--strict', '--hypothesis-seed', str(seed)
         )
         for _ in hrange(2)
     ]

--- a/tests/pytest/test_seeding.py
+++ b/tests/pytest/test_seeding.py
@@ -27,20 +27,21 @@ pytest_plugins = str('pytester')
 
 
 TEST_SUITE = """
-from hypothesis import given, settings
+from hypothesis import given, settings, assume
 import hypothesis.strategies as st
 
 
 first = None
 
 @settings(database=None)
-@given(st.text(min_size=3))
-def test_fails_once(some_string):
+@given(st.integers())
+def test_fails_once(some_int):
+    assume(abs(some_int) > 10000)
     global first
     if first is None:
-        first = some_string
+        first = some_int
 
-    assert some_string != first
+    assert some_int != first
 """
 
 
@@ -66,7 +67,7 @@ def test_runs_repeatably_when_seed_is_set(seed, testdir):
         l
         for r in results
         for l in r.stdout.lines
-        if 'some_string=' in l
+        if 'some_int=' in l
     ]
 
     assert len(failure_lines) == 2
@@ -91,7 +92,7 @@ def test_runs_repeatably_when_following_seed_instruction(testdir):
         l
         for r in results
         for l in r.stdout.lines
-        if 'some_string=' in l
+        if 'some_int=' in l
     ]
 
     assert len(failure_lines) == 2


### PR DESCRIPTION
Users often find themselves in one or more of the following scenarios:

* They have data types with very bad reprs
* They are using Hypothesis features that currently don't play well with `@example`.
* Their CI setup doesn't interact brilliantly with the Hypothesis example database.

This can make it annoying to impossible to reproduce failures from CI locally.

This PR aims to mitigate that: When a test fails, if the random seed required to reproduce that test was not already set deterministically (with `@seed` or `derandomize=True` or with the command line argument I'll mention in a moment), Hypothesis will print out the seed it used along with instructions on how to use it to reproduce the example.

In order to make that information more readily useful and allow reproducing examples without editing the source code, this also adds a command line flag for pytest users to pass the seed explicitly.