### PR TITLE
Migrate usage of nametuple to attrs

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -4,5 +4,4 @@ This is a refactoring release. It moves a number of internal uses
 of nametuple over to using attrs based classes, and removes a couple
 of internal namedtuple classes that were no longer in use.
 
-
 It should have no user visible impact.

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,8 @@
+RELEASE_TYPE: patch
+
+This is a refactoring release. It moves a number of internal uses
+of nametuple over to using attrs based classes, and removes a couple
+of internal namedtuple classes that were no longer in use.
+
+
+It should have no user visible impact.

--- a/src/hypothesis/_settings.py
+++ b/src/hypothesis/_settings.py
@@ -29,7 +29,8 @@ import inspect
 import warnings
 import threading
 from enum import Enum, IntEnum, unique
-from collections import namedtuple
+
+import attr
 
 from hypothesis.errors import InvalidArgument, HypothesisDeprecationWarning
 from hypothesis.configuration import hypothesis_home_dir
@@ -331,11 +332,15 @@ class settings(settingsMeta('settings', (object,), {})):
         settings._assign_default_internal(settings.get_profile(name))
 
 
-Setting = namedtuple(
-    'Setting', (
-        'name', 'description', 'default', 'options', 'validator',
-        'future_default', 'deprecation_message',
-    ))
+@attr.s()
+class Setting(object):
+    name = attr.ib()
+    description = attr.ib()
+    default = attr.ib()
+    options = attr.ib()
+    validator = attr.ib()
+    future_default = attr.ib()
+    deprecation_message = attr.ib()
 
 
 settings.define_setting(

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -808,9 +808,9 @@ def given(*given_arguments, **given_kwargs):
                 test_runner, search_strategy, test, settings, random)
             state.run()
 
-        for attr in dir(test):
-            if attr[0] != '_' and not hasattr(wrapped_test, attr):
-                setattr(wrapped_test, attr, getattr(test, attr))
+        for test_attr in dir(test):
+            if test_attr[0] != '_' and not hasattr(wrapped_test, test_attr):
+                setattr(wrapped_test, test_attr, getattr(test, test_attr))
         wrapped_test.is_hypothesis_test = True
         wrapped_test._hypothesis_internal_use_seed = getattr(
             test, '_hypothesis_internal_use_seed', None

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -25,7 +25,8 @@ import time
 import functools
 import traceback
 from random import Random
-from collections import namedtuple
+
+import attr
 
 import hypothesis.strategies as st
 from hypothesis.errors import Flaky, Timeout, NoSuchExample, \
@@ -73,7 +74,10 @@ def test_is_flaky(test, expected_repr):
     return test_or_flaky
 
 
-Example = namedtuple('Example', ('args', 'kwargs'))
+@attr.s()
+class Example(object):
+    args = attr.ib()
+    kwargs = attr.ib()
 
 
 def example(*args, **kwargs):

--- a/src/hypothesis/searchstrategy/collections.py
+++ b/src/hypothesis/searchstrategy/collections.py
@@ -17,8 +17,6 @@
 
 from __future__ import division, print_function, absolute_import
 
-from collections import namedtuple
-
 import hypothesis.internal.conjecture.utils as cu
 from hypothesis.internal.compat import OrderedDict, hbytes
 from hypothesis.searchstrategy.strategies import SearchStrategy, \
@@ -28,11 +26,7 @@ from hypothesis.searchstrategy.strategies import SearchStrategy, \
 class TupleStrategy(SearchStrategy):
 
     """A strategy responsible for fixed length tuples based on heterogenous
-    strategies for each of their elements.
-
-    This also handles namedtuples
-
-    """
+    strategies for each of their elements."""
 
     def __init__(self,
                  strategies, tuple_type):
@@ -137,10 +131,6 @@ class UniqueListStrategy(SearchStrategy):
 
     def do_validate(self):
         self.element_strategy.validate()
-
-    Parameter = namedtuple(
-        'Parameter', ('parameter_seed', 'parameter')
-    )
 
     def do_draw(self, data):
         elements = cu.many(

--- a/src/hypothesis/searchstrategy/numbers.py
+++ b/src/hypothesis/searchstrategy/numbers.py
@@ -18,7 +18,6 @@
 from __future__ import division, print_function, absolute_import
 
 import math
-from collections import namedtuple
 
 import hypothesis.internal.conjecture.utils as d
 import hypothesis.internal.conjecture.floats as flt
@@ -154,10 +153,6 @@ class FixedBoundedFloatStrategy(SearchStrategy):
     closer to one of the ends.
 
     """
-    Parameter = namedtuple(
-        'Parameter',
-        ('cut', 'leftwards')
-    )
 
     def __init__(self, lower_bound, upper_bound):
         SearchStrategy.__init__(self)

--- a/src/hypothesis/searchstrategy/strategies.py
+++ b/src/hypothesis/searchstrategy/strategies.py
@@ -40,51 +40,10 @@ class SearchStrategy(object):
     """A SearchStrategy is an object that knows how to explore data of a given
     type.
 
-    Except where noted otherwise, methods on this class are not part of the
-    public API and their behaviour may change significantly between minor
-    version releases. They will generally be stable between patch releases.
-
-    With that in mind, here is how SearchStrategy works.
-
-    A search strategy is responsible for generating, simplifying and
-    serializing examples for saving.
-
-    In order to do this a strategy has three types (where type here is more
-    precise than just the class of the value. For example a tuple of ints
-    should be considered different from a tuple of strings):
-
-    1. The strategy parameter type
-    2. The strategy template type
-    3. The generated type
-
-    Of these, the first two should be considered to be private implementation
-    details of a strategy and the only valid thing to do them is to pass them
-    back to the search strategy. Additionally, templates may be compared for
-    equality and hashed.
-
-    Templates must be of quite a restricted type. A template may be any of the
-    following:
-
-    1. Any instance of the types bool, float, int, str (unicode on 2.7)
-    2. None
-    3. Any tuple or namedtuple of valid template types
-    4. Any frozenset of valid template types
-
-    This may be relaxed a bit in future, but the requirement that templates are
-    hashable probably won't be.
-
-    This may all seem overly complicated but it's for a fairly good reason.
-
-    Given these, data generation happens in three phases:
-
-    1. Draw a parameter value from a random number (defined by
-       draw_parameter)
-    2. Given a parameter value and a Random, draw a random template
-    3. Reify a template value, deterministically turning it into a value of
-       the desired type.
-
-    Data simplification proceeds on template values, taking a template and
-    providing a generator over some examples of similar but simpler templates.
+    Except where noted otherwise, methods on this class are not part of
+    the public API and their behaviour may change significantly between
+    minor version releases. They will generally be stable between patch
+    releases.
 
     """
 

--- a/src/hypothesis/stateful.py
+++ b/src/hypothesis/stateful.py
@@ -30,7 +30,8 @@ from __future__ import division, print_function, absolute_import
 import inspect
 import traceback
 from unittest import TestCase
-from collections import namedtuple
+
+import attr
 
 import hypothesis.internal.conjecture.utils as cu
 from hypothesis.core import find
@@ -260,10 +261,13 @@ class StateMachineSearchStrategy(SearchStrategy):
         return StateMachineRunner(data, self.program_size)
 
 
-Rule = namedtuple(
-    u'Rule',
-    (u'targets', u'function', u'arguments', u'precondition')
-)
+@attr.s()
+class Rule(object):
+    targets = attr.ib()
+    function = attr.ib()
+    arguments = attr.ib()
+    precondition = attr.ib()
+
 
 self_strategy = runner()
 
@@ -330,7 +334,9 @@ def rule(targets=(), target=None, **kwargs):
     return accept
 
 
-VarReference = namedtuple(u'VarReference', (u'name',))
+@attr.s()
+class VarReference(object):
+    name = attr.ib()
 
 
 def precondition(precond):
@@ -377,10 +383,10 @@ def precondition(precond):
     return decorator
 
 
-Invariant = namedtuple(
-    'Invariant',
-    ('function', 'precondition')
-)
+@attr.s()
+class Invariant(object):
+    function = attr.ib()
+    precondition = attr.ib()
 
 
 def invariant():
@@ -417,7 +423,10 @@ def invariant():
     return accept
 
 
-ShuffleBundle = namedtuple('ShuffleBundle', ('bundle', 'swaps'))
+@attr.s()
+class ShuffleBundle(object):
+    bundle = attr.ib()
+    swaps = attr.ib()
 
 
 class RuleBasedStateMachine(GenericStateMachine):

--- a/src/hypothesis/tools/mergedbs.py
+++ b/src/hypothesis/tools/mergedbs.py
@@ -61,6 +61,7 @@ def get_rows(cursor):
         yield tuple(r)
 
 
+@attr.s()
 class Report(object):
     inserts = attr.ib()
     deletes = attr.ib()

--- a/src/hypothesis/tools/mergedbs.py
+++ b/src/hypothesis/tools/mergedbs.py
@@ -48,7 +48,8 @@ from __future__ import division, print_function, absolute_import
 
 import sys
 import sqlite3
-from collections import namedtuple
+
+import attr
 
 
 def get_rows(cursor):
@@ -60,7 +61,9 @@ def get_rows(cursor):
         yield tuple(r)
 
 
-Report = namedtuple(u'Report', (u'inserts', u'deletes'))
+class Report(object):
+    inserts = attr.ib()
+    deletes = attr.ib()
 
 
 def merge_paths(ancestor, current, other):


### PR DESCRIPTION
This started out as a pull request to remove the various Parameter classes that haven't been used in more than a year, but I figured that while I was in the area I might as well get rid of the rest of our uses of namedtuple too! Now that we depend on attrs we might as well use it.

This also rips out some very out of date docstring contents from SearchStrategy.