### PR TITLE
Improve behaviour of deadlines on the boundary

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,20 @@
+RELEASE_TYPE: patch
+
+This release improves the handling of deadlines so that they act better with
+the shrinking process. This fixes :issue:`892`.
+
+This involves two changes:
+
+1. The deadline is raised during the initial generation and shrinking, and then
+   lowered to the set value for final replay. This restricts our attention to
+   examples which exceed the deadline by a more significant margin, which
+   increases their reliability.
+2. When despite the above a test still becomes flaky because it is
+   significantly faster on rerun than it was on its first run, the error
+   message is now more explicit about the nature of this problem, and includes
+   both the initial test run time and the new test run time.
+
+In addition, this release also clarifies the documentation of the deadline
+setting slightly to be more explicit about where it applies.
+
+This work was funded by `Smarkets <https://smarkets.com/>`_.

--- a/src/hypothesis/_settings.py
+++ b/src/hypothesis/_settings.py
@@ -633,9 +633,13 @@ settings.define_setting(
     default=not_set,
     description=u"""
 If set, a time in milliseconds (which may be a float to express
-smaller units of time) that a test is not allowed to exceed. Tests which take
-longer than that will be converted into errors. Set this to None to disable
-this behaviour entirely.
+smaller units of time) that each individual example (i.e. each time your test
+function is called, not the whole decorated test) within a test is not
+allowed to exceed. Tests which take longer than that may be converted into
+errors (but will not necessarily be if close to the deadline, to allow some
+variability in test run time).
+
+Set this to None to disable this behaviour entirely.
 
 In future this will default to 200. For now, a
 HypothesisDeprecationWarning will be emitted if you exceed that default

--- a/src/hypothesis/errors.py
+++ b/src/hypothesis/errors.py
@@ -195,3 +195,10 @@ class MultipleFailures(HypothesisException):
 
 class DeadlineExceeded(HypothesisException):
     """Raised when an individual test body has taken too long to run."""
+
+    def __init__(self, runtime, deadline):
+        super(DeadlineExceeded, self).__init__((
+            'Test took %.2fms, which exceeds the deadline of '
+            '%.2fms') % (runtime, deadline))
+        self.runtime = runtime
+        self.deadline = deadline


### PR DESCRIPTION
Deadlines currently interact poorly with shrinking in the
shrinker will try to find an example which is right on the
boundary of failing, which means that given the slightly
unreliable nature of timing, often when you replay the
example it doesn't fail! This results in a confusing user
experience.

The fix is twofold:

1. Give a better error message when this happens.
2. Try to avoid it happening in the first place by raising
   the deadline temporarily during the shrinking process, so
   that we stop at a boundary that is significantly above that
   of the deadline.

This fixes #892.