### PR TITLE
Don't try to feed coverage files it doesn't want

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This release fixes a bug where when running with use_coverage=True inside an
+existing running instance of coverage, Hypothesis would frequently put files
+that the coveragerc excluded in the report for the enclosing coverage.

--- a/tests/nocover/test_coverage.py
+++ b/tests/nocover/test_coverage.py
@@ -81,7 +81,7 @@ def test_achieves_full_coverage(tmpdir, branch, timid):
         some_function_to_test(a, b, c)
 
     cov = Coverage(
-        config_file=False, data_file=str(tmpdir.join('.coveragerc')),
+        config_file=False, data_file=str(tmpdir.join('.coverage')),
         branch=branch, timid=timid,
     )
     cov._warn = escalate_warning
@@ -93,3 +93,28 @@ def test_achieves_full_coverage(tmpdir, branch, timid):
     lines = data.lines(__file__)
     for i in hrange(LINE_START + 1, LINE_END + 1):
         assert i in lines
+
+
+def rnd():
+    import random
+    return random.gauss(0, 1)
+
+
+@pytest.mark.parametrize('branch', [False, True])
+@pytest.mark.parametrize('timid', [False, True])
+def test_does_not_trace_files_outside_inclusion(tmpdir, branch, timid):
+    @given(st.booleans())
+    def test(a):
+        rnd()
+
+    cov = Coverage(
+        config_file=False, data_file=str(tmpdir.join('.coverage')),
+        branch=branch, timid=timid, include=[__file__],
+    )
+    cov._warn = escalate_warning
+    cov.start()
+    test()
+    cov.stop()
+
+    data = cov.get_data()
+    assert len(list(data.measured_files())) == 1


### PR DESCRIPTION
Currently the following two facts interact poorly:

* We deliberately collect files that coverage ignores, because we're interested in more than just reporting and want to use coverage information to distinguish different states.
* We feed collected data back to coverage so that things that ran under Hypothesis contribute to its reporting.

Unfortunately, as things currently stand, we were feeding it files that it had deliberately ignored. This resulted in it including them in its report when it shouldn't have.

This PR fixes that. When running under an existing collector, every time we see a new file we ask it whether it's interested in that file (we have to do this dynamically as we run because it requires access to the frame object. This is for reasons internal to coverage that don't particularly concern us except in that they constrain the design). If it says yes, we record the file. At the end we then only report back on the files that coverage actually wanted to know about.

Fixes #883 