### PR TITLE
Note pytest stdout capturing in verbosity docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,7 +69,8 @@ todo_include_todos = False
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
     'numpy': ('https://docs.scipy.org/doc/numpy/', None),
-    'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None)
+    'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
+    'pytest': ('https://docs.pytest.org/en/stable/', None),
 }
 
 autodoc_mock_imports = ['numpy', 'pandas']
@@ -127,6 +128,6 @@ man_pages = [
 
 texinfo_documents = [
     (master_doc, 'Hypothesis', u'Hypothesis Documentation',
-     author, 'Hypothesis', 'One line description of project.',
+     author, 'Hypothesis', 'Advanced property-based testing for Python.',
      'Miscellaneous'),
 ]

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -105,6 +105,9 @@ You can also override the default by setting the environment variable
 setting ``HYPOTHESIS_VERBOSITY_LEVEL=verbose`` will run all your tests printing
 intermediate results and errors.
 
+If you are using ``pytest``, you may also need to
+:doc:`disable output capturing for passing tests <pytest:capture>`.
+
 -------------------------
 Building settings objects
 -------------------------


### PR DESCRIPTION
Closes #349 - output capture is properly a concern for the Pytest project, but we should document this as a common source of confusion.