### PR TITLE
Fix pyup.yml format to actually batch

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -2,16 +2,14 @@ requirements:
   - requirements/tools.txt
       updates: all
       pin: True
-      schedule: "every week on monday"
   - requirements/test.txt
       updates: all
       pin: True
-      schedule: "every week on monday"
   - requirements/benchmark.txt
       updates: all
       pin: True
-      schedule: "every week on monday"
   - requirements/coverage.txt
       updates: all
       pin: True
-      schedule: "every week on monday"
+
+schedule: "every week on monday"


### PR DESCRIPTION
Based on rereading [the pyup docs](https://pyup.io/docs/bot/config/) I now see why pyup is still just as chatty as ever after turning on weekly batching - we had the format wrong and pyup wasn't telling us because who validates yaml anyway?

This should hopefully fix that.