### PR TITLE
Allow specification of individual settings on the command line.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,3 +57,4 @@ If you want to hear from people who are already using Hypothesis, some of them `
 about it <https://hypothesis.readthedocs.io/en/latest/endorsements.html>`_.
 
 If you want to create a downstream package of Hypothesis, please read `these guidelines for packagers <https://hypothesis.readthedocs.io/en/latest/packaging.html>`_.
+


### PR DESCRIPTION
This is an ultra-early WIP PR whose purpose is to set off a discussion about how the proposed feature might be implemented and what its interface might be, as [suggested](https://stackoverflow.com/a/46689434/4122880) by @DRMacIver on SO.

**No work has been done yet!**

The feature is: making it possible to specify individual settings on the command line.

Hypothesis already supports switching profile with

    pytest --hypothesis-profile some_profile

so a similar approach for individual settings might look like this:

    pytest --hypothesis-profile some_profile --hypothesis-setting 'use_coverage=False'

I am aware of one other way of specifying profile:

    HYPOTHESIS_PROFILE=xxxx

Supporting this mechanism would also be useful.