### PR TITLE
Switch to a more sophisticated calculation for strategy properties

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,16 @@
+RELEASE_TYPE: patch
+
+This release is an internal change that affects how Hypothesis handles
+calculating certain properties of strategies.
+
+The primary effect of this is that it fixes a bug where use of
+:func:`~hypothesis.deferred` could sometimes trigger an internal assertion
+error. However the fix for this bug involved some moderately deep changes to
+how Hypothesis handles certain constructs so you may notice some additional
+knock-on effects.
+
+In particular the way Hypothesis handles drawing data from strategies that
+cannot generate any values has changed to bail out sooner than it previously
+did. This may speed up certain tests, but it is unlikely to make much of a
+difference in practice for tests that were not already failing with
+Unsatisfiable.

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -418,7 +418,7 @@ then use the result and go on to do other things are definitely also possible.
         @given(GoalData)
         def test_create_goal_dry_run(self, data):
             # We want slug to be unique for each run so that multiple test runs
-            # don't interfere with eachother. If for some reason some slugs trigger
+            # don't interfere with each other. If for some reason some slugs trigger
             # an error and others don't we'll get a Flaky error, but that's OK.
             slug = hex(random.getrandbits(32))[2:]
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -15,7 +15,7 @@ set -x
 env | grep UTF
 
 # This is to guard against multiple builds in parallel. The various installers will tend
-# to stomp all over eachother if you do this and they haven't previously successfully
+# to stomp all over each other if you do this and they haven't previously successfully
 # succeeded. We use a lock file to block progress so only one install runs at a time.
 # This script should be pretty fast once files are cached, so the lost of concurrency
 # is not a major problem.

--- a/src/hypothesis/extra/pandas/impl.py
+++ b/src/hypothesis/extra/pandas/impl.py
@@ -526,7 +526,7 @@ def data_frames(
 
             # For columns with no filling the problem is harder, and drawing
             # them like that would result in rows being very far apart from
-            # eachother in the underlying data stream, which gets in the way
+            # each other in the underlying data stream, which gets in the way
             # of shrinking. So what we do is reorder and draw those columns
             # row wise, so that the values of each row are next to each other.
             # This makes life easier for the shrinker when deleting blocks of

--- a/src/hypothesis/internal/conjecture/data.py
+++ b/src/hypothesis/internal/conjecture/data.py
@@ -102,6 +102,8 @@ class ConjectureData(object):
     def draw(self, strategy):
         if self.depth >= MAX_DEPTH:
             self.mark_invalid()
+        if strategy.is_empty:
+            self.mark_invalid()
 
         if self.is_find and not strategy.supports_find:
             raise InvalidArgument((

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -853,7 +853,7 @@ class ConjectureRunner(object):
         """Attempts to zero every block. This is a very coarse pass that we
         only run once to attempt to remove some irrelevant detail. The main
         purpose of it is that if we manage to zero a lot of data then many
-        attempted deletes become duplicates of eachother, so we run fewer
+        attempted deletes become duplicates of each other, so we run fewer
         tests.
 
         If more blocks become possible to zero later that will be

--- a/src/hypothesis/searchstrategy/collections.py
+++ b/src/hypothesis/searchstrategy/collections.py
@@ -94,6 +94,11 @@ class ListStrategy(SearchStrategy):
 
     def do_validate(self):
         self.element_strategy.validate()
+        if self.is_empty:
+            raise InvalidArgument((
+                'Cannot create non-empty lists with elements drawn from '
+                'strategy %r because it has no values.') % (
+                self.element_strategy,))
 
     def calc_is_empty(self, recur):
         if self.min_size == 0:
@@ -102,12 +107,8 @@ class ListStrategy(SearchStrategy):
             return recur(self.element_strategy)
 
     def do_draw(self, data):
-        if self.is_empty:
-            raise InvalidArgument((
-                'Cannot create non-empty lists with elements drawn from '
-                'strategy %r because it has no values.') % (
-                self.element_strategy,))
-        elif self.element_strategy.is_empty:
+        if self.element_strategy.is_empty:
+            assert self.min_size == 0
             return []
 
         elements = cu.many(
@@ -146,6 +147,11 @@ class UniqueListStrategy(SearchStrategy):
 
     def do_validate(self):
         self.element_strategy.validate()
+        if self.is_empty:
+            raise InvalidArgument((
+                'Cannot create non-empty lists with elements drawn from '
+                'strategy %r because it has no values.') % (
+                self.element_strategy,))
 
     def calc_is_empty(self, recur):
         if self.min_size == 0:
@@ -154,12 +160,8 @@ class UniqueListStrategy(SearchStrategy):
             return recur(self.element_strategy)
 
     def do_draw(self, data):
-        if self.is_empty:
-            raise InvalidArgument((
-                'Cannot create non-empty lists with elements drawn from '
-                'strategy %r because it has no values.') % (
-                    self.element_strategy,))
-        elif self.element_strategy.is_empty:
+        if self.element_strategy.is_empty:
+            assert self.min_size == 0
             return []
 
         elements = cu.many(

--- a/src/hypothesis/searchstrategy/deferred.py
+++ b/src/hypothesis/searchstrategy/deferred.py
@@ -65,11 +65,11 @@ class DeferredStrategy(SearchStrategy):
     def supports_find(self):
         return self.wrapped_strategy.supports_find
 
-    def calc_is_empty(self):
-        return self.wrapped_strategy.is_empty
+    def calc_is_empty(self, recur):
+        return recur(self.wrapped_strategy)
 
-    def calc_has_reusable_values(self):
-        return self.wrapped_strategy.has_reusable_values
+    def calc_has_reusable_values(self, recur):
+        return recur(self.wrapped_strategy)
 
     def __repr__(self):
         if self.__wrapped_strategy is not None:

--- a/src/hypothesis/searchstrategy/deferred.py
+++ b/src/hypothesis/searchstrategy/deferred.py
@@ -74,7 +74,7 @@ class DeferredStrategy(SearchStrategy):
     def __repr__(self):
         if self.__wrapped_strategy is not None:
             if self.__in_repr:
-                return '(...)'
+                return '(deferred@%r)' % (id(self),)
             try:
                 self.__in_repr = True
                 return repr(self.__wrapped_strategy)

--- a/src/hypothesis/searchstrategy/flatmapped.py
+++ b/src/hypothesis/searchstrategy/flatmapped.py
@@ -30,8 +30,8 @@ class FlatMapStrategy(SearchStrategy):
         self.flatmapped_strategy = strategy
         self.expand = expand
 
-    def calc_is_empty(self):
-        return self.flatmapped_strategy.is_empty
+    def calc_is_empty(self, recur):
+        return recur(self.flatmapped_strategy)
 
     def __repr__(self):
         if not hasattr(self, u'_cached_repr'):

--- a/src/hypothesis/searchstrategy/lazy.py
+++ b/src/hypothesis/searchstrategy/lazy.py
@@ -51,6 +51,16 @@ def unwrap_strategies(s):
         try:
             result = unwrap_strategies(s.wrapped_strategy)
             unwrap_cache[s] = result
+            try:
+                assert result.force_has_reusable_values == \
+                    s.force_has_reusable_values
+            except AttributeError:
+                pass
+
+            try:
+                result.force_has_reusable_values = s.force_has_reusable_values
+            except AttributeError:
+                pass
             return result
         except AttributeError:
             return s
@@ -84,11 +94,11 @@ class LazyStrategy(SearchStrategy):
     def supports_find(self):
         return self.wrapped_strategy.supports_find
 
-    def calc_is_empty(self):
-        return self.wrapped_strategy.is_empty
+    def calc_is_empty(self, recur):
+        return recur(self.wrapped_strategy)
 
-    def calc_has_reusable_values(self):
-        return self.wrapped_strategy.has_reusable_values
+    def calc_has_reusable_values(self, recur):
+        return recur(self.wrapped_strategy)
 
     @property
     def wrapped_strategy(self):
@@ -112,10 +122,6 @@ class LazyStrategy(SearchStrategy):
                 self.__wrapped_strategy = self.__function(
                     *unwrapped_args,
                     **unwrapped_kwargs)
-                self.__wrapped_strategy.force_has_reusable_values = \
-                    base.has_reusable_values
-                assert self.__wrapped_strategy.has_reusable_values == \
-                    base.has_reusable_values
         return self.__wrapped_strategy
 
     def do_validate(self):

--- a/src/hypothesis/searchstrategy/misc.py
+++ b/src/hypothesis/searchstrategy/misc.py
@@ -31,7 +31,7 @@ class BoolStrategy(SearchStrategy):
     def __repr__(self):
         return u'BoolStrategy()'
 
-    def calc_has_reusable_values(self):
+    def calc_has_reusable_values(self, recur):
         return True
 
     def do_draw(self, data):
@@ -50,7 +50,7 @@ class JustStrategy(SearchStrategy):
     def __repr__(self):
         return 'just(%r)' % (self.value,)
 
-    def calc_has_reusable_values(self):
+    def calc_has_reusable_values(self, recur):
         return True
 
     def do_draw(self, data):
@@ -86,7 +86,7 @@ class SampledFromStrategy(SearchStrategy):
         self.elements = d.check_sample(elements)
         assert self.elements
 
-    def calc_has_reusable_values(self):
+    def calc_has_reusable_values(self, recur):
         return True
 
     def do_draw(self, data):

--- a/src/hypothesis/searchstrategy/strategies.py
+++ b/src/hypothesis/searchstrategy/strategies.py
@@ -63,7 +63,7 @@ class SearchStrategy(object):
         an override: If the property has not been explicitly set, we calculate
         it on first access and memoize the result for later.
 
-        The problem is that for properties that depend on eachother, a naive
+        The problem is that for properties that depend on each other, a naive
         calculation strategy may hit infinite recursion. Consider for example
         the property is_empty. A strategy defined as x = st.deferred(lambda x)
         is certainly empty (in order ot draw a value from x we would have to

--- a/src/hypothesis/searchstrategy/strategies.py
+++ b/src/hypothesis/searchstrategy/strategies.py
@@ -400,9 +400,8 @@ class OneOfStrategy(SearchStrategy):
 
     def do_draw(self, data):
         n = len(self.element_strategies)
-        if n == 0:
-            data.mark_invalid()
-        elif n == 1:
+        assert n > 0
+        if n == 1:
             return data.draw(self.element_strategies[0])
         elif self.sampler is None:
             i = cu.integer_range(data, 0, n - 1)

--- a/src/hypothesis/searchstrategy/strategies.py
+++ b/src/hypothesis/searchstrategy/strategies.py
@@ -148,7 +148,10 @@ class SearchStrategy(object):
                 count += 1
                 # If we seem to be taking a really long time to stabilize we
                 # start tracking seen values to attempt to detect an infinite
-                # loop.
+                # loop. This should be impossible, and most code will never
+                # hit the count, but having an assertion for it means that
+                # testing is easier to debug and we don't just have a hung
+                # test.
                 if count > 50:
                     key = frozenset(mapping.items())
                     assert key not in seen, (key, name)

--- a/src/hypothesis/searchstrategy/strategies.py
+++ b/src/hypothesis/searchstrategy/strategies.py
@@ -142,7 +142,17 @@ class SearchStrategy(object):
             else:
                 needs_update = None
 
+            count = 0
+            seen = set()
             while needs_update:
+                count += 1
+                # If we seem to be taking a really long time to stabilize we
+                # start tracking seen values to attempt to detect an infinite
+                # loop.
+                if count > 50:
+                    key = frozenset(mapping.items())
+                    assert key not in seen, (key, name)
+                    seen.add(key)
                 to_update = needs_update
                 needs_update = set()
                 for strat in to_update:

--- a/src/hypothesis/searchstrategy/strategies.py
+++ b/src/hypothesis/searchstrategy/strategies.py
@@ -152,7 +152,12 @@ class SearchStrategy(object):
                 # hit the count, but having an assertion for it means that
                 # testing is easier to debug and we don't just have a hung
                 # test.
-                if count > 50:
+                # Note: This is actually covered, by test_very_deep_deferral
+                # in tests/cover/test_deferred_strategies.py. Unfortunately it
+                # runs into a coverage bug. See
+                # https://bitbucket.org/ned/coveragepy/issues/605/
+                # for details.
+                if count > 50:  # pragma: no cover
                     key = frozenset(mapping.items())
                     assert key not in seen, (key, name)
                     seen.add(key)

--- a/src/hypothesis/searchstrategy/strategies.py
+++ b/src/hypothesis/searchstrategy/strategies.py
@@ -317,6 +317,8 @@ class SearchStrategy(object):
         try:
             self.validate_called = True
             self.do_validate()
+            self.is_empty
+            self.has_reusable_values
         except:
             self.validate_called = False
             raise

--- a/src/hypothesis/searchstrategy/strategies.py
+++ b/src/hypothesis/searchstrategy/strategies.py
@@ -115,6 +115,8 @@ class SearchStrategy(object):
                     if result is calculating:
                         hit_recursion[0] = True
                         return default
+                    else:
+                        return result
                 except KeyError:
                     mapping[strat] = calculating
                     mapping[strat] = getattr(strat, calculation)(recur)

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -131,12 +131,13 @@ defines_strategy_with_reusable_values = base_defines_strategy(True)
 
 
 class Nothing(SearchStrategy):
-    @property
-    def is_empty(self):
+    def calc_is_empty(self, recur):
         return True
 
     def do_draw(self, data):
-        data.mark_invalid()
+        # This method should never be called because draw() will mark the
+        # data as invalid immediately because is_empty is True.
+        assert False
 
     def calc_has_reusable_values(self, recur):
         return True

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -137,7 +137,7 @@ class Nothing(SearchStrategy):
     def do_draw(self, data):
         # This method should never be called because draw() will mark the
         # data as invalid immediately because is_empty is True.
-        assert False
+        assert False  # pragma: no cover
 
     def calc_has_reusable_values(self, recur):
         return True

--- a/tests/common/setup.py
+++ b/tests/common/setup.py
@@ -34,7 +34,7 @@ def run():
     set_hypothesis_home_dir(mkdtemp())
 
     charmap()
-    assert os.path.exists(charmap_file())
+    assert os.path.exists(charmap_file()), charmap_file()
     assert isinstance(settings, type)
 
     # We do a smoke test here before we mess around with settings.

--- a/tests/cover/test_argument_validation.py
+++ b/tests/cover/test_argument_validation.py
@@ -49,4 +49,8 @@ for ex in [
     adjust(ex, max_size='no')
 
 
+BAD_ARGS.extend([
+    e(st.lists, st.nothing(), unique=True, min_size=1),
+])
+
 test_raise_invalid_argument = argument_validation_test(BAD_ARGS)

--- a/tests/cover/test_deferred_strategies.py
+++ b/tests/cover/test_deferred_strategies.py
@@ -17,8 +17,6 @@
 
 from __future__ import division, print_function, absolute_import
 
-import operator
-
 import pytest
 
 from hypothesis import strategies as st

--- a/tests/cover/test_deferred_strategies.py
+++ b/tests/cover/test_deferred_strategies.py
@@ -17,9 +17,12 @@
 
 from __future__ import division, print_function, absolute_import
 
+import operator
+
 import pytest
 
 from hypothesis import strategies as st
+from hypothesis import given
 from hypothesis.errors import InvalidArgument
 from tests.common.debug import minimal, assert_no_examples
 
@@ -144,3 +147,18 @@ def test_self_recursive_lists():
     assert minimal(x) == []
     assert minimal(x, bool) == [[]]
     assert minimal(x, lambda x: len(x) > 1) == [[], []]
+
+
+def test_literals_strategy_is_valid():
+    literals = st.deferred(lambda: st.one_of(
+        st.booleans(),
+        st.tuples(literals, literals),
+        literals.map(lambda x: [x]),
+    ))
+
+    @given(literals)
+    def test(e):
+        pass
+    test()
+
+    assert not literals.has_reusable_values

--- a/tests/cover/test_deferred_strategies.py
+++ b/tests/cover/test_deferred_strategies.py
@@ -188,3 +188,15 @@ def test_very_deep_deferral():
 
     assert strategies[0].has_reusable_values
     assert not strategies[0].is_empty
+
+
+def test_recursion_in_middle():
+    # This test is significant because the integers().map(abs) is not checked
+    # in the initial pass - when we recurse into x initially we decide that
+    # x is empty, so the tuple is empty, and don't need to check the third
+    # argument. Then when we do the more refined test we've discovered that x
+    # is non-empty, so we need to check the non-emptiness of the last component
+    # to determine the non-emptiness of the tuples.
+    x = st.deferred(
+        lambda: st.tuples(st.none(), x, st.integers().map(abs)) | st.none())
+    assert not x.is_empty

--- a/tests/cover/test_deferred_strategies.py
+++ b/tests/cover/test_deferred_strategies.py
@@ -160,3 +160,9 @@ def test_literals_strategy_is_valid():
     test()
 
     assert not literals.has_reusable_values
+
+
+def test_impossible_self_recursion():
+    x = st.deferred(lambda: st.tuples(st.none(), x))
+    assert x.is_empty
+    assert x.has_reusable_values

--- a/tests/cover/test_nothing.py
+++ b/tests/cover/test_nothing.py
@@ -45,7 +45,7 @@ def test_set_of_nothing(xs):
 
 def test_validates_min_size():
     with pytest.raises(InvalidArgument):
-        st.lists(st.nothing(), min_size=1).validate()
+        st.lists(st.nothing(), min_size=1).example()
 
 
 def test_function_composition():

--- a/tests/cover/test_nothing.py
+++ b/tests/cover/test_nothing.py
@@ -45,7 +45,7 @@ def test_set_of_nothing(xs):
 
 def test_validates_min_size():
     with pytest.raises(InvalidArgument):
-        st.lists(st.nothing(), min_size=1).example()
+        st.lists(st.nothing(), min_size=1).validate()
 
 
 def test_function_composition():

--- a/tests/cover/test_nothing.py
+++ b/tests/cover/test_nothing.py
@@ -64,3 +64,12 @@ def test_fixed_dictionaries_detect_empty_values():
 
 def test_no_examples():
     assert_no_examples(st.nothing())
+
+
+@pytest.mark.parametrize('s', [
+    st.nothing(), st.nothing().map(lambda x: x),
+    st.nothing().filter(lambda x: True),
+    st.nothing().flatmap(lambda x: st.integers())
+])
+def test_empty(s):
+    assert s.is_empty

--- a/tests/cover/test_reusable_values.py
+++ b/tests/cover/test_reusable_values.py
@@ -50,6 +50,10 @@ def reusable():
     )
 
 
+assert not reusable.is_empty
+
+
+@example(st.integers(min_value=1))
 @given(reusable)
 def test_reusable_strategies_are_all_reusable(s):
     try:


### PR DESCRIPTION
I managed to trigger an `AssertionError` when writing a deferred strategy for something due to an unfortunate interaction. The problem example was the following strategy:

```python
literals = st.deferred(lambda: st.one_of(
    st.booleans(),
    st.tuples(literals, literals),
    literals.map(lambda x: [x]),
))
```

The issue with this is that we change our minds midway through the calculation here as to whether literals can have reusable values, so we end up deciding that `tuples(literals, literals)` are reusable values but `literals` aren't.

The root cause here is primarily that the way we were handling recursive calculations of fixed points was, to be honest, super dodgy. This pull request fixes that, replacing it with a more sophisticated and fully accurate approach based on value propagation - when calculating a property for a strategy, we calculate the property simultaneously for all related strategies by iterating to a fixed point.

This has a number of knock-on effects. They mostly boil down to the fact that the old wrong method was robust against certain things that the new one is not. Primarily, it handled mutual recursion better - you could have is_empty depending on element_strategies depending on is_empty and nothing would go wrong. That is no longer the case.

The solution is don't do that then. The strategies module had a lot of special casing for `is_empty`. That special casing is now handled inside `draw` and `do_draw` -~~ these have the advantage that `is_empty` *can't* recurse into them because it doesn't have access to the data object, so mutual recursion is impossible~~ (that was true, but I've now moved it so that `validate()` explicitly resolves these properties as a bunch of our tests had assumptions that we could detect invalid arguments in validate. There's still no mutual recursion because they don't call validate, but it's in principle possible).

This also includes the sensible related optimisation that when `draw()` is called with an empty strategy we invalidate immediately. The primary motivation for this is that it removes the need for a lot of special cases of the form "in this case return `nothing()`" that we had in the strategies module.