### PR TITLE
adds numpy ndarray to the list of sampleable types

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -164,6 +164,7 @@ their individual contributions.
 * `Alex Willmer <https://github.com/moreati>`_ (alex@moreati.org.uk)
 * `Ben Peterson <https://github.com/killthrush>`_ (killthrush@hotmail.com_)
 * `Charles O'Farrell <https://www.github.com/charleso>`_
+* `Charlie Tanksley <https://www.github.com/charlietanksley>`_
 * `Chris Down  <https://chrisdown.name>`_
 * `Christopher Martin <https://www.github.com/chris-martin>`_ (ch.martin@gmail.com)
 * `Cory Benfield <https://www.github.com/Lukasa>`_

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: minor
+
+- :func:`~hypothesis.strategies.sampled_from` can now sample from
+  one-dimensional numpy ndarrays. Sampling from multi-dimensional
+  ndarrays still results in a deprecation warning. Thanks to Charlie
+  Tanksley for this patch.

--- a/src/hypothesis/internal/conjecture/utils.py
+++ b/src/hypothesis/internal/conjecture/utils.py
@@ -72,6 +72,23 @@ def centered_integer_range(data, lower, upper, center):
 
 
 def check_sample(values):
+    try:
+        from numpy import ndarray
+        if isinstance(values, ndarray):
+            if values.ndim != 1:
+                note_deprecation((
+                    'Only one-dimensional arrays are supported for sampling, '
+                    'and the given value has {ndim} dimensions (shape '
+                    '{shape}).  This array would give samples of array slices '
+                    'instead of elements!  Use np.ravel(values) to convert '
+                    'to a one-dimensional array, or tuple(values) if you '
+                    'want to sample slices.  Sampling a multi-dimensional '
+                    'array will be an error in a future version of Hypothesis.'
+                ).format(ndim=values.ndim, shape=values.shape))
+            return tuple(values)
+    except ImportError:  # pragma: no cover
+        pass
+
     if not isinstance(values, (OrderedDict, Sequence, enum.EnumMeta)):
         note_deprecation(
             ('Cannot sample from %r, not a sequence.  ' % (values,)) +

--- a/tests/numpy/test_sampled_from.py
+++ b/tests/numpy/test_sampled_from.py
@@ -1,0 +1,42 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2017 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import numpy as np
+
+from hypothesis import given
+from tests.common.utils import checks_deprecated_behaviour
+from hypothesis.strategies import sampled_from
+
+a_numpy_array = np.array([1, 2, 3])
+
+a_multi_dimensional_numpy_array = np.array([[1, 2, 3], [4, 5, 6]])
+
+
+@given(sampled_from(a_numpy_array))
+def test_can_sample_numpy_array_without_warning(member):
+    assert member in a_numpy_array
+
+
+@checks_deprecated_behaviour
+def test_multi_dimensional_arrays_are_a_no():
+    @given(sampled_from(a_multi_dimensional_numpy_array))
+    def test(member):
+        assert member in a_multi_dimensional_numpy_array
+
+    test()

--- a/tests/numpy/test_sampled_from.py
+++ b/tests/numpy/test_sampled_from.py
@@ -19,24 +19,29 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 
-from hypothesis import given
+from hypothesis import given, assume
+from hypothesis.extra import numpy as npst
 from tests.common.utils import checks_deprecated_behaviour
-from hypothesis.strategies import sampled_from
-
-a_numpy_array = np.array([1, 2, 3])
-
-a_multi_dimensional_numpy_array = np.array([[1, 2, 3], [4, 5, 6]])
+from hypothesis.strategies import data, sampled_from
 
 
-@given(sampled_from(a_numpy_array))
-def test_can_sample_numpy_array_without_warning(member):
-    assert member in a_numpy_array
+@given(data(), npst.arrays(
+    dtype=npst.scalar_dtypes(),
+    shape=npst.array_shapes(max_dims=1)
+))
+def test_can_sample_1D_numpy_array_without_warning(data, arr):
+    elem = data.draw(sampled_from(arr))
+    try:
+        assume(not np.isnan(elem))
+    except TypeError:
+        pass
+    assert elem in arr
 
 
 @checks_deprecated_behaviour
-def test_multi_dimensional_arrays_are_a_no():
-    @given(sampled_from(a_multi_dimensional_numpy_array))
-    def test(member):
-        assert member in a_multi_dimensional_numpy_array
-
-    test()
+@given(data(), npst.arrays(
+    dtype=npst.scalar_dtypes(),
+    shape=npst.array_shapes(min_dims=2, max_dims=5)
+))
+def test_sampling_multi_dimensional_arrays_is_deprecated(data, arr):
+    data.draw(sampled_from(arr))


### PR DESCRIPTION
# What

Makes it so you can `hypothesis.strategies.sampled_from` an `ndarray`.

## Before

```
Python 2.7.14 (default, Sep 25 2017, 09:53:22) 
[GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import numpy
>>> import hypothesis
>>> hypothesis.strategies.sampled_from(numpy.array([1, 2, 3])).example()
.../hypothesis-3.33.0-py2.7.egg/hypothesis/strategies.py:418: HypothesisDeprecationWarning: Cannot sample from array([1, 2, 3]), not a sequence.  Hypothesis goes to some length to ensure that sampling an element from a collection (with `sampled_from` or `choices`) is replayable and can be minimised.  To replay a saved example, the sampled values must have the same iteration order on every run - ruling out sets, dicts, etc due to hash randomisation.  Most cases can simply use `sorted(values)`, but mixed types or special values such as math.nan require careful handling - and note that when simplifying an example, Hypothesis treats earlier values as simpler.
  values = check_sample(elements)
3
```

## After

```
Python 2.7.14 (default, Sep 25 2017, 09:53:22) 
[GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import numpy
>>> import hypothesis
>>> hypothesis.strategies.sampled_from(numpy.array([1, 2, 3])).example()
1
```

# Current Problems

The tests fail. The problem is that the main tests for this are in https://github.com/HypothesisWorks/hypothesis-python/blob/master/tests/cover/test_sampled_from.py, which is called after only installing the packages from `requirements/test.txt` which *does not* include numpy.  So this blows up when those early tests are run.

I could fix this by adding numpy to that requirement file, but I'm thinking this is the wrong approach.  At the moment I can't think of any other approaches so I'd love some suggestions here.

