### PR TITLE
Better sampling from Enums

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,11 @@
+RELEASE_TYPE: patch
+
+This patch has two improvements for strategies based on enumerations.
+
+- :func:`~hypothesis.strategies.from_type` now handles enumerations correctly,
+  delegating to :func:`~hypothesis.strategies.sampled_from`.  Previously it
+  noted that ``Enum.__init__`` has no required arguments and therefore delegated
+  to :func:`~hypothesis.strategies.builds`, which would subsequently fail.
+- When sampling from an :class:`python:enum.Flag`, we also generate combinations
+  of members. Eg for ``Flag('Permissions', 'READ, WRITE, EXECUTE')`` we can now
+  generate, ``Permissions.READ``, ``Permissions.READ|WRITE``, and so on.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -59,7 +59,7 @@ and ``max_size`` are at least zero.
 -------------------
 
 This release fixes a performance problem in tests where
- :attr:`~hypothesis.settings.use_coverage` is set to True.
+:attr:`~hypothesis.settings.use_coverage` is set to True.
 
 Tests experience a slow-down proportionate to the amount of code they cover.
 This is still the case, but the factor is now low enough that it should be


### PR DESCRIPTION
We actually already support sampling from enums, but this still adds two features:

- `from_type(an_enum)` now correctly delegates to `sampled_from(an_enum)`, rather than `builds(an_enum)` (which fails, despite being a class with no required args to `__init__`)
- When sampling from an [`enum.Flag`](https://docs.python.org/3/library/enum.html#flag) subclass, we also generate combinations of members.  Eg for `Flag('Permissions', 'READ, WRITE, EXECUTE')`, we can now generate `Permissions.READ|EXECUTE`.  This is done dynamically to avoid O(2\^n) memory blowup.