### PR TITLE
Looser test for Pandas < 0.19

### DIFF
--- a/tests/pandas/test_indexes.py
+++ b/tests/pandas/test_indexes.py
@@ -97,7 +97,10 @@ def test_generate_arbitrary_indices(data):
         else:
             raise
     if dtype is None:
-        assert index.dtype == inferred_dtype
+        if pandas.__version__ >= '0.19':
+            assert index.dtype == inferred_dtype
+        else:
+            assert inferred_dtype in (index.dtype, np.dtype(object))
     else:
         assert index.dtype == converted_dtype
 


### PR DESCRIPTION
It's something about datetimes and empty indexes - whatever the underlying cause, this fixes #923 and I think that's good enough.