### PR TITLE
Infer strategies from typing.NewType instances

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+:func:`~hypothesis.strategies.from_type` failed with a very confusing error
+if passed a :func:`~python:typing.NewType` (:issue:`901`).  These psudeo-types
+are now unwrapped correctly, and strategy inference works as expected.

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -928,7 +928,7 @@ def from_type(thing):
     from hypothesis.searchstrategy import types
     if not isinstance(thing, type):
         try:
-            # At runtime, `typing.NewType` returns the identity function rather
+            # At runtime, `typing.NewType` returns an identity function rather
             # than an actual type, but we can check that for a possible match
             # and then read the magic attribute to unwrap it.
             import typing

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -21,7 +21,7 @@ import math
 import datetime as dt
 import operator
 from decimal import Context, Decimal
-from inspect import isclass
+from inspect import isclass, isfunction
 from numbers import Rational
 from fractions import Fraction
 
@@ -927,11 +927,18 @@ def from_type(thing):
     """
     from hypothesis.searchstrategy import types
     if not isinstance(thing, type):
-        # Under Python 3.6, Unions are not instances of `type` - but we still
-        # want to resolve them!  This __origin__ check only passes if thing is
-        # a Union with parameters; if it doesn't we can't resolve it anyway.
         try:
+            # At runtime, `typing.NewType` returns the identity function rather
+            # than an actual type, but we can check that for a possible match
+            # and then read the magic attribute to unwrap it.
             import typing
+            if all([
+                hasattr(thing, '__supertype__'), hasattr(typing, 'NewType'),
+                isfunction(thing), getattr(thing, '__module__', 0) == 'typing'
+            ]):
+                return from_type(thing.__supertype__)
+            # Under Python 3.6, Unions are not instances of `type` - but we
+            # still want to resolve them!
             if getattr(thing, '__origin__', None) is typing.Union:
                 args = sorted(thing.__args__, key=types.type_sorting_key)
                 return one_of([from_type(t) for t in args])

--- a/tests/py3/test_lookup.py
+++ b/tests/py3/test_lookup.py
@@ -299,3 +299,13 @@ def test_error_if_has_unresolvable_hints():
         pass
     with pytest.raises(InvalidArgument):
         inner()
+
+
+@pytest.mark.skipif(not hasattr(typing, 'NewType'), reason='test for NewType')
+def test_resolves_NewType():
+    for t in [
+        typing.NewType('T', int),
+        typing.NewType('UnionT', typing.Optional[int]),
+        typing.NewType('NestedT', typing.NewType('T', int)),
+    ]:
+        from_type(t).example()

--- a/tests/py3/test_lookup.py
+++ b/tests/py3/test_lookup.py
@@ -28,7 +28,7 @@ from hypothesis import find, given, infer, assume
 from hypothesis.errors import NoExamples, InvalidArgument, ResolutionFailed
 from hypothesis.strategies import from_type
 from hypothesis.searchstrategy import types
-from hypothesis.internal.compat import get_type_hints
+from hypothesis.internal.compat import integer_types, get_type_hints
 
 typing = pytest.importorskip('typing')
 sentinel = object()
@@ -303,9 +303,9 @@ def test_error_if_has_unresolvable_hints():
 
 @pytest.mark.skipif(not hasattr(typing, 'NewType'), reason='test for NewType')
 def test_resolves_NewType():
-    for t in [
-        typing.NewType('T', int),
-        typing.NewType('UnionT', typing.Optional[int]),
-        typing.NewType('NestedT', typing.NewType('T', int)),
-    ]:
-        from_type(t).example()
+    typ = typing.NewType('T', int)
+    nested = typing.NewType('NestedT', typ)
+    uni = typing.NewType('UnionT', typing.Optional[int])
+    assert isinstance(from_type(typ).example(), integer_types)
+    assert isinstance(from_type(nested).example(), integer_types)
+    assert isinstance(from_type(uni).example(), integer_types + (type(None),))


### PR DESCRIPTION
Which are not actually types at runtime, hence the requirement for special handling.  Closes #901.