### PR TITLE
Enable coverage on pypy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,6 @@ env:
         - TASK=check-unicode
         - TASK=check-ancient-pip
         - TASK=check-pure-tracer
-        - TASK=check-pypy-with-tracer
         - TASK=check-py273
         - TASK=check-py27-typing
         - TASK=check-py34

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,10 @@
+RELEASE_TYPE: minor
+
+This changes the default value of
+:attr:`use_coverage=True <hypothesis.settings.use_coverage>` to True when
+running on pypy (it was already True on CPython).
+
+It was previously set to False because we expected it to be too slow, but
+recent benchmarking shows that actually performance of the feature on pypy is
+fairly acceptable - sometimes it's slower than on CPython, sometimes it's
+faster, but it's generally within a factor of two either way.

--- a/src/hypothesis/_settings.py
+++ b/src/hypothesis/_settings.py
@@ -34,7 +34,6 @@ import attr
 
 from hypothesis.errors import InvalidArgument, HypothesisDeprecationWarning
 from hypothesis.configuration import hypothesis_home_dir
-from hypothesis.internal.compat import PYPY
 from hypothesis.utils.conventions import UniqueIdentifier, not_set
 from hypothesis.utils.dynamicvariables import DynamicVariable
 
@@ -649,15 +648,15 @@ deadline and have not explicitly set a deadline yourself.
 
 settings.define_setting(
     'use_coverage',
-    default=not PYPY,
-    show_default=False,
+    default=True,
     description="""
 Whether to use coverage information to improve Hypothesis's ability to find
-bugs. You should generally leave this turned on unless your code performs
-poorly when run under coverage.
+bugs.
 
-Note: This is turned on by default except on pypy, where coverage performance
-is sufficiently poor as to make this unusable.
+You should generally leave this turned on unless your code performs
+poorly when run under coverage. If you turn it off, please file a bug report
+or add a comment to an existing one about the problem that prompted you to do
+so.
 """
 )
 


### PR DESCRIPTION
@manueljacob pointed out that performance of `use_coverage` was actually perfectly reasonable on pypy. I think some of this was because it wasn't suffering so badly from the problems fixed in #922, but even once those are fixed my limited benchmarking suggests that the performance on pypy is perfectly reasonable. 

Certainly its performance after the various recent performance fixes is a lot better than CPython performance was in 3.30.4, so we might as well make pypy users suffer and get a bunch of interesting bug reports from them too. 😁 