### PR TITLE
[WIP] Handle pathological inputs to decimals()

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,13 @@
+RELEASE_TYPE: patch
+
+This release allows :func:`~hypothesis.strategies.decimals` to handle inputs
+which previously caused serious performance problems (:issue:`838`).
+
+- ``Decimal(10) ** 999999`` is a valid bound for the decimals strategy,
+  but caused problems when it was internally cast to an integer. We now use
+  a variety of tricks including rescaling values and multi-step generation
+  to handle very large or small values correctly *and* efficiently.
+- Using very precise bounds would generate examples with that many digits of
+  precision.  This could easily happen by accident - eg.
+  ``Decimal(1).next_minus()`` may have over a million decimal places - so we
+  now use similar tricks to consider fewer digits of the bounds internally.

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -1296,9 +1296,9 @@ def decimals(min_value=None, max_value=None,
     special = []
     if allow_nan or (allow_nan is None and (None in (min_value, max_value))):
         special.extend(map(Decimal, ('NaN', '-NaN', 'sNaN', '-sNaN')))
-    if allow_infinity or (allow_infinity is max_value is None):
+    if allow_infinity or (allow_infinity is None and max_value is None):
         special.append(Decimal('Infinity'))
-    if allow_infinity or (allow_infinity is min_value is None):
+    if allow_infinity or (allow_infinity is None and min_value is None):
         special.append(Decimal('-Infinity'))
     return strat | sampled_from(special)
 

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -1354,6 +1354,14 @@ def decimals(min_value=None, max_value=None,
                 min_value.adjusted(), max_value.adjusted()
             ).map(lambda i: Decimal(10) ** i).flatmap(scaled_decimals)
 
+    # Filter to bounds.  This should only ever take effect with precision of
+    # one digit, which otherwise behaves differently on various versions and
+    # operating systems.
+    if min_value is not None:
+        strat = strat.filter(lambda v: v >= min_value)
+    if max_value is not None:
+        strat = strat.filter(lambda v: v <= max_value)
+
     # Compose with sampled_from for infinities and NaNs as appropriate
     special = []
     if allow_nan or (allow_nan is None and (None in (min_value, max_value))):

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -1308,7 +1308,7 @@ def decimals(min_value=None, max_value=None,
         if min_value is not None:
             min_value = ctx.add(min_value, 0)
             if exact_bounds['min'] < min_value:
-                min_value = ctx.next_plus(min_value)
+                min_value = ctx.next_plus(min_value)  # pragma: no cover
         if max_value is not None:
             max_value = ctx.add(max_value, 0)
             if exact_bounds['max'] > max_value:

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -1269,7 +1269,7 @@ def decimals(min_value=None, max_value=None,
         # Fixed-point decimals are basically integers with a scale factor
         def ctx(val, name=None):
             """Return a context in which this value is lossless."""
-            prec = max([2, abs(val or Decimal(1)).adjusted() + places + 1])
+            prec = max([1, abs(val or Decimal(1)).adjusted()]) + places + 1
             if name is not None and prec > 10 ** 4:
                 raise InvalidArgument(
                     'To represent %s_value=%r with %s places would take %s '

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -1244,6 +1244,10 @@ def decimals(min_value=None, max_value=None,
     If ``places`` is not None, all finite values drawn from the strategy will
     have that number of digits after the decimal place.
 
+    Regardless of their value, generated examples may have at most ten
+    thousand digits of precision.  Note that this does not exclude large
+    values - `Decimal(10) ** 99999` has only one digit of precision!
+
     Examples from this strategy do not have a well defined shrink order but
     try to maximize human readability when shrinking.
 

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -21,7 +21,7 @@ import enum
 import math
 import datetime as dt
 import operator
-from decimal import Context, Decimal
+from decimal import Context, Decimal, localcontext
 from inspect import isclass, isfunction
 from fractions import Fraction
 from functools import reduce
@@ -1204,6 +1204,25 @@ def fractions(min_value=None, max_value=None, max_denominator=None):
         lambda f: f.limit_denominator(max_denominator))
 
 
+def _as_finite_decimal(value, name, allow_infinity):
+    """Convert decimal bounds to decimals, carefully."""
+    assert name in ('min_value', 'max_value')
+    if value is None:
+        return None
+    if not isinstance(value, Decimal):
+        with localcontext(Context()):  # ensure that default traps are enabled
+            value = try_convert(Decimal, value, name)
+    if value.is_finite():
+        return value
+    if value.is_infinite() and (value < 0 if 'min' in name else value > 0):
+        if allow_infinity or allow_infinity is None:
+            return None
+        raise InvalidArgument('allow_infinity=%r, but %s=%r'
+                              % (allow_infinity, name, value))
+    # This could be infinity, quiet NaN, or signalling NaN
+    raise InvalidArgument(u'Invalid %s=%r' % (name, value))
+
+
 @cacheable
 @defines_strategy_with_reusable_values
 def decimals(min_value=None, max_value=None,
@@ -1233,28 +1252,9 @@ def decimals(min_value=None, max_value=None,
     check_valid_integer(places)
     if places is not None and places < 0:
         raise InvalidArgument('places=%r may not be negative' % places)
-
-    if min_value is not None:
-        min_value = try_convert(Decimal, min_value, 'min_value')
-        if min_value.is_infinite() and min_value < 0:
-            if not (allow_infinity or allow_infinity is None):
-                raise InvalidArgument('allow_infinity=%r, but min_value=%r'
-                                      % (allow_infinity, min_value))
-            min_value = None
-        elif not min_value.is_finite():
-            # This could be positive infinity, quiet NaN, or signalling NaN
-            raise InvalidArgument(u'Invalid min_value=%r' % min_value)
-    if max_value is not None:
-        max_value = try_convert(Decimal, max_value, 'max_value')
-        if max_value.is_infinite() and max_value > 0:
-            if not (allow_infinity or allow_infinity is None):
-                raise InvalidArgument('allow_infinity=%r, but max_value=%r'
-                                      % (allow_infinity, max_value))
-            max_value = None
-        elif not max_value.is_finite():
-            raise InvalidArgument(u'Invalid max_value=%r' % max_value)
+    min_value = _as_finite_decimal(min_value, 'min_value', allow_infinity)
+    max_value = _as_finite_decimal(max_value, 'max_value', allow_infinity)
     check_valid_interval(min_value, max_value, 'min_value', 'max_value')
-
     if allow_infinity and (None not in (min_value, max_value)):
         raise InvalidArgument('Cannot allow infinity between finite bounds')
     # Set up a strategy for finite decimals.  Note that both floating and

--- a/tests/cover/test_direct_strategies.py
+++ b/tests/cover/test_direct_strategies.py
@@ -88,6 +88,8 @@ def fn_ktest(*fnkwargs):
     (ds.decimals, {'max_value': 'inf', 'allow_infinity': False}),
     (ds.decimals, {'min_value': complex(1, 2)}),
     (ds.decimals, {'min_value': '0.1', 'max_value': '0.9', 'places': 0}),
+    (ds.decimals, {'min_value': decimal.Decimal('1' + 10000 * '0' + '1'),
+                   'max_value': decimal.Decimal('1' + 10000 * '0' + '9')}),
     (ds.dictionaries, {
         'keys': ds.booleans(), 'values': ds.booleans(),
         'min_size': 10, 'max_size': 1}),
@@ -160,6 +162,9 @@ def test_validates_keyword_arguments(fn, kwargs):
     (ds.decimals, {'min_value': 1.0, 'allow_nan': False}),
     (ds.decimals, {'max_value': 1.0, 'allow_nan': False}),
     (ds.decimals, {'max_value': 1.0, 'min_value': -1.0, 'allow_nan': False}),
+    (ds.decimals, {'max_value': 10 ** 120, 'min_value': 10 ** 110}),
+    (ds.decimals, {'min_value': decimal.Decimal('1' + 10000 * '0' + '9'),
+                   'max_value': decimal.Decimal('2' + 10000 * '0' + '1')}),
     (ds.decimals, {'min_value': '-inf'}),
     (ds.decimals, {'max_value': 'inf'}),
     (ds.fractions, {

--- a/tests/cover/test_numerics.py
+++ b/tests/cover/test_numerics.py
@@ -128,3 +128,12 @@ def test_issue_739_regression(x):
 def test_issue_838_regression(x):
     # If this hands forever, that's a regression
     pass
+
+
+@given(data())
+def test_absurdly_precise_bounds_error(data):
+    OVERLY_PRECISE = 10100  # greater-than-maximum precision
+    with decimal.localcontext(decimal.Context(prec=OVERLY_PRECISE)):
+        lo, hi = decimal.Decimal(1) / 3, decimal.Decimal(2) / 3
+    with pytest.raises(InvalidArgument):
+        data.draw(decimals(lo, hi, places=OVERLY_PRECISE))

--- a/tests/cover/test_numerics.py
+++ b/tests/cover/test_numerics.py
@@ -122,3 +122,9 @@ def test_issue_725_regression(x):
 @given(decimals(min_value='0.1', max_value='0.3'))
 def test_issue_739_regression(x):
     pass
+
+
+@given(decimals(min_value='10E99998', max_value='10E99999'))
+def test_issue_838_regression(x):
+    # If this hands forever, that's a regression
+    pass


### PR DESCRIPTION
This is basically a follow-on from #789, in which I made the `decimals()` strategy *more* correct but also opened up some pathological performance problems if you feed it odd inputs, which makes it a little less vulnerable to accidental DOS attacks.

- If for some reason you supply an invalid string argument in a decimal context that disables InvalidOperation, you now get a better error message because we use a fresh context.  If you've *also* messed with the default context, that's your problem.
- If you pass `Decimal(10) ** 99999` as a bound, we now scale it before casting to an integer (or Fraction, which is a pair of integers) and scale the result back up.  This is obviously very slow and memory-intensive otherwise.
- We cap the internal precision, so we never ask Conjecture for more than ten thousand digits per value.  This caps the time and memory cost of each example at a reasonable level, without any impact most people will ever notice.

Closes #838.
  