### PR TITLE
Address performance problems in new target selector code

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,5 +1,8 @@
 RELEASE_TYPE: patch
 
-This release fixes a performance regression that was introduced in 3.28.4. It
-is likely to affect anyone who has a significant amount of code being covered
-by a single Hypothesis test.
+This release fixes a performance problem in tests where
+ :attr:`~hypothesis.settings.use_coverage` is set to True.
+
+Tests experience a slow-down proportionate to the amount of code they cover.
+This is still the case, but the factor is now low enough that it should be
+unnoticeable. Previously it was large and became much larger in 3.28.4.

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This release fixes a performance regression that was introduced in 3.28.4. It
+is likely to affect anyone who has a significant amount of code being covered
+by a single Hypothesis test.

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -551,11 +551,26 @@ def escalate_warning(msg, slug=None):  # pragma: no cover
     )
 
 
-@attr.s(slots=True, frozen=True)
 class Arc(object):
-    filename = attr.ib()
-    source = attr.ib()
-    target = attr.ib()
+    __slots__ = ('filename', 'source', 'target')
+
+    def __init__(self, filename, source, target):
+        self.filename = filename
+        self.source = source
+        self.target = target
+
+
+ARC_CACHE = {}
+
+
+def arc(filename, source, target):
+    try:
+        return ARC_CACHE[filename][source][target]
+    except KeyError:
+        result = Arc(filename, source, target)
+        ARC_CACHE.setdefault(
+            filename, {}).setdefault(source, {})[target] = result
+        return result
 
 
 in_given = False
@@ -720,7 +735,7 @@ class StateForActualGivenExecution(object):
                         if is_hypothesis_file(filename):
                             continue
                         data.tags.update(
-                            Arc(filename, source, target)
+                            arc(filename, source, target)
                             for source, target in covdata.arcs(filename)
                         )
             if result is not None and self.settings.perform_health_check:

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -138,10 +138,7 @@ class ConjectureRunner(object):
 
         self.debug_data(data)
 
-        tags = frozenset(
-            self.tag_intern_table.setdefault(t, t)
-            for t in data.tags
-        )
+        tags = frozenset(data.tags)
         data.tags = self.tag_intern_table.setdefault(tags, tags)
 
         if data.status == Status.VALID:

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -1132,9 +1132,23 @@ class SampleSet(object):
         return random.choice(self.__values)
 
 
-@attr.s(slots=True, hash=True, cmp=True)
 class Negated(object):
-    tag = attr.ib()
+    __slots__ = ('tag',)
+
+    def __init__(self, tag):
+        self.tag = tag
+
+
+NEGATED_CACHE = {}
+
+
+def negated(tag):
+    try:
+        return NEGATED_CACHE[tag]
+    except KeyError:
+        result = Negated(tag)
+        NEGATED_CACHE[tag] = result
+        return result
 
 
 universal = UniqueIdentifier('universal')
@@ -1229,7 +1243,7 @@ class TargetSelector(object):
 
         for t in new_tags:
             self.non_universal_tags.add(t)
-            self.examples_by_tags[Negated(t)] = list(
+            self.examples_by_tags[negated(t)] = list(
                 self.examples_by_tags[universal]
             )
 
@@ -1251,7 +1265,7 @@ class TargetSelector(object):
             yield t
         for t in self.non_universal_tags:
             if t not in data.tags:
-                yield Negated(t)
+                yield negated(t)
 
     def rescore(self, tag):
         new_score = (

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -24,8 +24,6 @@ from random import Random, getrandbits
 from weakref import WeakKeyDictionary
 from collections import defaultdict
 
-import attr
-
 from hypothesis import settings as Settings
 from hypothesis import Phase
 from hypothesis.reporting import debug_report

--- a/tests/cover/test_core.py
+++ b/tests/cover/test_core.py
@@ -24,6 +24,7 @@ from flaky import flaky
 
 import hypothesis.strategies as s
 from hypothesis import find, given, reject, settings
+from hypothesis.core import arc
 from hypothesis.errors import NoSuchExample, Unsatisfiable
 from tests.common.utils import checks_deprecated_behaviour
 
@@ -98,3 +99,7 @@ def test_settings_are_default_in_find():
     find(
         s.booleans(), lambda x: settings.default is some_normal_settings,
         settings=some_normal_settings)
+
+
+def test_arc_is_memoized():
+    assert arc('foo', 1, 2) is arc('foo', 1, 2)


### PR DESCRIPTION
It turns out that:

* We use tag objects as hash keys a *lot* in target selections
* Our tag objects are all attrs classes and attrs has some significant problems with hashing and equality performance right now: https://github.com/python-attrs/attrs/issues/261  

This replaces our tags with hash-consed (i.e. memoized) objects, so that two value equal tags are always reference equal. This significantly speeds up their use as keys and set members.

Fixes #919.