### PR TITLE
Allow direct use of keyword arguments in `settings.register_profile`

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -180,6 +180,7 @@ their individual contributions.
 * `Derek Gustafson <https://www.github.com/degustaf>`_
 * `Florian Bruhin <https://www.github.com/The-Compiler>`_
 * `follower <https://www.github.com/follower>`_
+* `Jacek Generowicz <https://www.github.com/jacg>`_ (github@my-post-office.net)
 * `Jeremy Thurgood <https://github.com/jerith>`_
 * `JP Viljoen <https://github.com/froztbyte>`_ (froztbyte@froztbyte.net)
 * `Jonty Wareing <https://www.github.com/Jonty>`_ (jonty@jonty.co.uk)

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,11 +1,14 @@
 RELEASE_TYPE: patch
 
-This patch has two improvements for strategies based on enumerations.
+This release enables direct use of keyword arguments in
+:func:`~hypothesis.settings.settings.register_profile`.
 
-- :func:`~hypothesis.strategies.from_type` now handles enumerations correctly,
-  delegating to :func:`~hypothesis.strategies.sampled_from`.  Previously it
-  noted that ``Enum.__init__`` has no required arguments and therefore delegated
-  to :func:`~hypothesis.strategies.builds`, which would subsequently fail.
-- When sampling from an :class:`python:enum.Flag`, we also generate combinations
-  of members. Eg for ``Flag('Permissions', 'READ, WRITE, EXECUTE')`` we can now
-  generate, ``Permissions.READ``, ``Permissions.READ|WRITE``, and so on.
+- :func:`~hypothesis.settings.settings.register_profile` no longer
+  requires a :class:`~hypothesis.settings.settings` instance to be
+  passed in: the keyword arguments used to construct the instance can
+  be passed in directly.
+
+  Alternatively, such an instance can be passed in, along with keyword
+  arguments which override any settings present in the instance.
+
+Thanks to Jacek Generowicz for this feature.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -213,7 +213,7 @@ of tests that explicitly change the settings.
 .. doctest::
 
     >>> from hypothesis import settings
-    >>> settings.register_profile("ci", settings(max_examples=1000))
+    >>> settings.register_profile("ci", max_examples=1000)
     >>> settings().max_examples
     200
     >>> settings.load_profile("ci")
@@ -239,9 +239,9 @@ If this variable is not defined the Hypothesis defined defaults will be loaded.
 
     >>> import os
     >>> from hypothesis import settings, Verbosity
-    >>> settings.register_profile("ci", settings(max_examples=1000))
-    >>> settings.register_profile("dev", settings(max_examples=10))
-    >>> settings.register_profile("debug", settings(max_examples=10, verbosity=Verbosity.verbose))
+    >>> settings.register_profile("ci", max_examples=1000)
+    >>> settings.register_profile("dev", max_examples=10)
+    >>> settings.register_profile("debug", max_examples=10, verbosity=Verbosity.verbose)
     >>> settings.load_profile(os.getenv(u'HYPOTHESIS_PROFILE', 'default'))
 
 If you are using the hypothesis pytest plugin and your profiles are registered

--- a/src/hypothesis/_settings.py
+++ b/src/hypothesis/_settings.py
@@ -290,7 +290,7 @@ class settings(settingsMeta('settings', (object,), {})):
         return default_context_manager.__exit__(*args, **kwargs)
 
     @staticmethod
-    def register_profile(name, settings):
+    def register_profile(name, parent=settings(), **kwds):
         """registers a collection of values to be used as a settings profile.
         These settings can be loaded in by name. Enable different defaults for
         different settings.
@@ -298,7 +298,7 @@ class settings(settingsMeta('settings', (object,), {})):
         - settings is a settings object
 
         """
-        settings._profiles[name] = settings
+        settings._profiles[name] = settings(parent=parent, **kwds)
 
     @staticmethod
     def get_profile(name):


### PR DESCRIPTION
Currently, registering a profile requires repetition of `settings`:

    settings.register_profile("ci", settings(max_examples=1000))
    ^^^^^^^^                        ^^^^^^^^
      once                           twice

This PR proposes to allow using the keyword arguments *directly*:

    settings.register_profile("ci", max_examples=1000)

Reusing stored instances of `settings` as a starting point, with the keyword arguments overriding individual settings, could be permitted like this:

    settings.register_profile("ci", stored_settings_instance, max_examples=1000)

I know how to do this conceptually, but in practice there are two steps I am unsure about

1. How to copy an instance of `settings`
2. How to override settings within an existing instance of `settings`

... or some more direct combination of the two.

`settings` does many things that have side-effects, and it has a non-standard metaclass, so I am not at all confident about getting it right.