### PR TITLE
Deprecate repeated given

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,13 @@
+RELEASE_TYPE: minor
+
+Hypothesis now emits deprecation warnings if you apply
+:func:`@given <hypothesis.given>` more than once to a target.
+
+Applying :func:`@given <hypothesis.given>` repeatedly wraps the target multiple
+times. Each wrapper will search the space of of possible parameters separately.
+This is equivalent but will be much more inefficient than doing it with a
+single call to :func:`@given <hypothesis.given>`.
+
+For example, instead of
+``@given(booleans()) @given(integers())``, you could write
+``@given(booleans(), integers())``

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -977,6 +977,17 @@ def given(*given_arguments, **given_kwargs):
             # Tell pytest to omit the body of this function from tracebacks
             __tracebackhide__ = True
 
+            if getattr(test, 'is_hypothesis_test', False):
+                note_deprecation((
+                    'You have applied @given to a test more than once. In '
+                    'future this will be an error. Applying @given twice '
+                    'wraps the test twice, which can be extremely slow. A '
+                    'similar effect can be gained by combining the arguments '
+                    'to the two calls to given. For example, instead of '
+                    '@given(booleans()) @given(integers()), you could write '
+                    '@given(booleans(), integers())'
+                ))
+
             settings = wrapped_test._hypothesis_internal_use_settings
 
             random = get_random_for_wrapped_test(test, wrapped_test)

--- a/tests/cover/test_given_error_conditions.py
+++ b/tests/cover/test_given_error_conditions.py
@@ -80,3 +80,12 @@ def test_error_if_infer_is_posarg():
         pass
     with pytest.raises(InvalidArgument):
         inner()
+
+
+def test_given_twice_deprecated():
+    @given(booleans())
+    @given(integers())
+    def inner(a, b):
+        pass
+    with validate_deprecation():
+        inner()


### PR DESCRIPTION
Report a deprecation if @given is applied to a test more than once.

Currently, a user can apply @given to a test as many times as they like.  The effect of this may not be obvious at first, but what it actually does is wrap the test multiple times: the inner most decorator will be applied first, generating a wrapped test, and then the outer decorator will be applied. Each wrapper will search the space of of possible parameters separately, which will be much more inefficient than doing it together.  I'm also concerned (but haven't investigated) that this is liable to interact badly with use of @example; if @example is used before the first decorator, the example will be tested in the outer wrapper, but if it's used before an inner decorator, the example will be tested in the inner wrapper, after parameters from the outer wrapper have been applied.

It's possible that this could be used deliberately, but it's such a confusing (and undocumented) set of effects that it feels far more likely that users would do this accidentally and get confused by the results.

This therefore feels like an unintended use of the API, and we could possibly jump straight to giving an error.  However in IRC conversation, @DRMacIver suggested that he thought people probably are using this deliberately, but that all of that usage should use a single given.

I've therefore put together this PR which reports a deprecation if `@given` is used more than once.  My first PR to hypothesis for 5 years, so I've probably done something wrong, very happy to work on this more.