### PR TITLE
Fix builds introspection with type hints

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,6 +1,11 @@
 RELEASE_TYPE: patch
 
-This is a bugfix release: :func:`~hypothesis.strategies.builds` would try to
-infer a strategy for required positional arguments of the target from type
-hints, even if they had been given to :func:`~hypothesis.strategies.builds`
-as positional arguments.  Now it only inferrs missing required arguments.
+This is a bugfix release:
+
+- :func:`~hypothesis.strategies.builds` would try to infer a strategy for
+  required positional arguments of the target from type hints, even if they
+  had been given to :func:`~hypothesis.strategies.builds` as positional
+  arguments (:issue:`946`).  Now it only infers missing required arguments.
+- An internal introspection function wrongly reported ``self`` as a required
+  argument for bound methods, which might also have affected
+  :func:`~hypothesis.strategies.builds`.  Now it knows better.

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This is a bugfix release: :func:`~hypothesis.strategies.builds` would try to
+infer a strategy for required positional arguments of the target from type
+hints, even if they had been given to :func:`~hypothesis.strategies.builds`
+as positional arguments.  Now it only inferrs missing required arguments.

--- a/src/hypothesis/internal/reflection.py
+++ b/src/hypothesis/internal/reflection.py
@@ -99,9 +99,9 @@ def required_args(target, args=(), kwargs=()):
         return None
     # For classes, self is present in the argspec but not really required
     posargs = spec.args[1:] if inspect.isclass(target) else spec.args
-    return set(posargs + spec.kwonlyargs) \
+    return set(posargs[len(args):] + spec.kwonlyargs) \
         - set(spec.args[len(spec.args) - len(spec.defaults or ()):]) \
-        - set(spec.kwonlydefaults or ()) - set(args) - set(kwargs)
+        - set(spec.kwonlydefaults or ()) - set(kwargs)
 
 
 def convert_keyword_arguments(function, args, kwargs):

--- a/tests/py3/test_lookup.py
+++ b/tests/py3/test_lookup.py
@@ -339,3 +339,29 @@ def test_resolves_flag_enum(resolver):
         assert isinstance(ex, F)
 
     inner()
+
+
+class AnnotatedTarget(object):
+
+    def __init__(self, a: int, b: int):
+        pass
+
+    def method(self, a: int, b: int):
+        pass
+
+
+@pytest.mark.parametrize('target', [
+    AnnotatedTarget, AnnotatedTarget(1, 2).method
+])
+@pytest.mark.parametrize('args,kwargs', [
+    ((), {}),
+    ((1,), {}),
+    ((1, 2), {}),
+    ((), dict(a=1)),
+    ((), dict(b=2)),
+    ((), dict(a=1, b=2)),
+])
+def test_required_args(target, args, kwargs):
+    # Mostly checking that `self` (and only self) is correctly excluded
+    st.builds(target, *map(st.just, args),
+              **{k: st.just(v) for k, v in kwargs.items()}).example()

--- a/tests/py3/test_lookup.py
+++ b/tests/py3/test_lookup.py
@@ -231,6 +231,11 @@ def annotated_func(a: int, b: int=2, *, c: int, d: int=4):
     return a + b + c + d
 
 
+def test_issue_946_regression():
+    # Turned type hints into kwargs even if the required posarg was passed
+    st.builds(annotated_func, st.integers()).example()
+
+
 @pytest.mark.parametrize('thing', [
     annotated_func,  # Works via typing.get_type_hints
     typing.NamedTuple('N', [('a', int)]),  # Falls back to inspection


### PR DESCRIPTION
This is a subtle but nasty bug I added when working on type inference introspection.  The root cause is that the calculation of what arguments are required assumes that the `args` tuple contains the *names* of the arguments, where it actually contains the *values*.  😕 

Closes #946, with thanks to the excellent report by @hoefling.