### PR TITLE
Fix pandas test *again*

### DIFF
--- a/tests/pandas/test_indexes.py
+++ b/tests/pandas/test_indexes.py
@@ -99,8 +99,6 @@ def test_generate_arbitrary_indices(data):
     if dtype is None:
         if pandas.__version__ >= '0.19':
             assert index.dtype == inferred_dtype
-        else:
-            assert inferred_dtype in (index.dtype, np.dtype(object))
     else:
         assert index.dtype == converted_dtype
 


### PR DESCRIPTION
Turns out that #924 *didn't* fix it in general, so now we just skip that assertion entirely on Pandas 0.18

This is not what I'd planned for Hacktoberfest 😞 