### PR TITLE
Block install on Python 3.3 for EOL on 29 September

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@ export COVERAGE_FILE=$(BUILD_RUNTIMES)/.coverage
 
 PY27=$(BUILD_RUNTIMES)/snakepit/python2.7
 PY273=$(BUILD_RUNTIMES)/snakepit/python2.7.3
-PY33=$(BUILD_RUNTIMES)/snakepit/python3.3
 PY34=$(BUILD_RUNTIMES)/snakepit/python3.4
 PY35=$(BUILD_RUNTIMES)/snakepit/python3.5
 PY36=$(BUILD_RUNTIMES)/snakepit/python3.6
@@ -49,9 +48,6 @@ $(PY27):
 
 $(PY273):
 	scripts/retry.sh scripts/install.sh 2.7.3
-
-$(PY33):
-	scripts/retry.sh scripts/install.sh 3.3
 
 $(PY34):
 	scripts/retry.sh scripts/install.sh 3.4
@@ -129,9 +125,6 @@ check-py273: $(PY273) $(TOX)
 check-py27-typing: $(PY27) $(TOX)
 	$(TOX) --recreate -e py27typing
 
-check-py33: $(PY33) $(TOX)
-	$(TOX) --recreate -e py33-full
-
 check-py34: $(PY34) $(TOX)
 	$(TOX) --recreate -e py34-full
 
@@ -200,7 +193,7 @@ check-coverage: $(TOX)
 check-unicode: $(TOX) $(PY27)
 	$(TOX) --recreate -e unicode
 
-check-noformat: check-coverage check-py26 check-py27 check-py33 check-py34 check-py35 check-pypy check-django check-pytest
+check-noformat: check-coverage check-py26 check-py27 check-py34 check-py35 check-pypy check-django check-pytest
 
 check: check-format check-noformat
 

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,8 @@
+RELEASE_TYPE: minor
+
+This release blocks installation of Hypothesis on Python 3.3, which
+:PEP:`reached its end of life date on 2017-09-29 <398>`.
+
+This should not be of interest to anyone but downstream maintainers -
+if you are affected, migrate to a secure version of Python as soon as
+possible or at least seek commercial support.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -85,20 +85,11 @@ install () {
 
 for var in "$@"; do
   case "${var}" in
-    2.6)
-      install 2.6.9 python2.6
-      ;;
     2.7)
       install 2.7.11 python2.7
       ;;
     2.7.3)
       install 2.7.3 python2.7.3
-      ;;
-    3.2)
-      install 3.2.6 python3.2
-      ;;
-    3.3)
-      install 3.3.6 python3.3
       ;;
     3.4)
       install 3.4.3 python3.4

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ extras['faker'] = extras['fakefactory']
 extras['all'] = sorted(sum(extras.values(), []))
 
 extras[":python_version == '2.7'"] = ['enum34']
-extras[":python_version == '3.3'"] = ['enum34']
 
 install_requires = ['attrs']
 
@@ -75,7 +74,7 @@ setup(
     zip_safe=False,
     extras_require=extras,
     install_requires=install_requires,
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',

--- a/src/hypothesis/internal/compat.py
+++ b/src/hypothesis/internal/compat.py
@@ -490,8 +490,6 @@ else:
 # an existing file where you're not allowed to. This is rather less consistent
 # between versions than might be hoped.
 if PY3:
-    # Note: This only works on >= 3.3, but we only support >= 3.3 so that's
-    # fine
     FileExistsError = FileExistsError
 
 elif WINDOWS:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,33,34,35,36,py}-{brief,prettyquick,full,custom,benchmark}
+envlist = py{27,34,35,36,py}-{brief,prettyquick,full,custom,benchmark}
 toxworkdir={env:TOX_WORK_DIR:.tox}
 
 passenv=


### PR DESCRIPTION
[Python 3.3 will be end-of-life on September 29](https://www.python.org/dev/peps/pep-0398/#x-end-of-life).  Support for Python 3.3 was officially dropped in Hypothesis 2, but it still probably mostly worked for a while (with no testing, I'm actually unsure) and until now our `install_requires` setting has allowed it.

With no further security updates, it's appropriate to explicitly block this version - if anyone is still using it they should upgrade as a matter of urgency, or possibly pay for commercial support (for both Python and Hypothesis).

I also removed our tooling for [2.6 and 3.2, both past EOL](https://docs.python.org/devguide/#status-of-python-branches), and the `setup.cfg` file which [has never done anything](https://github.com/HypothesisWorks/hypothesis-python/commits/master/setup.cfg).

*To be merged 2017-09-29*