### PR TITLE
Fix over-precise assertion about Pandas dtype

### DIFF
--- a/tests/pandas/test_data_frame.py
+++ b/tests/pandas/test_data_frame.py
@@ -61,7 +61,7 @@ def test_can_specify_just_column_count(df):
     rows=st.fixed_dictionaries({'A': st.integers(1, 10), 'B': st.floats()}))
 )
 def test_gets_the_correct_data_shape_for_just_rows(table):
-    assert table['A'].dtype == np.dtype(int)
+    assert table['A'].dtype == np.dtype('int64')
     assert table['B'].dtype == np.dtype(float)
 
 

--- a/tests/pandas/test_series.py
+++ b/tests/pandas/test_series.py
@@ -57,7 +57,7 @@ def test_can_generate_integral_series(s):
 
 @given(pdst.series(elements=st.integers(0, 10)))
 def test_will_use_dtype_of_elements(s):
-    assert s.dtype == np.dtype(int)
+    assert s.dtype == np.dtype('int64')
 
 
 @given(pdst.series(elements=st.floats(allow_nan=False)))


### PR DESCRIPTION
`pd.Series([1]).dtype` is `int64` for any integer in the valid range (and `dtype('O')` beyond it).  `np.dtype(int)` gives `np.int_`, which is defined as ['same as C `long`'](https://docs.scipy.org/doc/numpy/user/basics.types.html), and thus can be 32 or 64 bit depending on the machine.  This pull therefore fixes #876, failing test on i686, by checking that the dtype of these series is `'int64'` rather than `int`.

A similar issue to be aware of is handled by our centralised conversion functions - `np.array([int_x]).dtype` will vary with the value of `x`.  On my machine 32bit within that range, and 64bit otherwise, but the docs allow different results so long as the dtype is sufficient for the values.