### PR TITLE
Add a sensible eviction policy for Hypothesis's strategy caching

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,11 @@
+RELEASE_TYPE: patch
+
+This release changes Hypothesis's caching approach for functions in
+:module:`hypothesis.strategies`. Previously it would have cached extremely
+aggressively and cache entries would never be evicted. Now it adopts a
+least-frequently used, least recently used key invalidation policy, and is
+somewhat more conservative about which strategies it caches.
+
+This should cause some workloads (anything that creates strategies based on
+dynamic values, e.g. using flatmap or composite) to see a significantly lower
+memory usage.

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,7 +1,7 @@
 RELEASE_TYPE: patch
 
 This release changes Hypothesis's caching approach for functions in
-:module:`hypothesis.strategies`. Previously it would have cached extremely
+``hypothesis.strategies``. Previously it would have cached extremely
 aggressively and cache entries would never be evicted. Now it adopts a
 least-frequently used, least recently used key invalidation policy, and is
 somewhat more conservative about which strategies it caches.

--- a/src/hypothesis/internal/cache.py
+++ b/src/hypothesis/internal/cache.py
@@ -77,7 +77,7 @@ class GenericCache(object):
             self.on_evict(evicted.key, evicted.value, evicted.score)
 
     def clear(self):
-        self.data.clear()
+        del self.data[:]
         self.keys_to_indices.clear()
 
     def __repr__(self):

--- a/src/hypothesis/internal/cache.py
+++ b/src/hypothesis/internal/cache.py
@@ -46,17 +46,6 @@ class GenericCache(object):
         self.__balance(i)
         return result.value
 
-    def __contains__(self, key):
-        return key in self.keys_to_indices
-
-    def clear(self):
-        self.data.clear()
-        self.keys_to_indices.clear()
-
-    def __repr__(self):
-        return "{%s}" % (', '.join(
-            "%r: %r" % (e.key, e.value) for e in self.data),)
-
     def __setitem__(self, key, value):
         if self.max_size == 0:
             return
@@ -87,20 +76,29 @@ class GenericCache(object):
                 assert evicted.score <= self.data[0].score
             self.on_evict(evicted.key, evicted.value, evicted.score)
 
-    def check_rep(self):
-        for i, e in enumerate(self.data):
-            for j in [i * 2 + 1, i * 2 + 2]:
-                if j < len(self.data):
-                    assert e.score <= self.data[j].score, self.data
+    def clear(self):
+        self.data.clear()
+        self.keys_to_indices.clear()
+
+    def __repr__(self):
+        return '{%s}' % (', '.join(
+            '%r: %r' % (e.key, e.value) for e in self.data),)
 
     def new_entry(self, key, value):
-        return 0
+        raise NotImplementedError()
 
     def on_access(self, key, value, score):
         return score
 
     def on_evict(self, key, value, score):
         pass
+
+    def check_valid(self):
+        for i, e in enumerate(self.data):
+            assert self.keys_to_indices[e.key] == i
+            for j in [i * 2 + 1, i * 2 + 2]:
+                if j < len(self.data):
+                    assert e.score <= self.data[j].score, self.data
 
     def __swap(self, i, j):
         assert i < j

--- a/src/hypothesis/internal/cache.py
+++ b/src/hypothesis/internal/cache.py
@@ -1,0 +1,183 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2017 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import attr
+
+
+@attr.s(slots=True)
+class Entry(object):
+    key = attr.ib()
+    value = attr.ib()
+    score = attr.ib()
+
+
+class GenericCache(object):
+    __slots__ = ('keys_to_indices', 'data', 'max_size')
+
+    def __init__(self, max_size):
+        self.keys_to_indices = {}
+        self.data = []
+        self.max_size = max_size
+
+    def __len__(self):
+        assert len(self.keys_to_indices) == len(self.data)
+        return len(self.data)
+
+    def __getitem__(self, key):
+        i = self.keys_to_indices[key]
+        result = self.data[i]
+        self.on_access(result.key, result.value, result.score)
+        self.__balance(i)
+        return result.value
+
+    def __contains__(self, key):
+        return key in self.keys_to_indices
+
+    def clear(self):
+        self.data.clear()
+        self.keys_to_indices.clear()
+
+    def __repr__(self):
+        return "{%s}" % (', '.join(
+            "%r: %r" % (e.key, e.value) for e in self.data),)
+
+    def __setitem__(self, key, value):
+        if self.max_size == 0:
+            return
+        evicted = None
+        try:
+            i = self.keys_to_indices[key]
+        except KeyError:
+            entry = Entry(key, value, self.new_entry(key, value))
+            if len(self.data) >= self.max_size:
+                evicted = self.data[0]
+                del self.keys_to_indices[evicted.key]
+                i = 0
+                self.data[0] = entry
+            else:
+                i = len(self.data)
+                self.data.append(entry)
+            self.keys_to_indices[key] = i
+        else:
+            entry = self.data[i]
+            assert entry.key == key
+            entry.value = value
+            entry.score = self.on_access(entry.key, entry.value, entry.score)
+
+        self.__balance(i)
+
+        if evicted is not None:
+            if self.data[0] is not entry:
+                assert evicted.score <= self.data[0].score
+            self.on_evict(evicted.key, evicted.value, evicted.score)
+
+    def check_rep(self):
+        for i, e in enumerate(self.data):
+            for j in [i * 2 + 1, i * 2 + 2]:
+                if j < len(self.data):
+                    assert e.score <= self.data[j].score, self.data
+
+    def new_entry(self, key, value):
+        return 0
+
+    def on_access(self, key, value, score):
+        return score
+
+    def on_evict(self, key, value, score):
+        pass
+
+    def __swap(self, i, j):
+        assert i < j
+        assert self.data[j].score < self.data[i].score
+        self.data[i], self.data[j] = self.data[j], self.data[i]
+        self.keys_to_indices[self.data[i].key] = i
+        self.keys_to_indices[self.data[j].key] = j
+
+    def __balance(self, i):
+        while i > 0:
+            parent = (i - 1) // 2
+            if self.__out_of_order(parent, i):
+                self.__swap(parent, i)
+                i = parent
+            else:
+                break
+        while True:
+            children = [
+                j for j in (2 * i + 1, 2 * i + 2)
+                if j < len(self.data)
+            ]
+            if len(children) == 2:
+                children.sort(key=lambda j: self.data[j].score)
+            for j in children:
+                if self.__out_of_order(i, j):
+                    self.__swap(i, j)
+                    i = j
+                    break
+            else:
+                break
+
+    def __out_of_order(self, i, j):
+        assert i == (j - 1) // 2
+        return self.data[j].score < self.data[i].score
+
+
+class LRUCache(GenericCache):
+    __slots__ = ('__tick',)
+
+    def __init__(self, max_size):
+        super(LRUCache, self).__init__(max_size)
+        self.__tick = 0
+
+    def new_entry(self, key, value):
+        return self.tick()
+
+    def on_access(self, key, value, score):
+        return self.tick()
+
+    def tick(self):
+        self.__tick += 1
+        return self.__tick
+
+
+class LFUCache(GenericCache):
+    def new_entry(self, key, value):
+        return 1
+
+    def on_access(self, key, value, score):
+        return score + 1
+
+
+class LFLRUCache(GenericCache):
+    __slots__ = ('__tick',)
+
+    def __init__(self, max_size, ):
+        super(LFLRUCache, self).__init__(max_size)
+        self.__tick = 0
+
+    def tick(self):
+        self.__tick += 1
+        return self.__tick
+
+    def new_entry(self, key, value):
+        return [1, self.tick()]
+
+    def on_access(self, key, value, score):
+        score[0] += 1
+        score[1] = self.tick()
+        return score

--- a/src/hypothesis/internal/cache.py
+++ b/src/hypothesis/internal/cache.py
@@ -46,7 +46,9 @@ class GenericCache(object):
     The cache will be in a valid state in all of these cases.
 
     Implementations are expected to implement new_entry and optionally
-    on_access and on_evict to implement a specific scoring strategy."""
+    on_access and on_evict to implement a specific scoring strategy.
+
+    """
     __slots__ = ('keys_to_indices', 'data', 'max_size')
 
     def __init__(self, max_size):
@@ -111,12 +113,20 @@ class GenericCache(object):
 
     def new_entry(self, key, value):
         """Called when a key is written that does not currently appear in the
-        map. Returns the score to associate with the key."""
+        map.
+
+        Returns the score to associate with the key.
+
+        """
         raise NotImplementedError()
 
     def on_access(self, key, value, score):
         """Called every time a key that is already in the map is read or
-        written. Returns the new score for the key."""
+        written.
+
+        Returns the new score for the key.
+
+        """
         return score
 
     def on_evict(self, key, value, score):
@@ -125,9 +135,12 @@ class GenericCache(object):
         pass
 
     def check_valid(self):
-        """Debugging method for use in tests. Asserts that all of the cache's
-        invariants hold. When everything is working correctly this should be
-        an expensive no-op."""
+        """Debugging method for use in tests.
+
+        Asserts that all of the cache's invariants hold. When everything
+        is working correctly this should be an expensive no-op.
+
+        """
 
         for i, e in enumerate(self.data):
             assert self.keys_to_indices[e.key] == i
@@ -171,8 +184,11 @@ class GenericCache(object):
                 break
 
     def __out_of_order(self, i, j):
-        """Returns True if the indices i, j are in the wrong order. i must be
-        the parent of j."""
+        """Returns True if the indices i, j are in the wrong order.
+
+        i must be the parent of j.
+
+        """
 
         assert i == (j - 1) // 2
         return self.data[j].score < self.data[i].score
@@ -190,7 +206,9 @@ class LRUReusedCache(GenericCache):
     This retains most of the benefits of an LRU cache, but adds an element of
     scan-resistance to the process: If we end up scanning through a large
     number of keys without reusing them, this does not evict the existing
-    entries in preference for the new ones."""
+    entries in preference for the new ones.
+
+    """
     __slots__ = ('__tick',)
 
     def __init__(self, max_size, ):

--- a/src/hypothesis/internal/escalation.py
+++ b/src/hypothesis/internal/escalation.py
@@ -45,11 +45,18 @@ def belongs_to(package):
     return accept
 
 
+PREVENT_ESCALATION = os.getenv('HYPOTHESIS_DO_NOT_ESCALATE') == 'true'
+
+FILE_CACHE = {}
+
+
 is_hypothesis_file = belongs_to(hypothesis)
 is_coverage_file = belongs_to(coverage)
 
 
 def escalate_hypothesis_internal_error():
+    if PREVENT_ESCALATION:
+        return
     error_type, _, tb = sys.exc_info()
     import traceback
     filepath = traceback.extract_tb(tb)[-1][0]

--- a/src/hypothesis/searchstrategy/lazy.py
+++ b/src/hypothesis/searchstrategy/lazy.py
@@ -100,6 +100,13 @@ class LazyStrategy(SearchStrategy):
     def calc_has_reusable_values(self, recur):
         return recur(self.wrapped_strategy)
 
+    def calc_is_cacheable(self, recur):
+        for source in (self.__args, self.__kwargs.values()):
+            for v in source:
+                if isinstance(v, SearchStrategy) and not v.is_cacheable:
+                    return False
+        return True
+
     @property
     def wrapped_strategy(self):
         if self.__wrapped_strategy is None:

--- a/src/hypothesis/searchstrategy/misc.py
+++ b/src/hypothesis/searchstrategy/misc.py
@@ -38,6 +38,14 @@ class BoolStrategy(SearchStrategy):
         return d.boolean(data)
 
 
+def is_simple_data(value):
+    try:
+        hash(value)
+        return True
+    except TypeError:
+        return False
+
+
 class JustStrategy(SearchStrategy):
 
     """A strategy which simply returns a single fixed value with probability
@@ -52,6 +60,9 @@ class JustStrategy(SearchStrategy):
 
     def calc_has_reusable_values(self, recur):
         return True
+
+    def calc_is_cacheable(self, recur):
+        return is_simple_data(self.value)
 
     def do_draw(self, data):
         return self.value
@@ -88,6 +99,9 @@ class SampledFromStrategy(SearchStrategy):
 
     def calc_has_reusable_values(self, recur):
         return True
+
+    def calc_is_cacheable(self, recur):
+        return is_simple_data(self.elements)
 
     def do_draw(self, data):
         return d.choice(data, self.elements)

--- a/src/hypothesis/searchstrategy/strategies.py
+++ b/src/hypothesis/searchstrategy/strategies.py
@@ -204,6 +204,12 @@ class SearchStrategy(object):
     # this causing unexpected behaviour.
     has_reusable_values = recursive_property('has_reusable_values', True)
 
+    # Whether this strategy is suitable for holding onto in a cache.
+    is_cacheable = recursive_property('is_cacheable', True)
+
+    def calc_is_cacheable(self, recur):
+        return True
+
     def calc_is_empty(self, recur):
         # Note: It is correct and significant that the default return value
         # from calc_is_empty is False despite the default value for is_empty
@@ -384,6 +390,9 @@ class OneOfStrategy(SearchStrategy):
     def calc_has_reusable_values(self, recur):
         return all(recur(e) for e in self.original_strategies)
 
+    def calc_is_cacheable(self, recur):
+        return all(recur(e) for e in self.original_strategies)
+
     @property
     def element_strategies(self):
         from hypothesis.strategies import check_strategy
@@ -455,6 +464,9 @@ class MappedSearchStrategy(SearchStrategy):
     def calc_is_empty(self, recur):
         return recur(self.mapped_strategy)
 
+    def calc_is_cacheable(self, recur):
+        return recur(self.mapped_strategy)
+
     def __repr__(self):
         if not hasattr(self, '_cached_repr'):
             self._cached_repr = '%r.map(%s)' % (
@@ -498,6 +510,9 @@ class FilteredStrategy(SearchStrategy):
         self.filtered_strategy = strategy
 
     def calc_is_empty(self, recur):
+        return recur(self.filtered_strategy)
+
+    def calc_is_cacheable(self, recur):
         return recur(self.filtered_strategy)
 
     def __repr__(self):

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -104,7 +104,8 @@ def cacheable(fn):
             return fn(*args, **kwargs)
         except KeyError:
             result = fn(*args, **kwargs)
-            cache[cache_key] = result
+            if result.is_cacheable:
+                cache[cache_key] = result
             return result
     cached_strategy.__clear_cache = cache.clear
     return cached_strategy

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -28,6 +28,7 @@ from fractions import Fraction
 from hypothesis.errors import InvalidArgument, ResolutionFailed
 from hypothesis.control import assume
 from hypothesis._settings import note_deprecation
+from hypothesis.internal.cache import LFLRUCache
 from hypothesis.searchstrategy import SearchStrategy
 from hypothesis.internal.compat import gcd, ceil, floor, hrange, \
     text_type, integer_types, get_type_hints, getfullargspec, \
@@ -85,9 +86,10 @@ def convert_value(v):
     return (type(v), v)
 
 
-def cacheable(fn):
-    cache = {}
+STRATEGY_CACHE = LFLRUCache(1024)
 
+
+def cacheable(fn):
     @proxies(fn)
     def cached_strategy(*args, **kwargs):
         kwargs_cache_key = set()
@@ -97,17 +99,18 @@ def cacheable(fn):
         except TypeError:
             return fn(*args, **kwargs)
         cache_key = (
+            fn,
             tuple(map(convert_value, args)), frozenset(kwargs_cache_key))
         try:
-            return cache[cache_key]
+            return STRATEGY_CACHE[cache_key]
         except TypeError:
             return fn(*args, **kwargs)
         except KeyError:
             result = fn(*args, **kwargs)
             if not isinstance(result, SearchStrategy) or result.is_cacheable:
-                cache[cache_key] = result
+                STRATEGY_CACHE[cache_key] = result
             return result
-    cached_strategy.__clear_cache = cache.clear
+    cached_strategy.__clear_cache = STRATEGY_CACHE.clear
     return cached_strategy
 
 
@@ -1743,6 +1746,7 @@ def check_valid_sizes(min_size, average_size, max_size):
 _AVERAGE_LIST_LENGTH = 5.0
 
 
+@cacheable
 def deferred(definition):
     """A deferred strategy allows you to write a strategy that references other
     strategies that have not yet been defined. This allows for the easy

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -104,7 +104,7 @@ def cacheable(fn):
             return fn(*args, **kwargs)
         except KeyError:
             result = fn(*args, **kwargs)
-            if result.is_cacheable:
+            if not isinstance(result, SearchStrategy) or result.is_cacheable:
                 cache[cache_key] = result
             return result
     cached_strategy.__clear_cache = cache.clear

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -28,7 +28,7 @@ from fractions import Fraction
 from hypothesis.errors import InvalidArgument, ResolutionFailed
 from hypothesis.control import assume
 from hypothesis._settings import note_deprecation
-from hypothesis.internal.cache import LFLRUCache
+from hypothesis.internal.cache import LRUReusedCache
 from hypothesis.searchstrategy import SearchStrategy
 from hypothesis.internal.compat import gcd, ceil, floor, hrange, \
     text_type, integer_types, get_type_hints, getfullargspec, \
@@ -86,7 +86,7 @@ def convert_value(v):
     return (type(v), v)
 
 
-STRATEGY_CACHE = LFLRUCache(1024)
+STRATEGY_CACHE = LRUReusedCache(1024)
 
 
 def cacheable(fn):

--- a/tests/cover/test_cache_implementation.py
+++ b/tests/cover/test_cache_implementation.py
@@ -22,9 +22,9 @@ from random import Random
 import pytest
 
 import hypothesis.strategies as st
-from hypothesis import note, given, assume, example
-from hypothesis.internal.cache import LFUCache, LRUCache, GenericCache, \
-    TwoLevelCache
+from hypothesis import note, given, assume, example, settings
+from hypothesis.internal.cache import LFUCache, LRUCache, LFLRUCache, \
+    GenericCache
 
 
 @st.composite
@@ -54,9 +54,10 @@ class RandomCache(GenericCache):
 
 @pytest.mark.parametrize(
     'implementation', [
-        LRUCache, LFUCache, TwoLevelCache, ValueScored, RandomCache
+        LRUCache, LFUCache, LFLRUCache, ValueScored, RandomCache
     ]
 )
+@example(writes=[(0, 0), (3, 0), (1, 0), (2, 0), (2, 0), (1, 0)], size=4)
 @example(writes=[(0, 0)], size=1)
 @example(writes=[(1, 0), (2, 0), (0, -1), (1, 0)], size=3)
 @given(write_pattern(), st.integers(1, 10))

--- a/tests/cover/test_cache_implementation.py
+++ b/tests/cover/test_cache_implementation.py
@@ -1,0 +1,147 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2017 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+from random import Random
+
+import pytest
+
+import hypothesis.strategies as st
+from hypothesis import note, given, assume, example
+from hypothesis.internal.cache import LFUCache, LRUCache, GenericCache, \
+    TwoLevelCache
+
+
+@st.composite
+def write_pattern(draw):
+    keys = draw(st.lists(st.integers(0, 1000), unique=True, min_size=1))
+    values = draw(st.lists(st.integers(), unique=True, min_size=1))
+    return draw(
+        st.lists(st.tuples(st.sampled_from(keys), st.sampled_from(values))))
+
+
+class ValueScored(GenericCache):
+    def new_entry(self, key, value):
+        return value
+
+
+class RandomCache(GenericCache):
+    def __init__(self, max_size):
+        super(RandomCache, self).__init__(max_size)
+        self.random = Random(0)
+
+    def new_entry(self, key, value):
+        return self.random.random()
+
+    def on_access(self, key, value, score):
+        return self.random.random()
+
+
+@pytest.mark.parametrize(
+    'implementation', [
+        LRUCache, LFUCache, TwoLevelCache, ValueScored, RandomCache
+    ]
+)
+@example(writes=[(0, 0)], size=1)
+@example(writes=[(1, 0), (2, 0), (0, -1), (1, 0)], size=3)
+@given(write_pattern(), st.integers(1, 10))
+def test_behaves_like_a_dict_with_losses(implementation, writes, size):
+    model = {}
+    target = implementation(max_size=size)
+
+    for k, v in writes:
+        try:
+            assert model[k] == target[k]
+        except KeyError:
+            pass
+        model[k] = v
+        target[k] = v
+        target.check_rep()
+        assert target[k] == v
+        for r, s in model.items():
+            try:
+                assert s == target[r]
+            except KeyError:
+                pass
+        assert len(target) <= min(len(model), size)
+
+
+@given(write_pattern(), st.integers(1, 10), st.data())
+def test_always_evicts_the_lowest_scoring_value(writes, size, data):
+    scores = {}
+
+    assume(size < len({k for k, _ in writes}))
+    evicted = set()
+
+    def new_score(key):
+        scores[key] = data.draw(
+            st.integers(0, 1000), label='scores[%r]' % (key,))
+        return scores[key]
+
+    last_entry = [None]
+
+    class Cache(GenericCache):
+        def new_entry(self, key, value):
+            last_entry[0] = key
+            evicted.discard(key)
+            assert key not in scores
+            return new_score(key)
+
+        def on_access(self, key, value, score):
+            assert key in scores
+            return new_score(key)
+
+        def on_evict(self, key, value, score):
+            note('Evicted %r' % (key,))
+            assert score == scores[key]
+            del scores[key]
+            if len(scores) > 1:
+                assert score <= min(
+                    v for k, v in scores.items()
+                    if k != last_entry[0]
+                )
+            evicted.add(key)
+
+    target = Cache(max_size=size)
+    model = {}
+
+    for k, v in writes:
+        target[k] = v
+        model[k] = v
+
+    assert evicted
+    assert len(evicted) + len(target) == len(model)
+    assert len(scores) == len(target)
+
+    for k, v in model.items():
+        try:
+            assert target[k] == v
+            assert k not in evicted
+        except KeyError:
+            assert k in evicted
+
+
+def test_basic_access():
+    cache = ValueScored(max_size=2)
+    cache[1] = 0
+    cache[1] = 0
+    cache[0] = 1
+    cache[2] = 0
+    assert cache[2] == 0
+    assert cache[0] == 1
+    assert len(cache) == 2

--- a/tests/cover/test_cache_implementation.py
+++ b/tests/cover/test_cache_implementation.py
@@ -23,7 +23,7 @@ import pytest
 
 import hypothesis.strategies as st
 from hypothesis import note, given, assume, example
-from hypothesis.internal.cache import LRUReusedCache, GenericCache
+from hypothesis.internal.cache import GenericCache, LRUReusedCache
 
 
 class LRUCache(GenericCache):

--- a/tests/cover/test_cache_implementation.py
+++ b/tests/cover/test_cache_implementation.py
@@ -22,7 +22,7 @@ from random import Random
 import pytest
 
 import hypothesis.strategies as st
-from hypothesis import note, given, assume, example, settings
+from hypothesis import note, given, assume, example
 from hypothesis.internal.cache import LFUCache, LRUCache, LFLRUCache, \
     GenericCache
 
@@ -72,7 +72,7 @@ def test_behaves_like_a_dict_with_losses(implementation, writes, size):
             pass
         model[k] = v
         target[k] = v
-        target.check_rep()
+        target.check_valid()
         assert target[k] == v
         for r, s in model.items():
             try:
@@ -146,3 +146,18 @@ def test_basic_access():
     assert cache[2] == 0
     assert cache[0] == 1
     assert len(cache) == 2
+
+
+def test_can_clear_a_cache():
+    x = ValueScored(1)
+    x[0] = 1
+    assert len(x) == 1
+    x.clear()
+    assert len(x) == 0
+
+
+def test_max_size_cache_ignores():
+    x = ValueScored(0)
+    x[0] = 1
+    with pytest.raises(KeyError):
+        x[0]

--- a/tests/cover/test_cacheable.py
+++ b/tests/cover/test_cacheable.py
@@ -1,0 +1,40 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2017 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import hypothesis.strategies as st
+import pytest
+
+
+@pytest.mark.parametrize('s', [
+    st.floats(),
+    st.tuples(st.integers()),
+    st.tuples(),
+    st.one_of(st.integers(), st.text()),
+])
+def test_is_cacheable(s):
+    assert s.is_cacheable
+
+
+@pytest.mark.parametrize('s', [
+    st.just([]),
+    st.tuples(st.integers(), st.just([])),
+    st.one_of(st.integers(), st.text(), st.just([])),
+])
+def test_is_not_cacheable(s):
+    assert not s.is_cacheable

--- a/tests/cover/test_cacheable.py
+++ b/tests/cover/test_cacheable.py
@@ -17,8 +17,9 @@
 
 from __future__ import division, print_function, absolute_import
 
-import hypothesis.strategies as st
 import pytest
+
+import hypothesis.strategies as st
 
 
 @pytest.mark.parametrize('s', [

--- a/tests/cover/test_cacheable.py
+++ b/tests/cover/test_cacheable.py
@@ -39,3 +39,13 @@ def test_is_cacheable(s):
 ])
 def test_is_not_cacheable(s):
     assert not s.is_cacheable
+
+
+def test_non_cacheable_things_are_not_cached():
+    x = st.just([])
+    assert st.tuples(x) != st.tuples(x)
+
+
+def test_cacheable_things_are_cached():
+    x = st.just(())
+    assert st.tuples(x) == st.tuples(x)

--- a/tests/cover/test_escalation.py
+++ b/tests/cover/test_escalation.py
@@ -1,0 +1,49 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2017 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import pytest
+
+import hypothesis.internal.escalation as esc
+
+
+def test_does_not_escalate_errors_in_a_non_hypothesis_file():
+    try:
+        assert False
+    except AssertionError:
+        esc.escalate_hypothesis_internal_error()
+
+
+def test_does_escalate_errors_in_a_hypothesis_file(monkeypatch):
+    monkeypatch.setattr(esc, 'is_hypothesis_file', lambda x: True)
+
+    with pytest.raises(AssertionError):
+        try:
+            assert False
+        except AssertionError:
+            esc.escalate_hypothesis_internal_error()
+
+
+def test_does_not_escalate_errors_in_a_hypothesis_file_if_disabled(monkeypatch):
+    monkeypatch.setattr(esc, 'is_hypothesis_file', lambda x: True)
+    monkeypatch.setattr(esc, 'PREVENT_ESCALATION', True)
+
+    try:
+        assert False
+    except AssertionError:
+        esc.escalate_hypothesis_internal_error()

--- a/tests/cover/test_escalation.py
+++ b/tests/cover/test_escalation.py
@@ -22,14 +22,14 @@ import pytest
 import hypothesis.internal.escalation as esc
 
 
-def test_does_not_escalate_errors_in_a_non_hypothesis_file():
+def test_does_not_escalate_errors_in_non_hypothesis_file():
     try:
         assert False
     except AssertionError:
         esc.escalate_hypothesis_internal_error()
 
 
-def test_does_escalate_errors_in_a_hypothesis_file(monkeypatch):
+def test_does_escalate_errors_in_hypothesis_file(monkeypatch):
     monkeypatch.setattr(esc, 'is_hypothesis_file', lambda x: True)
 
     with pytest.raises(AssertionError):
@@ -39,7 +39,7 @@ def test_does_escalate_errors_in_a_hypothesis_file(monkeypatch):
             esc.escalate_hypothesis_internal_error()
 
 
-def test_does_not_escalate_errors_in_a_hypothesis_file_if_disabled(monkeypatch):
+def test_does_not_escalate_errors_in_hypothesis_file_if_disabled(monkeypatch):
     monkeypatch.setattr(esc, 'is_hypothesis_file', lambda x: True)
     monkeypatch.setattr(esc, 'PREVENT_ESCALATION', True)
 


### PR DESCRIPTION
Hypothesis historically caches all the things (ALL THE THINGS? Well, no, not quite, but most of the things doesn't have the same ring to it) in its strategy module. This is because I was lazy and didn't want to write, or find a decent cache.

Well, now I have. I wasn't very happy with any of the options, and I had this neat property-based testing library lying around that makes it easier to write your own data structures and not be worried about them being wrong, so I ended up writing my own.

The caching policy adopted is an LFLRU cache - that is, we evict the key that has been used the least often, breaking ties by evicting the one which has been used the least recently. This seems likely to be a good fit for Hypothesis's workload, though it's hard to say for sure.

Note; This is not exactly a WIP pull request, because I think all of the actual implementation is done, but I'm aware that IOU documentation. Feel free to either a) Ask lots of questions about the inevitably many bits that don't make sense and/or b) Wait until I write the documentation.