### PR TITLE
Add performance examples

### DIFF
--- a/perf/README.rst
+++ b/perf/README.rst
@@ -1,0 +1,11 @@
+====================
+Performance Examples
+====================
+
+This is a small collection of examples for testing Hypothesis performance,
+particularly centred on testing behaviour under coverage.
+
+It's nothing particularly useful or principled, and we will at some point
+want to make all of this more formal, but it at least gives us a useful
+place to store examples we know are interesting from a performance point
+of view.

--- a/perf/calls_mock.py
+++ b/perf/calls_mock.py
@@ -1,0 +1,44 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2017 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import string
+from time import time
+from unittest.mock import MagicMock, call
+
+import hypothesis.strategies as st
+from hypothesis import given
+
+
+def fut(D, nodes):
+    return [D(n) for n in nodes]
+
+
+@given(data=st.lists(st.text(alphabet=string.ascii_lowercase)))
+def test_fut(data):
+    d = MagicMock()
+
+    fut(d, data)
+
+    d.assert_has_calls([call(id) for id in data])
+
+
+if __name__ == '__main__':
+    t = time()
+    test_fut()
+    print('Took', time() - t)

--- a/perf/high_coverage.py
+++ b/perf/high_coverage.py
@@ -1,0 +1,102 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2017 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+from time import time
+
+import hypothesis.strategies as st
+from hypothesis import given, settings
+
+
+def noop():
+    pass
+
+
+@settings(use_coverage=True, database=None)
+@given(st.data())
+def test_stuff(x):
+    if x.draw(st.booleans()):
+        noop()
+    if x.draw(st.booleans()):
+        noop()
+    if x.draw(st.booleans()):
+        noop()
+    if x.draw(st.booleans()):
+        noop()
+    if x.draw(st.booleans()):
+        noop()
+    if x.draw(st.booleans()):
+        noop()
+    if x.draw(st.booleans()):
+        noop()
+    if x.draw(st.booleans()):
+        noop()
+    if x.draw(st.booleans()):
+        noop()
+    if x.draw(st.booleans()):
+        noop()
+    if x.draw(st.booleans()):
+        noop()
+    if x.draw(st.booleans()):
+        noop()
+    if x.draw(st.booleans()):
+        noop()
+    if x.draw(st.booleans()):
+        noop()
+    if x.draw(st.booleans()):
+        noop()
+    if x.draw(st.booleans()):
+        noop()
+    if x.draw(st.booleans()):
+        noop()
+    if x.draw(st.booleans()):
+        noop()
+    if x.draw(st.booleans()):
+        noop()
+    if x.draw(st.booleans()):
+        noop()
+    if x.draw(st.booleans()):
+        noop()
+    if x.draw(st.booleans()):
+        noop()
+    if x.draw(st.booleans()):
+        noop()
+    if x.draw(st.booleans()):
+        noop()
+    if x.draw(st.booleans()):
+        noop()
+    if x.draw(st.booleans()):
+        noop()
+    if x.draw(st.booleans()):
+        noop()
+    if x.draw(st.booleans()):
+        noop()
+    if x.draw(st.booleans()):
+        noop()
+    if x.draw(st.booleans()):
+        noop()
+    if x.draw(st.booleans()):
+        noop()
+    if x.draw(st.booleans()):
+        noop()
+
+
+if __name__ == '__main__':
+    t = time()
+    test_stuff()
+    print('Took', time() - t)

--- a/perf/noop.py
+++ b/perf/noop.py
@@ -1,0 +1,35 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2017 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+from time import time
+
+from hypothesis import given, settings
+from hypothesis.strategies import integers
+
+
+@settings(use_coverage=True)
+@given(integers())
+def test_noop(x):
+    pass
+
+
+if __name__ == '__main__':
+    t = time()
+    test_noop()
+    print('Took', time() - t)


### PR DESCRIPTION
This just adds a directory with some of the examples I've been using to debug performance recently. It's nothing at all sophisticated, I just figured it was better to have these in the repo than not.