### PR TITLE
Enable 'DeprecationWarnings as errors' for all tests

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,15 @@
+RELEASE_TYPE: patch
+
+This is a yak shaving release, mostly concerned with our own tests.
+
+While :func:`~python:inspect.getfullargspec` was documented as deprecated
+in Python 3.5, it never actually emitted a warning.  Our code to silence
+this (nonexistent) warning has therefore been removed.
+
+We now run our tests with ``DeprecationWarning`` as an error, and made some
+minor changes to our own tests as a result.  This required similar upstream
+updates to :pypi:`coverage` and :pypi:`execnet` (a test-time dependency via
+:pypi:`pytest-xdist`).
+
+There is no user-visible change in Hypothesis itself, but we encourage you
+to consider enabling deprecations as errors in your own tests.

--- a/src/hypothesis/internal/compat.py
+++ b/src/hypothesis/internal/compat.py
@@ -294,22 +294,6 @@ if PY2:
 else:
     from inspect import getfullargspec, FullArgSpec
 
-    if sys.version_info[:2] == (3, 5):
-        # silence deprecation warnings on Python 3.5
-        # (un-deprecated in 3.6 to allow single-source 2/3 code like this)
-        def silence_warnings(func):
-            import warnings
-            import functools
-
-            @functools.wraps(func)
-            def inner(*args, **kwargs):
-                with warnings.catch_warnings():
-                    warnings.simplefilter('ignore', DeprecationWarning)
-                    return func(*args, **kwargs)
-            return inner
-
-        getfullargspec = silence_warnings(getfullargspec)
-
 
 if sys.version_info[:2] < (3, 6):
     def get_type_hints(thing):

--- a/tests/common/setup.py
+++ b/tests/common/setup.py
@@ -22,15 +22,17 @@ import warnings
 from tempfile import mkdtemp
 
 from hypothesis import settings, unlimited
-from hypothesis.errors import HypothesisDeprecationWarning
 from hypothesis.configuration import set_hypothesis_home_dir
 from hypothesis.internal.charmap import charmap, charmap_file
 from hypothesis.internal.coverage import IN_COVERAGE_TESTS
 
 
-def run():
+def run(deprecations_as_errors=True):
     warnings.filterwarnings('error', category=UnicodeWarning)
-    warnings.filterwarnings('error', category=HypothesisDeprecationWarning)
+    # This catches deprecations in our dependencies, as well as internally
+    # (because HypothesisDeprecationWarning subclasses DeprecationWarning)
+    if deprecations_as_errors:  # disabled for old versions of Django
+        warnings.filterwarnings('error', category=DeprecationWarning)
 
     set_hypothesis_home_dir(mkdtemp())
 

--- a/tests/common/setup.py
+++ b/tests/common/setup.py
@@ -24,7 +24,6 @@ from tempfile import mkdtemp
 from hypothesis import settings, unlimited
 from hypothesis.errors import HypothesisDeprecationWarning
 from hypothesis.configuration import set_hypothesis_home_dir
-from hypothesis.internal.compat import PYPY
 from hypothesis.internal.charmap import charmap, charmap_file
 from hypothesis.internal.coverage import IN_COVERAGE_TESTS
 
@@ -54,7 +53,7 @@ def run():
             )
 
     settings.register_profile('default', settings(
-        timeout=unlimited, use_coverage=not (IN_COVERAGE_TESTS or PYPY)))
+        timeout=unlimited, use_coverage=not IN_COVERAGE_TESTS))
 
     settings.register_profile('with_coverage', settings(
         timeout=unlimited, use_coverage=True,

--- a/tests/cover/test_regex.py
+++ b/tests/cover/test_regex.py
@@ -120,8 +120,8 @@ def test_matching(category, predicate, invert, is_unicode):
     u'(foo)+', u'([\'"])[a-z]+\\1',
     u'(?:[a-z])([\'"])[a-z]+\\1', u'(?P<foo>[\'"])[a-z]+(?P=foo)',  # groups
     u'^abc',  # beginning
-    u'\d', u'[\d]', u'[^\D]', u'\w', u'[\w]', u'[^\W]',
-    u'\s', u'[\s]', u'[^\S]',  # categories
+    u'\\d', u'[\\d]', u'[^\\D]', u'\\w', u'[\\w]', u'[^\\W]',
+    u'\\s', u'[\\s]', u'[^\\S]',  # categories
 ])
 @pytest.mark.parametrize('encode', [False, True])
 def test_can_generate(pattern, encode):
@@ -144,8 +144,8 @@ def test_literals_with_ignorecase(pattern):
 
 
 @pytest.mark.parametrize('pattern', [
-    re.compile(u'\A[^a][^b]\Z', re.IGNORECASE),
-    u'\A(?i)[^a][^b]\Z'
+    re.compile(u'\\A[^a][^b]\\Z', re.IGNORECASE),
+    u'(?i)\\A[^a][^b]\\Z'
 ])
 def test_not_literal_with_ignorecase(pattern):
     assert_all_examples(
@@ -169,9 +169,9 @@ def test_any_with_dotall_generate_newline_binary(pattern):
 
 
 @pytest.mark.parametrize('pattern', [
-    u'\d', u'[\d]', u'[^\D]',
-    u'\w', u'[\w]', u'[^\W]',
-    u'\s', u'[\s]', u'[^\S]',
+    u'\\d', u'[\\d]', u'[^\\D]',
+    u'\\w', u'[\\w]', u'[^\\W]',
+    u'\\s', u'[\\s]', u'[^\\S]',
 ])
 @pytest.mark.parametrize('is_unicode', [False, True])
 @pytest.mark.parametrize('invert', [False, True])
@@ -210,7 +210,7 @@ def test_caret_in_the_middle_does_not_generate_anything():
 
 
 def test_end_with_terminator_does_not_pad():
-    assert_all_examples(st.from_regex(u'abc\Z'), lambda x: x[-3:] == u"abc")
+    assert_all_examples(st.from_regex(u'abc\\Z'), lambda x: x[-3:] == u"abc")
 
 
 def test_end():
@@ -345,14 +345,14 @@ def test_can_pad_strings_with_newlines():
 
 def test_given_multiline_regex_can_insert_after_dollar():
     find_any(
-        st.from_regex(re.compile(u"\Ahi$", re.MULTILINE)),
+        st.from_regex(re.compile(u"\\Ahi$", re.MULTILINE)),
         lambda x: '\n' in x and x.split(u"\n")[1]
     )
 
 
 def test_given_multiline_regex_can_insert_before_caret():
     find_any(
-        st.from_regex(re.compile(u"^hi\Z", re.MULTILINE)),
+        st.from_regex(re.compile(u"^hi\\Z", re.MULTILINE)),
         lambda x: '\n' in x and x.split(u"\n")[0]
     )
 

--- a/tests/django/manage.py
+++ b/tests/django/manage.py
@@ -23,7 +23,10 @@ import sys
 from tests.common.setup import run
 
 if __name__ == u'__main__':
-    run()
+    import django
+
+    django_version = tuple(int(n) for n in django.__version__.split('.')[:2])
+    run(deprecations_as_errors=django_version >= (1, 11))
     os.environ.setdefault(
         u'DJANGO_SETTINGS_MODULE', u'tests.django.toys.settings')
 

--- a/tests/django/toys/urls.py
+++ b/tests/django/toys/urls.py
@@ -20,10 +20,12 @@ from __future__ import division, print_function, absolute_import
 from django.contrib import admin
 from django.conf.urls import url, include
 
+patterns, namespace, name = admin.site.urls
+
 urlpatterns = [
     # Examples:
     # url(r'^$', 'toys.views.home', name='home'),
     # url(r'^blog/', include('blog.urls')),
 
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', include((patterns, name), namespace=namespace))
 ]

--- a/tests/django/toystore/models.py
+++ b/tests/django/toystore/models.py
@@ -27,7 +27,7 @@ class Company(models.Model):
 
 class Store(models.Model):
     name = models.CharField(max_length=100, unique=True)
-    company = models.ForeignKey(Company, null=False)
+    company = models.ForeignKey(Company, null=False, on_delete=models.CASCADE)
 
 
 class CharmField(models.Field):
@@ -63,15 +63,15 @@ class CouldBeCharming(models.Model):
 
 
 class SelfLoop(models.Model):
-    me = models.ForeignKey(u'self', null=True)
+    me = models.ForeignKey(u'self', null=True, on_delete=models.SET_NULL)
 
 
 class LoopA(models.Model):
-    b = models.ForeignKey(u'LoopB', null=False)
+    b = models.ForeignKey(u'LoopB', null=False, on_delete=models.CASCADE)
 
 
 class LoopB(models.Model):
-    a = models.ForeignKey(u'LoopA', null=True)
+    a = models.ForeignKey(u'LoopA', null=True, on_delete=models.SET_NULL)
 
 
 class ManyNumerics(models.Model):
@@ -104,7 +104,7 @@ class CustomishDefault(models.Model):
 
 class MandatoryComputed(models.Model):
     name = models.CharField(max_length=100, unique=True)
-    company = models.ForeignKey(Company, null=False)
+    company = models.ForeignKey(Company, null=False, on_delete=models.CASCADE)
 
     def __init__(self, **kw):
         if u'company' in kw:

--- a/tests/nocover/test_compat.py
+++ b/tests/nocover/test_compat.py
@@ -17,8 +17,8 @@
 
 from __future__ import division, print_function, absolute_import
 
-import sys
 import inspect
+import warnings
 
 import pytest
 
@@ -74,7 +74,9 @@ def d(a1, a2=1, a3=2, a4=None):
 
 @pytest.mark.parametrize('f', [a, b, c, d])
 def test_agrees_on_argspec(f):
-    basic = inspect.getargspec(f)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', DeprecationWarning)
+        basic = inspect.getargspec(f)
     full = getfullargspec(f)
     assert basic.args == full.args
     assert basic.varargs == full.varargs
@@ -106,13 +108,13 @@ def test_to_bytes_in_big_endian_order(x, y):
     assert int_to_bytes(x, 8) <= int_to_bytes(y, 8)
 
 
-@pytest.mark.skipif(sys.version_info[0] != 3 or sys.version_info[:2] == (3, 5),
-                    reason='getfullargspec was deprecated, so we wrap it')
+@pytest.mark.skipif(not hasattr(inspect, 'getfullargspec'),
+                    reason='inspect.getfullargspec only exists under Python 3')
 def test_inspection_compat():
     assert getfullargspec is inspect.getfullargspec
 
 
-@pytest.mark.skipif(sys.version_info[0] != 3,
+@pytest.mark.skipif(not hasattr(inspect, 'FullArgSpec'),
                     reason='inspect.FullArgSpec only exists under Python 3')
 def test_inspection_result_compat():
     assert FullArgSpec is inspect.FullArgSpec

--- a/tests/quality/test_discovery_ability.py
+++ b/tests/quality/test_discovery_ability.py
@@ -46,7 +46,7 @@ RUNS = 100
 REQUIRED_RUNS = 50
 
 
-INITIAL_LAMBDA = re.compile(u'^lambda[^:]*:\s*')
+INITIAL_LAMBDA = re.compile(u'^lambda[^:]*:\\s*')
 
 
 def strip_lambda(s):


### PR DESCRIPTION
Motivation: [this Twitter thread](https://twitter.com/ncoghlan_dev/status/917088410162012160) where @ncoghlan pointed out that `inspect.getfullargspec` has never actually emitted a `DeprecationWarning`.  I wrote the mentioned workaround in #625, when I trusted the docs and didn't bother checking.  There's a lesson in that, I'm sure 😉

- [x] Remove that workaround.  Reflect that this was an easy job.  (I had an inkling, but still pretty funny in hindsight)
- [x] Before merging, check that our test suite does actually enable `DeprecationWarning`s for all code we use.  (that is, I think I was only wrong on the facts of whether it was deprecated, not the proper response -
 avoid if practical, emulate latest compatible interface if not 😛)
- [x] We don't.  Enable all deprecation warnings
- [x] Await release of `execnet` with fix for use of deprecated `inspect.getargspec` (pytest-dev/execnet#49), so tests in CI show something useful
- [x] Fix use of deprecated constructs in Hypothesis tests (invalid string escapes, regex groups not at start, etc)
- [x] Open PR to fix use of deprecated regex (groups not at start) in Coverage.py  (nedbat/coveragepy#33)
- [x] Downgrade this warning (from "error" to "always") in our tests, and force it to be temporary (coverage release expected in a few weeks, and we'll take it out then).
- [x] Explain the whole 'enable DeprecationWarning as error' thing in the release notes, including motivation and that it's now known safe with Hypothesis.