### PR TITLE
Coverage guided testing

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,7 +8,7 @@ omit =
     **/strategytests.py
     **/compat*.py
     **/extra/__init__.py
-    **/.tox/*/lib/*/site-packages/hypothesis/internal/branchcheck.py
+    **/.tox/*/lib/*/site-packages/hypothesis/internal/coverage.py
 
 [report]
 exclude_lines =

--- a/.coveragerc
+++ b/.coveragerc
@@ -16,7 +16,6 @@ exclude_lines =
     @abc.abstractproperty
     NotImplementedError
     pragma: no cover
-    suppress_tracing
     __repr__
     __ne__
     __copy__

--- a/.coveragerc
+++ b/.coveragerc
@@ -16,6 +16,7 @@ exclude_lines =
     @abc.abstractproperty
     NotImplementedError
     pragma: no cover
+    suppress_tracing
     __repr__
     __ne__
     __copy__

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ env:
         - TASK=check-unicode
         - TASK=check-ancient-pip
         - TASK=check-pure-tracer
+        - TASK=check-pypy-with-tracer
         - TASK=check-py273
         - TASK=check-py27-typing
         - TASK=check-py34

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ env:
         # worth testing.
         - TASK=check-unicode
         - TASK=check-ancient-pip
+        - TASK=check-pure-tracer
         - TASK=check-py273
         - TASK=check-py27-typing
         - TASK=check-py34

--- a/Makefile
+++ b/Makefile
@@ -197,6 +197,9 @@ check-examples3: $(TOX)
 check-coverage: $(TOX)
 	$(TOX) --recreate -e coverage
 
+check-pure-tracer: $(TOX)
+	$(TOX) --recreate -e pure-tracer
+
 check-unicode: $(TOX) $(PY27)
 	$(TOX) --recreate -e unicode
 

--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,9 @@ check-py36: $(BEST_PY3) $(TOX)
 check-pypy: $(PYPY) $(TOX)
 	$(TOX) --recreate -e pypy-full
 
+check-pypy-with-tracer: $(PYPY) $(TOX)
+	$(TOX) --recreate -e pypy-with-tracer
+
 check-nose: $(TOX)
 	$(TOX) --recreate -e nose
 

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,26 @@
+RELEASE_TYPE: minor
+
+This release makes Hypothesis coverage aware. Hypothesis now runs all test
+bodies under coverage, and uses this information to guide its testing.
+
+The :attr:`~hypothesis.settings.use_coverage` setting can be used to disable
+this behaviour if you want to test code that is sensitive to coverage being
+enabled (either because of performance or interaction with the trace function).
+
+The main benefits of this feature are:
+
+* Hypothesis now observes when examples it discovers cover particular lines
+  or branches and stores them in the database for later.
+* Hypothesis will make some use of this information to guide its exploration of
+  the search space and improve the examples it finds (this is currently used
+  only very lightly and will likely improve significantly in future releases).
+
+This also has the following side-effects:
+
+* Hypothesis now has an install time dependency on the coverage package.
+* Tests that are already running Hypothesis under coverage will likely get
+  faster.
+* Tests that are not running under coverage now run their test bodies under
+  coverage by default (unless on pypy, where coverage is too slow for this to
+  be a sensible default. You can still turn the feature on using the setting
+  discussed below).

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -21,6 +21,9 @@ This also has the following side-effects:
 * Tests that are already running Hypothesis under coverage will likely get
   faster.
 * Tests that are not running under coverage now run their test bodies under
-  coverage by default (unless on pypy, where coverage is too slow for this to
-  be a sensible default. You can still turn the feature on using the setting
-  discussed below).
+  coverage by default.
+
+
+This feature is only partially supported under pypy. It is significantly slower
+than on CPython and is turned off by default as a result, but it should still
+work correctly if you want to use it.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -44,7 +44,7 @@ Available settings
     :members: max_examples, max_iterations, min_satisfying_examples,
         max_shrinks, timeout, strict, database_file, stateful_step_count,
         database, perform_health_check, suppress_health_check, buffer_size,
-        phases, deadline
+        phases, deadline, use_coverage
 
 .. _phases:
 

--- a/requirements/benchmark.in
+++ b/requirements/benchmark.in
@@ -2,3 +2,4 @@ attrs
 click
 numpy
 scipy
+coverage

--- a/requirements/benchmark.txt
+++ b/requirements/benchmark.txt
@@ -6,5 +6,6 @@
 #
 attrs==17.2.0
 click==6.7
+coverage==4.4.1
 numpy==1.13.1
 scipy==0.19.1

--- a/requirements/tools.in
+++ b/requirements/tools.in
@@ -9,3 +9,4 @@ sphinx-rtd-theme
 tox
 twine
 attrs
+coverage

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -12,6 +12,7 @@ babel==2.5.1              # via sphinx
 certifi==2017.7.27.1      # via requests
 chardet==3.0.4            # via requests
 click==6.7                # via pip-tools
+coverage==4.4.1
 docformatter==0.8         # via pyformat
 docutils==0.14            # via restructuredtext-lint, sphinx
 first==2.0.1              # via pip-tools

--- a/scripts/basic-test.sh
+++ b/scripts/basic-test.sh
@@ -22,6 +22,8 @@ PYTEST="python -m pytest"
 
 $PYTEST tests/cover
 
+COVERAGE_TEST_TRACER=timid $PYTEST tests/cover
+
 if [ "$(python -c 'import sys; print(sys.version_info[0] == 2)')" = "True" ] ; then
     $PYTEST tests/py2
 else

--- a/scripts/benchmarks.py
+++ b/scripts/benchmarks.py
@@ -49,7 +49,7 @@ DATA_DIR = os.path.join(
 
 BENCHMARK_SETTINGS = settings(
     max_examples=200, max_iterations=1000, max_shrinks=1000,
-    database=None, timeout=unlimited,
+    database=None, timeout=unlimited, use_coverage=False,
 )
 
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -110,7 +110,7 @@ for var in "$@"; do
       install 3.6.1 python3.6
       ;;
     pypy)
-      install pypy-5.3.1 pypy
+      install pypy2.7-portable-5.8.0
       ;;
   esac
 done

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -110,7 +110,7 @@ for var in "$@"; do
       install 3.6.1 python3.6
       ;;
     pypy)
-      install pypy2.7-portable-5.8.0
+      install pypy2.7-portable-5.8.0 pypy
       ;;
   esac
 done

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ extras['all'] = sorted(sum(extras.values(), []))
 extras[":python_version == '2.7'"] = ['enum34']
 extras[":python_version == '3.3'"] = ['enum34']
 
-install_requires = ['attrs']
+install_requires = ['attrs', 'coverage']
 
 if sys.version_info[0] < 3:
     install_requires.append('enum34')

--- a/src/hypothesis/_settings.py
+++ b/src/hypothesis/_settings.py
@@ -34,6 +34,7 @@ import attr
 
 from hypothesis.errors import InvalidArgument, HypothesisDeprecationWarning
 from hypothesis.configuration import hypothesis_home_dir
+from hypothesis.internal.compat import PYPY
 from hypothesis.utils.conventions import UniqueIdentifier, not_set
 from hypothesis.utils.dynamicvariables import DynamicVariable
 
@@ -639,6 +640,20 @@ this behaviour entirely.
 In future this will default to 200. For now, a
 HypothesisDeprecationWarning will be emitted if you exceed that default
 deadline and have not explicitly set a deadline yourself.
+"""
+)
+
+settings.define_setting(
+    'use_coverage',
+    default=not PYPY,
+    show_default=False,
+    description="""
+Whether to use coverage information to improve Hypothesis's ability to find
+bugs. You should generally leave this turned on unless your code performs
+poorly when run under coverage.
+
+Note: This is turned on by default except on pypy, where coverage performance
+is sufficiently poor as to make this unusable.
 """
 )
 

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -710,7 +710,6 @@ class StateForActualGivenExecution(object):
             origin = traceback.extract_tb(tb)[-1]
             filename = origin[0]
             lineno = origin[1]
-            traceback.print_exc()
             data.mark_interesting((error_class, filename, lineno))
 
     def run(self):

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -28,15 +28,15 @@ import traceback
 from random import Random
 
 import attr
-
-import hypothesis.strategies as st
 from coverage import CoverageData
 from coverage.files import canonical_filename
+from coverage.collector import Collector
+
+import hypothesis.strategies as st
 from hypothesis.errors import Flaky, Timeout, NoSuchExample, \
     Unsatisfiable, InvalidArgument, DeadlineExceeded, MultipleFailures, \
     FailedHealthCheck, UnsatisfiedAssumption, \
     HypothesisDeprecationWarning
-from coverage.collector import Collector
 from hypothesis.control import BuildContext
 from hypothesis._settings import settings as Settings
 from hypothesis._settings import Phase, Verbosity, HealthCheck, \

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -729,13 +729,13 @@ class StateForActualGivenExecution(object):
             runner.run()
         else:  # pragma: no cover
             in_given = True
-            self.original_trace = sys.gettrace()
+            original_trace = sys.gettrace()
             try:
                 sys.settrace(None)
                 runner.run()
             finally:
                 in_given = False
-                sys.settrace(self.original_trace)
+                sys.settrace(original_trace)
         note_engine_for_statistics(runner)
         run_time = time.time() - self.start_time
         timed_out = runner.exit_reason == ExitReason.timeout

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -47,7 +47,8 @@ from hypothesis.reporting import report, verbose_report, current_verbosity
 from hypothesis.statistics import note_engine_for_statistics
 from hypothesis.internal.compat import ceil, str_to_bytes, \
     get_type_hints, getfullargspec, encoded_filepath
-from hypothesis.internal.coverage import IN_COVERAGE_TESTS
+from hypothesis.internal.coverage import IN_COVERAGE_TESTS, \
+    suppress_tracing
 from hypothesis.utils.conventions import infer, not_set
 from hypothesis.internal.escalation import is_hypothesis_file, \
     escalate_hypothesis_internal_error
@@ -116,13 +117,9 @@ def reify_and_execute(
 ):
     def run(data):
         with BuildContext(data, is_final=is_final):
-            orig = sys.gettrace()
-            try:  # pragma: no cover
-                sys.settrace(None)
+            with suppress_tracing():
                 import random as rnd_module
                 rnd_module.seed(0)
-            finally:  # pragma: no cover
-                sys.settrace(orig)
             args, kwargs = data.draw(search_strategy)
 
             if print_example:
@@ -672,21 +669,17 @@ class StateForActualGivenExecution(object):
                     self.search_strategy, self.test,
                 ))
             else:  # pragma: no cover
-                # This should always be a no-op, but the coverage tracer has
-                # a bad habit of resurrecting itself.
-                original = sys.gettrace()
-                sys.settrace(None)
                 try:
-                    try:
-                        self.collector.data = {}
-                        self.collector.start()
-                        result = self.test_runner(data, reify_and_execute(
-                            self.search_strategy, self.test,
-                        ))
-                    finally:
-                        self.collector.stop()
+                    with suppress_tracing():
+                        try:
+                            self.collector.data = {}
+                            self.collector.start()
+                            result = self.test_runner(data, reify_and_execute(
+                                self.search_strategy, self.test,
+                            ))
+                        finally:
+                            self.collector.stop()
                 finally:
-                    sys.settrace(original)
                     covdata = CoverageData()
                     self.collector.save_data(covdata)
                     self.coverage_data.update(covdata)
@@ -739,13 +732,11 @@ class StateForActualGivenExecution(object):
             runner.run()
         else:  # pragma: no cover
             in_given = True
-            original_trace = sys.gettrace()
             try:
-                sys.settrace(None)
-                runner.run()
+                with suppress_tracing():
+                    runner.run()
             finally:
                 in_given = False
-                sys.settrace(original_trace)
         note_engine_for_statistics(runner)
         run_time = time.time() - self.start_time
         timed_out = runner.exit_reason == ExitReason.timeout

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -544,8 +544,9 @@ def hypothesis_should_trace(original_filename, frame):  # pragma: no cover
     return disp
 
 
-def escalate_warning(msg):  # pragma: no cover
-    assert False, 'Unexpected warning from coverage: %s' % (msg,)
+def escalate_warning(msg, slug=None):  # pragma: no cover
+    assert False, 'Unexpected warning from coverage: %s, slug=%r' % (
+        msg, slug)
 
 
 @attr.s(slots=True, frozen=True)

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -46,7 +46,7 @@ from hypothesis.executors import new_style_executor, \
 from hypothesis.reporting import report, verbose_report, current_verbosity
 from hypothesis.statistics import note_engine_for_statistics
 from hypothesis.internal.compat import ceil, str_to_bytes, \
-    get_type_hints, getfullargspec
+    get_type_hints, getfullargspec, encoded_filepath
 from hypothesis.internal.coverage import IN_COVERAGE_TESTS
 from hypothesis.utils.conventions import infer, not_set
 from hypothesis.internal.escalation import is_hypothesis_file, \
@@ -525,14 +525,15 @@ STDLIB = os.path.dirname(os.__file__)
 
 
 def hypothesis_check_include(filename):  # pragma: no cover
-    return filename.endswith(u'.py')
+    return filename.endswith('.py')
 
 
 def hypothesis_should_trace(original_filename, frame):  # pragma: no cover
     disp = FileDisposition()
     assert original_filename is not None
     disp.original_filename = original_filename
-    disp.canonical_filename = canonical_filename(original_filename)
+    disp.canonical_filename = encoded_filepath(
+        canonical_filename(original_filename))
     disp.source_filename = disp.canonical_filename
     disp.reason = ''
     disp.file_tracer = None

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -610,10 +610,10 @@ class StateForActualGivenExecution(object):
 
         self.coverage_data = CoverageData()
 
-        if Collector._collectors:
-            self.hijack_collector(Collector._collectors[-1])
-
         if settings.use_coverage and not IN_COVERAGE_TESTS:  # pragma: no cover
+            if Collector._collectors:
+                self.hijack_collector(Collector._collectors[-1])
+
             self.collector = Collector(
                 branch=True,
                 timid=False,
@@ -626,7 +626,7 @@ class StateForActualGivenExecution(object):
         else:
             self.collector = None
 
-    def hijack_collector(self, collector):
+    def hijack_collector(self, collector):  # pragma: no cover
         original_save_data = collector.save_data
 
         def save_data(covdata):

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -545,8 +545,11 @@ def hypothesis_should_trace(original_filename, frame):  # pragma: no cover
 
 
 def escalate_warning(msg, slug=None):  # pragma: no cover
-    assert False, 'Unexpected warning from coverage: %s, slug=%r' % (
-        msg, slug)
+    if slug is not None:
+        msg = '%s (%s)' % (msg, slug)
+    raise AssertionError(
+        'Unexpected warning from coverage: %s' % (msg,)
+    )
 
 
 @attr.s(slots=True, frozen=True)

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -945,7 +945,7 @@ def given(*given_arguments, **given_kwargs):
             state.run()
 
         for attrib in dir(test):
-            if attrib[0] != '_' and not hasattr(wrapped_test, attrib):
+            if not (attrib.startswith('_') or hasattr(wrapped_test, attrib)):
                 setattr(wrapped_test, attrib, getattr(test, attrib))
         wrapped_test.is_hypothesis_test = True
         wrapped_test._hypothesis_internal_use_seed = getattr(

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -525,7 +525,7 @@ STDLIB = os.path.dirname(os.__file__)
 
 
 def hypothesis_check_include(filename):  # pragma: no cover
-    return filename.endswith('.py')
+    return filename.endswith(u'.py')
 
 
 def hypothesis_should_trace(original_filename, frame):  # pragma: no cover

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -733,8 +733,8 @@ class StateForActualGivenExecution(object):
             try:
                 sys.settrace(None)
                 runner.run()
-                in_given = False
             finally:
+                in_given = False
                 sys.settrace(self.original_trace)
         note_engine_for_statistics(runner)
         run_time = time.time() - self.start_time

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -637,7 +637,9 @@ class StateForActualGivenExecution(object):
                     self.search_strategy, self.test,
                 ))
             else:  # pragma: no cover
-                assert sys.gettrace() is None, sys.gettrace()
+                # This should always be a no-op, but the coverage tracer has
+                # a bad habit of resurrecting itself.
+                sys.settrace(None)
                 try:
                     self.collector.data = {}
                     self.collector.start()

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -565,6 +565,9 @@ class Arc(object):
 in_given = False
 
 
+FORCE_PURE_TRACER = os.getenv('HYPOTHESIS_FORCE_PURE_TRACER') == 'true'
+
+
 class StateForActualGivenExecution(object):
 
     def __init__(self, test_runner, search_strategy, test, settings, random):
@@ -617,7 +620,7 @@ class StateForActualGivenExecution(object):
 
             self.collector = Collector(
                 branch=True,
-                timid=False,
+                timid=FORCE_PURE_TRACER,
                 should_trace=hypothesis_should_trace,
                 check_include=hypothesis_check_include,
                 concurrency='thread',

--- a/src/hypothesis/extra/numpy.py
+++ b/src/hypothesis/extra/numpy.py
@@ -26,8 +26,8 @@ import hypothesis.internal.conjecture.utils as cu
 from hypothesis.errors import InvalidArgument
 from hypothesis.searchstrategy import SearchStrategy
 from hypothesis.internal.compat import hrange, text_type
+from hypothesis.internal.coverage import check_function
 from hypothesis.internal.reflection import proxies
-from hypothesis.internal.branchcheck import check_function
 
 TIME_RESOLUTIONS = tuple('Y  M  D  h  m  s  ms  us  ns  ps  fs  as'.split())
 

--- a/src/hypothesis/extra/pandas/impl.py
+++ b/src/hypothesis/extra/pandas/impl.py
@@ -30,7 +30,7 @@ import hypothesis.internal.conjecture.utils as cu
 from hypothesis.errors import InvalidArgument
 from hypothesis.control import reject
 from hypothesis.internal.compat import hrange
-from hypothesis.internal.branchcheck import check, check_function
+from hypothesis.internal.coverage import check, check_function
 
 try:
     from pandas.api.types import is_categorical_dtype

--- a/src/hypothesis/internal/compat.py
+++ b/src/hypothesis/internal/compat.py
@@ -243,6 +243,17 @@ else:
     from time import time as benchmark_time
 
 
+if PY2:
+    def encoded_filepath(filepath):
+        if isinstance(filepath, text_type):
+            return filepath.encode(sys.getfilesystemencoding())
+        else:
+            return filepath
+else:
+    def encoded_filepath(filepath):
+        return filepath
+
+
 def a_good_encoding():
     return 'utf-8'
 

--- a/src/hypothesis/internal/compat.py
+++ b/src/hypothesis/internal/compat.py
@@ -243,6 +243,12 @@ else:
     from time import time as benchmark_time
 
 
+# coverage mixes unicode and str filepaths on Python 2, which causes us
+# problems if we're running under unicodenazi (it might also cause problems
+# when not running under unicodenazi, but hard to say for sure). This method
+# exists to work around that: If we're given a unicode filepath, we turn it
+# into a string file path using the appropriate encoding. See
+# https://bitbucket.org/ned/coveragepy/issues/602/ for more information.
 if PY2:
     def encoded_filepath(filepath):
         if isinstance(filepath, text_type):

--- a/src/hypothesis/internal/conjecture/data.py
+++ b/src/hypothesis/internal/conjecture/data.py
@@ -17,13 +17,13 @@
 
 from __future__ import division, print_function, absolute_import
 
-import sys
 from enum import IntEnum
 
 from hypothesis.errors import Frozen, InvalidArgument
 from hypothesis.internal.compat import hbytes, hrange, text_type, \
     bit_length, benchmark_time, int_from_bytes, unicode_safe_repr
-from hypothesis.internal.coverage import IN_COVERAGE_TESTS
+from hypothesis.internal.coverage import IN_COVERAGE_TESTS, \
+    suppress_tracing
 
 
 class Status(IntEnum):
@@ -120,12 +120,8 @@ class ConjectureData(object):
         if self.depth >= MAX_DEPTH:
             self.mark_invalid()
         if self.depth == 0 and not IN_COVERAGE_TESTS:  # pragma: no cover
-            original_tracer = sys.gettrace()
-            try:
-                sys.settrace(None)
+            with suppress_tracing():
                 return self.__draw(strategy)
-            finally:
-                sys.settrace(original_tracer)
         else:
             return self.__draw(strategy)
 

--- a/src/hypothesis/internal/conjecture/data.py
+++ b/src/hypothesis/internal/conjecture/data.py
@@ -106,19 +106,18 @@ class ConjectureData(object):
         self.output += value
 
     def draw(self, strategy):
-        if strategy.is_empty:
-            self.mark_invalid()
-
-        if self.depth >= MAX_DEPTH:
-            self.mark_invalid()
         if self.is_find and not strategy.supports_find:
             raise InvalidArgument((
                 'Cannot use strategy %r within a call to find (presumably '
                 'because it would be invalid after the call had ended).'
             ) % (strategy,))
 
+        if strategy.is_empty:
+            self.mark_invalid()
+
         if self.depth >= MAX_DEPTH:
             self.mark_invalid()
+
         if self.depth == 0 and not IN_COVERAGE_TESTS:  # pragma: no cover
             original_tracer = sys.gettrace()
             try:

--- a/src/hypothesis/internal/conjecture/data.py
+++ b/src/hypothesis/internal/conjecture/data.py
@@ -121,6 +121,14 @@ class ConjectureData(object):
             self.mark_invalid()
         if self.depth == 0 and not IN_COVERAGE_TESTS:  # pragma: no cover
             original_tracer = sys.gettrace()
+            # This branch probably doesn't matter much in CPython, where
+            # sys.settrace is if not super-fast at least pretty fast when
+            # called with None, but on pypy sys.settrace() is opaque to the
+            # JIT, so not calling it if we can avoid it is better even when
+            # the argument is trivial.
+
+            # This hasn't been benchmarked at all so it might not be necesssary
+            # but it seems like a good idea.
             if original_tracer is None:
                 return self.__draw(strategy)
             else:

--- a/src/hypothesis/internal/conjecture/data.py
+++ b/src/hypothesis/internal/conjecture/data.py
@@ -17,13 +17,13 @@
 
 from __future__ import division, print_function, absolute_import
 
+import sys
 from enum import IntEnum
 
 from hypothesis.errors import Frozen, InvalidArgument
 from hypothesis.internal.compat import hbytes, hrange, text_type, \
     bit_length, benchmark_time, int_from_bytes, unicode_safe_repr
-from hypothesis.internal.coverage import IN_COVERAGE_TESTS, \
-    suppress_tracing
+from hypothesis.internal.coverage import IN_COVERAGE_TESTS
 
 
 class Status(IntEnum):
@@ -120,8 +120,12 @@ class ConjectureData(object):
         if self.depth >= MAX_DEPTH:
             self.mark_invalid()
         if self.depth == 0 and not IN_COVERAGE_TESTS:  # pragma: no cover
-            with suppress_tracing():
+            original_tracer = sys.gettrace()
+            try:
+                sys.settrace(None)
                 return self.__draw(strategy)
+            finally:
+                sys.settrace(original_tracer)
         else:
             return self.__draw(strategy)
 

--- a/src/hypothesis/internal/conjecture/data.py
+++ b/src/hypothesis/internal/conjecture/data.py
@@ -121,22 +121,11 @@ class ConjectureData(object):
             self.mark_invalid()
         if self.depth == 0 and not IN_COVERAGE_TESTS:  # pragma: no cover
             original_tracer = sys.gettrace()
-            # This branch probably doesn't matter much in CPython, where
-            # sys.settrace is if not super-fast at least pretty fast when
-            # called with None, but on pypy sys.settrace() is opaque to the
-            # JIT, so not calling it if we can avoid it is better even when
-            # the argument is trivial.
-
-            # This hasn't been benchmarked at all so it might not be necesssary
-            # but it seems like a good idea.
-            if original_tracer is None:
+            try:
+                sys.settrace(None)
                 return self.__draw(strategy)
-            else:
-                try:
-                    sys.settrace(None)
-                    return self.__draw(strategy)
-                finally:
-                    sys.settrace(original_tracer)
+            finally:
+                sys.settrace(original_tracer)
         else:
             return self.__draw(strategy)
 

--- a/src/hypothesis/internal/conjecture/data.py
+++ b/src/hypothesis/internal/conjecture/data.py
@@ -23,6 +23,7 @@ from enum import IntEnum
 from hypothesis.errors import Frozen, InvalidArgument
 from hypothesis.internal.compat import hbytes, hrange, text_type, \
     bit_length, benchmark_time, int_from_bytes, unicode_safe_repr
+from hypothesis.internal.coverage import IN_COVERAGE_TESTS
 
 
 class Status(IntEnum):
@@ -118,7 +119,7 @@ class ConjectureData(object):
 
         if self.depth >= MAX_DEPTH:
             self.mark_invalid()
-        if self.depth == 0:
+        if self.depth == 0 and not IN_COVERAGE_TESTS:  # pragma: no cover
             original_tracer = sys.gettrace()
             if original_tracer is None:
                 return self.__draw(strategy)

--- a/src/hypothesis/internal/coverage.py
+++ b/src/hypothesis/internal/coverage.py
@@ -53,7 +53,10 @@ def pretty_file_name(f):
     return result
 
 
-if os.getenv('HYPOTHESIS_INTERNAL_BRANCH_CHECK') == 'true':
+IN_COVERAGE_TESTS = os.getenv('HYPOTHESIS_INTERNAL_COVERAGE') == 'true'
+
+
+if IN_COVERAGE_TESTS:
     log = open('branch-check', 'w')
     written = set()
 

--- a/src/hypothesis/internal/coverage.py
+++ b/src/hypothesis/internal/coverage.py
@@ -114,3 +114,12 @@ else:
     @contextmanager
     def check(name):
         yield
+
+
+class suppress_tracing(object):
+    def __enter__(self):
+        self.__original_trace = sys.gettrace()
+        sys.settrace(None)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        sys.settrace(self.__original_trace)

--- a/src/hypothesis/internal/escalation.py
+++ b/src/hypothesis/internal/escalation.py
@@ -23,19 +23,22 @@ import sys
 import coverage
 import hypothesis
 from hypothesis.errors import DeadlineExceeded
+from hypothesis.internal.compat import text_type, binary_type, \
+    encoded_filepath
 
 
 def belongs_to(package):
     root = os.path.dirname(package.__file__)
-    cache = {}
+    cache = {text_type: {}, binary_type: {}}
 
     def accept(filepath):
         try:
-            return cache[filepath]
+            return cache[type(filepath)][filepath]
         except KeyError:
             pass
+        filepath = encoded_filepath(filepath)
         result = os.path.abspath(filepath).startswith(root)
-        cache[filepath] = result
+        cache[type(filepath)][filepath] = result
         return result
     accept.__name__ = 'is_%s_file' % (package.__name__,)
     return accept

--- a/src/hypothesis/internal/escalation.py
+++ b/src/hypothesis/internal/escalation.py
@@ -53,5 +53,8 @@ def escalate_hypothesis_internal_error():
         error_type, DeadlineExceeded
     ):
         raise
-    if is_coverage_file(filepath) and issubclass(error_type, AssertionError):
+    # This is so that if we do something wrong and trigger an internal Coverage
+    # error we don't try to catch it. It should be impossible to trigger, but
+    # you never know.
+    if is_coverage_file(filepath):  # pragma: no cover
         raise

--- a/src/hypothesis/internal/escalation.py
+++ b/src/hypothesis/internal/escalation.py
@@ -21,6 +21,7 @@ import os
 import sys
 
 import coverage
+
 import hypothesis
 from hypothesis.errors import DeadlineExceeded
 from hypothesis.internal.compat import text_type, binary_type, \

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -34,10 +34,10 @@ from hypothesis.internal.compat import gcd, ceil, floor, hrange, \
     implements_iterator
 from hypothesis.internal.floats import is_negative, float_to_int, \
     int_to_float, count_between_floats
+from hypothesis.internal.coverage import check_function
 from hypothesis.internal.renaming import renamed_arguments
 from hypothesis.utils.conventions import infer, not_set
 from hypothesis.internal.reflection import proxies, required_args
-from hypothesis.internal.branchcheck import check_function
 
 __all__ = [
     'nothing',

--- a/tests/common/debug.py
+++ b/tests/common/debug.py
@@ -17,6 +17,8 @@
 
 from __future__ import division, print_function, absolute_import
 
+import sys
+
 from hypothesis import settings as Settings
 from hypothesis import find, given, assume, reject
 from hypothesis.errors import NoSuchExample, Unsatisfiable
@@ -56,12 +58,16 @@ def minimal(
             runtime.append(0.0)
         return result
 
-    return find(
-        definition,
-        wrapped_condition,
-        settings=settings,
-        random=random,
-    )
+    try:
+        orig = sys.gettrace()
+        return find(
+            definition,
+            wrapped_condition,
+            settings=settings,
+            random=random,
+        )
+    finally:
+        sys.settrace(orig)
 
 
 def find_any(

--- a/tests/common/setup.py
+++ b/tests/common/setup.py
@@ -25,6 +25,7 @@ from hypothesis import settings, unlimited
 from hypothesis.errors import HypothesisDeprecationWarning
 from hypothesis.configuration import set_hypothesis_home_dir
 from hypothesis.internal.charmap import charmap, charmap_file
+from hypothesis.internal.coverage import IN_COVERAGE_TESTS
 
 
 def run():
@@ -51,7 +52,8 @@ def run():
                 v, s.name, s.name, s.default,
             )
 
-    settings.register_profile('default', settings(timeout=unlimited))
+    settings.register_profile('default', settings(
+        timeout=unlimited, use_coverage=not IN_COVERAGE_TESTS))
 
     settings.register_profile(
         'speedy', settings(

--- a/tests/common/setup.py
+++ b/tests/common/setup.py
@@ -24,6 +24,7 @@ from tempfile import mkdtemp
 from hypothesis import settings, unlimited
 from hypothesis.errors import HypothesisDeprecationWarning
 from hypothesis.configuration import set_hypothesis_home_dir
+from hypothesis.internal.compat import PYPY
 from hypothesis.internal.charmap import charmap, charmap_file
 from hypothesis.internal.coverage import IN_COVERAGE_TESTS
 
@@ -53,7 +54,11 @@ def run():
             )
 
     settings.register_profile('default', settings(
-        timeout=unlimited, use_coverage=not IN_COVERAGE_TESTS))
+        timeout=unlimited, use_coverage=not (IN_COVERAGE_TESTS or PYPY)))
+
+    settings.register_profile('with_coverage', settings(
+        timeout=unlimited, use_coverage=True,
+    ))
 
     settings.register_profile(
         'speedy', settings(

--- a/tests/common/utils.py
+++ b/tests/common/utils.py
@@ -96,3 +96,12 @@ def checks_deprecated_behaviour(func):
 
 def all_values(db):
     return set(v for vs in db.data.values() for v in vs)
+
+
+def non_covering_examples(database):
+    return {
+        v
+        for k, vs in database.data.items()
+        if not k.endswith(b'.coverage')
+        for v in vs
+    }

--- a/tests/cover/test_conjecture_engine.py
+++ b/tests/cover/test_conjecture_engine.py
@@ -564,7 +564,7 @@ def test_will_save_covering_examples():
         max_examples=100, max_iterations=10000, max_shrinks=0,
         buffer_size=1024,
         database=db,
-    ),  database_key=b'stuff')
+    ), database_key=b'stuff')
     runner.run()
     assert len(all_values(db)) == len(tags)
 
@@ -581,7 +581,7 @@ def test_will_shrink_covering_examples():
         max_examples=100, max_iterations=10000, max_shrinks=0,
         buffer_size=1024,
         database=db,
-    ),  database_key=b'stuff')
+    ), database_key=b'stuff')
     runner.run()
     assert all_values(db) == set(seen)
 

--- a/tests/cover/test_database_usage.py
+++ b/tests/cover/test_database_usage.py
@@ -22,7 +22,7 @@ import pytest
 import hypothesis.strategies as st
 from hypothesis import Verbosity, find, given, assume, settings
 from hypothesis.errors import NoSuchExample, Unsatisfiable
-from tests.common.utils import all_values
+from tests.common.utils import all_values, non_covering_examples
 from hypothesis.database import InMemoryExampleDatabase
 from hypothesis.internal.compat import hbytes
 
@@ -153,7 +153,7 @@ def test_clears_out_everything_smaller_than_the_interesting_example():
         with pytest.raises(AssertionError):
             test()
 
-        saved = all_values(database)
+        saved = non_covering_examples(database)
         if len(saved) > 30:
             break
     else:
@@ -164,7 +164,7 @@ def test_clears_out_everything_smaller_than_the_interesting_example():
     with pytest.raises(AssertionError):
         test()
 
-    saved = all_values(database)
+    saved = non_covering_examples(database)
 
     for s in saved:
         assert s >= target[0]

--- a/tests/cover/test_nesting.py
+++ b/tests/cover/test_nesting.py
@@ -1,0 +1,39 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2017 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+from pytest import raises
+
+import hypothesis.strategies as st
+from hypothesis import Verbosity, given, settings
+
+
+def test_nesting_1():
+    @given(st.integers(0, 100))
+    @settings(max_examples=5, database=None, deadline=None)
+    def test_blah(x):
+        @given(st.integers())
+        @settings(
+            max_examples=100, max_shrinks=0, database=None,
+            verbosity=Verbosity.quiet)
+        def test_nest(y):
+            if y >= x:
+                raise ValueError()
+        with raises(ValueError):
+            test_nest()
+    test_blah()

--- a/tests/cover/test_phases.py
+++ b/tests/cover/test_phases.py
@@ -84,7 +84,7 @@ def test_will_save_when_reuse_not_in_phases():
     with pytest.raises(ValueError):
         test_usage()
 
-    saved, = database.data.values()
+    saved, = [v for k, v in database.data.items() if b'coverage' not in k]
     assert len(saved) == 1
 
 

--- a/tests/cover/test_slippage.py
+++ b/tests/cover/test_slippage.py
@@ -22,7 +22,7 @@ import pytest
 import hypothesis.strategies as st
 from hypothesis import given, settings
 from hypothesis.errors import Flaky, MultipleFailures
-from tests.common.utils import capture_out
+from tests.common.utils import capture_out, non_covering_examples
 from hypothesis.database import InMemoryExampleDatabase
 
 
@@ -147,7 +147,7 @@ def test_garbage_collects_the_secondary_key():
     bug_fixed = True
 
     def count():
-        return sum(len(v) for v in db.data.values())
+        return len(non_covering_examples(db))
 
     prev = count()
     while prev > 0:

--- a/tests/nocover/test_coverage.py
+++ b/tests/nocover/test_coverage.py
@@ -18,9 +18,11 @@
 from __future__ import division, print_function, absolute_import
 
 import hypothesis.strategies as st
+from coverage import Coverage
 from hypothesis import given, settings
 from tests.common.utils import all_values
 from hypothesis.database import InMemoryExampleDatabase
+from hypothesis.internal.compat import hrange
 
 
 def test_tracks_and_saves_coverage():
@@ -41,3 +43,38 @@ def test_tracks_and_saves_coverage():
     test_branching()
 
     assert len(all_values(db)) == 3
+
+
+def some_function_to_test(a, b, c):
+    result = 0
+    if a:
+        result += 1
+    if b:
+        result += 1
+    if c:
+        result += 1
+    return result
+
+
+LINE_START = some_function_to_test.__code__.co_firstlineno
+with open(__file__) as i:
+    lines = [l.strip() for l in i]
+    LINE_END = LINE_START + lines[LINE_START:].index('')
+
+
+def test_achieves_full_coverage(tmpdir):
+    @given(st.booleans(), st.booleans(), st.booleans())
+    def test(a, b, c):
+        some_function_to_test(a, b, c)
+
+    cov = Coverage(
+        config_file=False, data_file=tmpdir.join('.coveragerc')
+    )
+    cov.start()
+    test()
+    cov.stop()
+
+    data = cov.get_data()
+    lines = data.lines(__file__)
+    for i in hrange(LINE_START + 1, LINE_END + 1):
+        assert i in lines

--- a/tests/nocover/test_coverage.py
+++ b/tests/nocover/test_coverage.py
@@ -17,6 +17,8 @@
 
 from __future__ import division, print_function, absolute_import
 
+import pytest
+
 import hypothesis.strategies as st
 from coverage import Coverage
 from hypothesis import given, settings
@@ -65,13 +67,15 @@ with open(__file__) as i:
     LINE_END = LINE_START + lines[LINE_START:].index('')
 
 
-def test_achieves_full_coverage(tmpdir):
+@pytest.mark.parametrize('branch', [False, True])
+def test_achieves_full_coverage(tmpdir, branch):
     @given(st.booleans(), st.booleans(), st.booleans())
     def test(a, b, c):
         some_function_to_test(a, b, c)
 
     cov = Coverage(
-        config_file=False, data_file=tmpdir.join('.coveragerc')
+        config_file=False, data_file=str(tmpdir.join('.coveragerc')),
+        branch=branch,
     )
     cov.start()
     test()

--- a/tests/nocover/test_coverage.py
+++ b/tests/nocover/test_coverage.py
@@ -1,0 +1,43 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2017 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import hypothesis.strategies as st
+from hypothesis import given, settings
+from tests.common.utils import all_values
+from hypothesis.database import InMemoryExampleDatabase
+
+
+def test_tracks_and_saves_coverage():
+    db = InMemoryExampleDatabase()
+
+    def do_nothing(): pass
+
+    @settings(database=db)
+    @given(st.integers())
+    def test_branching(i):
+        if i < 0:
+            do_nothing()
+        if i == 0:
+            do_nothing()
+        if i > 0:
+            do_nothing()
+
+    test_branching()
+
+    assert len(all_values(db)) == 3

--- a/tests/nocover/test_coverage.py
+++ b/tests/nocover/test_coverage.py
@@ -28,7 +28,10 @@ from hypothesis.internal.compat import hrange
 def test_tracks_and_saves_coverage():
     db = InMemoryExampleDatabase()
 
-    def do_nothing(): pass
+    def do_nothing():
+        """Use in place of pass for empty branches, which don't show up under
+        coverge."""
+        pass
 
     @settings(database=db)
     @given(st.integers())

--- a/tests/nocover/test_coverage.py
+++ b/tests/nocover/test_coverage.py
@@ -25,6 +25,7 @@ from hypothesis import given, settings
 from tests.common.utils import all_values
 from hypothesis.database import InMemoryExampleDatabase
 from hypothesis.internal.compat import hrange
+from hypothesis.core import escalate_warning
 
 
 def test_tracks_and_saves_coverage():
@@ -78,6 +79,7 @@ def test_achieves_full_coverage(tmpdir, branch, timid):
         config_file=False, data_file=str(tmpdir.join('.coveragerc')),
         branch=branch, timid=timid,
     )
+    cov._warn = escalate_warning
     cov.start()
     test()
     cov.stop()

--- a/tests/nocover/test_coverage.py
+++ b/tests/nocover/test_coverage.py
@@ -44,11 +44,11 @@ def test_tracks_and_saves_coverage():
     @settings(database=db)
     @given(st.integers())
     def test_branching(i):
-        if i < 0:
+        if i < -1000:
             do_nothing()
-        if i == 0:
+        elif i > 1000:
             do_nothing()
-        if i > 0:
+        else:
             do_nothing()
 
     test_branching()

--- a/tests/nocover/test_coverage.py
+++ b/tests/nocover/test_coverage.py
@@ -27,6 +27,11 @@ from tests.common.utils import all_values
 from hypothesis.database import InMemoryExampleDatabase
 from hypothesis.internal.compat import hrange
 
+pytestmark = pytest.mark.skipif(
+    not settings.default.use_coverage,
+    reason='Coverage is disabled for this build.'
+)
+
 
 def test_tracks_and_saves_coverage():
     db = InMemoryExampleDatabase()

--- a/tests/nocover/test_coverage.py
+++ b/tests/nocover/test_coverage.py
@@ -22,10 +22,10 @@ from coverage import Coverage
 
 import hypothesis.strategies as st
 from hypothesis import given, settings
+from hypothesis.core import escalate_warning
 from tests.common.utils import all_values
 from hypothesis.database import InMemoryExampleDatabase
 from hypothesis.internal.compat import hrange
-from hypothesis.core import escalate_warning
 
 
 def test_tracks_and_saves_coverage():

--- a/tests/nocover/test_coverage.py
+++ b/tests/nocover/test_coverage.py
@@ -18,9 +18,9 @@
 from __future__ import division, print_function, absolute_import
 
 import pytest
+from coverage import Coverage
 
 import hypothesis.strategies as st
-from coverage import Coverage
 from hypothesis import given, settings
 from tests.common.utils import all_values
 from hypothesis.database import InMemoryExampleDatabase
@@ -68,14 +68,15 @@ with open(__file__) as i:
 
 
 @pytest.mark.parametrize('branch', [False, True])
-def test_achieves_full_coverage(tmpdir, branch):
+@pytest.mark.parametrize('timid', [False, True])
+def test_achieves_full_coverage(tmpdir, branch, timid):
     @given(st.booleans(), st.booleans(), st.booleans())
     def test(a, b, c):
         some_function_to_test(a, b, c)
 
     cov = Coverage(
         config_file=False, data_file=str(tmpdir.join('.coveragerc')),
-        branch=branch,
+        branch=branch, timid=timid,
     )
     cov.start()
     test()

--- a/tests/nocover/test_float_shrinking.py
+++ b/tests/nocover/test_float_shrinking.py
@@ -42,6 +42,7 @@ def test_can_shrink_in_variable_sized_context(n):
 
 @example(1.5)
 @given(st.floats(min_value=0, allow_infinity=False, allow_nan=False))
+@settings(use_coverage=False)
 def test_shrinks_downwards_to_integers(f):
     g = minimal(
         st.floats(), lambda x: x >= f, random=Random(0),
@@ -52,7 +53,7 @@ def test_shrinks_downwards_to_integers(f):
 
 @example(1)
 @given(st.integers(1, 2 ** 16 - 1))
-@settings(verbosity=Verbosity.debug)
+@settings(use_coverage=False)
 def test_shrinks_downwards_to_integers_when_fractional(b):
     g = minimal(
         st.floats(),

--- a/tox.ini
+++ b/tox.ini
@@ -141,7 +141,7 @@ deps =
     -rrequirements/test.txt
     -rrequirements/coverage.txt
 setenv=
-    HYPOTHESIS_INTERNAL_BRANCH_CHECK=true
+    HYPOTHESIS_INTERNAL_COVERAGE=true
 commands =
     python -m coverage --version
     python -m coverage debug sys

--- a/tox.ini
+++ b/tox.ini
@@ -158,6 +158,17 @@ setenv=
 commands =
     python -m pytest tests/cover tests/nocover/test_coverage.py -n 0 {posargs}
 
+
+[testenv:pypy-with-tracer]
+setenv=
+    HYPOTHESIS_PROFILE=with_coverage
+basepython=pypy
+deps =
+    -rrequirements/test.txt
+commands =
+    python -m pytest tests/cover tests/nocover/test_coverage.py -n 0 {posargs}
+
+
 [testenv:examples3]
 setenv=
     HYPOTHESIS_STRICT_MODE=true

--- a/tox.ini
+++ b/tox.ini
@@ -166,7 +166,7 @@ basepython=pypy
 deps =
     -rrequirements/test.txt
 commands =
-    python -m pytest tests/cover tests/nocover/test_coverage.py -n 0 {posargs}
+    python -m pytest tests/cover/test_testdecorators.py tests/nocover/test_coverage.py -n 0 {posargs}
 
 
 [testenv:examples3]

--- a/tox.ini
+++ b/tox.ini
@@ -149,6 +149,15 @@ commands =
     python -m coverage report -m --fail-under=100 --show-missing
     python scripts/validate_branch_check.py
 
+
+[testenv:pure-tracer]
+deps =
+    -rrequirements/test.txt
+setenv=
+    HYPOTHESIS_FORCE_PURE_TRACER=true
+commands =
+    python -m pytest tests/cover -n 0 {posargs}
+
 [testenv:examples3]
 setenv=
     HYPOTHESIS_STRICT_MODE=true

--- a/tox.ini
+++ b/tox.ini
@@ -156,7 +156,7 @@ deps =
 setenv=
     HYPOTHESIS_FORCE_PURE_TRACER=true
 commands =
-    python -m pytest tests/cover -n 0 {posargs}
+    python -m pytest tests/cover tests/nocover/test_coverage.py -n 0 {posargs}
 
 [testenv:examples3]
 setenv=


### PR DESCRIPTION
[Quoth](https://github.com/HypothesisWorks/HypothesisWorks.github.io/pull/19#issuecomment-329531729) @Zac-HD recently:

> I know it's been on the backburner forever, but I'm personally interested in how coverage-guided exploration might be related to this.

And me in an email to @agroce:

> when I finally get around to getting coverage information used in Hypothesis.

We're both right. This is getting silly. I've been saying for literal years that Hypothesis was going to get coverage guided testing real soon now.

There have historically been a bunch of major obstacles to using coverage information in Hypothesis:

1. It's highly non-obvious how much we can benefit from it 
2. There are a host of fiddly little details
3. Performance is going to hurt
4. Actually just sitting down and doing it.

So, um, you know that thing where you get a bee in your bonnet and you decide that it's a really good idea to drink a tonne of coffee and whiskey at 10PM and stay up all night working on a problem that's been annoying you for ages and you keep putting off just doing the damn work on because all of the solutions are unsatisfying and you decide it's time to just take a very large stick at beat the damn problem until it cries uncle?

No? Oh, OK.

Well, consider this PR a stress test of the [drunken developer principle](https://twitter.com/DRMacIver/status/907702180861313026) and/or a test of your ability to distinguish my drunk code from my sober code.

It solves the above four problems as follows:

1. Eh. Lets pick some super low hanging fruit and worry about the rest later. Once the capability is present, functionality built on it can follow.
2. A Simple Matter Of Code
3. Oh well. We'll just use the coverage tracer plus some hacks and hope it's not too bad. It probably won't be too bad, and we can claw some performance back by protecting Hypothesis internal details and test case generation from running under coverage.
4. Coffee, whiskey, sugar, sleep deprivation, bad life choices.

# General Design Principles

1. We introduce a general notion of tagging to ConjectureData. We use it roughly similarly to `interestingness_origin` but with a bunch of difference. In particular data can have multiple tags.
2. We have a third database key (yes I know) for storing coverage examples.
3. We use coverage to provide those tags.
4. At the end we rerun our coverage corpus so that real coverage can benefit from all of the examples we've run.
5. In all sorts of circumstances we degrade back to the old algorithm and that's fine.
6. We use some flags to turn this off when testing coverage of our own code. This results in a bunch of "pragma: no cover" bits which are never triggered under coverage. Sad face.

In terms of coverage guided example discovery, we don't do much. The coverage corpus becomes the new seeds for mutation. We can and should do more of that later.

# Still TODO

* [x] Review and reflection by sober-@DRMacIver
* [x] ~~See if we can do a bit better on the coverage based example discovery~~ Lets not and wait on #859 before I poke around with the data generation any more.
* [x] ~~Poke a bit more at performance. It ain't great (it will be interesting to see how much the build slows down). I suspect some of that is the overhead of doing a lot of coverage start/stop (coverage isn't really designed to be run like this!). Of course, by the nature of this work none of the profiling tools are going to work properly.~~ eh it's not too bad. Let's just ship it and see what happens.
* [x] Usual "I bet the build is totally broken" wrangling, though what I ran locally was looking suspiciously functional. [BEHOLD](https://travis-ci.org/HypothesisWorks/hypothesis-python/builds/275856629)
* [x] Document all of the *completely terrible things* I have done to Coverage and feed them back to @nedbat as feature requests so he doesn't hate me. Done: See https://bitbucket.org/ned/coveragepy/pull-requests/129/fixes-documentation-comments-about/, https://bitbucket.org/ned/coveragepy/issues/604/add-api-method-to-merge-coveragedata, https://bitbucket.org/ned/coveragepy/issues/603/add-something-like-collector-to-the-public, https://bitbucket.org/ned/coveragepy/issues/602/internal-use-of-unicode-file-paths-on