### PR TITLE
Suggest that those using `just(foo())` may want `builds(foo)`

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+Refer to :func:`~hypothesis.strategies.builds` from
+:func:`~hypothesis.strategies.just` documentation for mutable values and when
+generating strategies from functions.

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -172,7 +172,12 @@ def nothing():
 def just(value):
     """Return a strategy which only generates value.
 
-    Note: value is not copied. Be wary of using mutable values.
+    If you are looking to convert the results of a function call to a strategy
+    then see :func:`~hypothesis.strategies.builds`
+
+    Note that value is not copied - you may wish to instead use
+    ``lambda: value`` with :func:`~hypothesis.strategies.builds` to ensure you
+    get a fresh value each time.
 
     """
     from hypothesis.searchstrategy.misc import JustStrategy


### PR DESCRIPTION
Because I spent a remarkable amount of time not realising I wanted
`builsd` - https://stackoverflow.com/a/46297774/928098