### PR TITLE
Get doctests working again; script to fix broken doctests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ env:
         - TASK=check-shellcheck
         - TASK=documentation
         - TASK=lint
+        - TASK=doctest
         - TASK=check-rst
         - TASK=check-format
         - TASK=check-benchmark

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This is a documentation release, which ensures code examples are up to date
+by running them as doctests in CI (:issue:`711`).

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,6 +79,8 @@ doctest_global_setup = '''
 from hypothesis import *
 from hypothesis.strategies import *
 # Run deterministically, and don't save examples
+import random
+random.seed(0)
 doctest_settings = settings(database=None, derandomize=True)
 settings.register_profile('doctests', doctest_settings)
 settings.load_profile('doctests')

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,7 +84,7 @@ settings.register_profile('doctests', doctest_settings)
 settings.load_profile('doctests')
 # Never show deprecated behaviour in code examples
 import warnings
-warnings.filterwarnings('error', category=HypothesisDeprecationWarning)
+warnings.filterwarnings('error', category=DeprecationWarning)
 '''
 
 # This config value must be a dictionary of external sites, mapping unique

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -43,7 +43,7 @@ e.g.:
 .. doctest::
 
     >>> lists(integers()).map(sorted).example()
-    [-224, -222, 16, 159, 120699286316048]
+    [-158104205405429173199472404790070005365, -131418136966037518992825706738877085689, -49279168042092131242764306881569217089, 2564476464308589627769617001898573635]
 
 Note that many things that you might use mapping for can also be done with
 :func:`~hypothesis.strategies.builds`.
@@ -60,9 +60,9 @@ example of ``s`` such that ``f(example)`` is truthy.
 .. doctest::
 
     >>> integers().filter(lambda x: x > 11).example()
-    1609027033942695427531
+    87034457550488036879331335314643907276
     >>> integers().filter(lambda x: x > 11).example()
-    251
+    145321388071838806577381808280858991039
 
 It's important to note that ``filter`` isn't magic and if your condition is too
 hard to satisfy then this can fail:
@@ -85,7 +85,7 @@ you wanted pairs of integers (x,y) such that x < y you could do the following:
 .. doctest::
 
     >>> tuples(integers(), integers()).map(sorted).filter(lambda x: x[0] < x[1]).example()
-    (180, 241)
+    [-145066798798423346485767563193971626126, -19139012562996970506504843426153630262]
 
 .. _flatmap:
 
@@ -155,23 +155,30 @@ returns a new strategy for it. So for example:
     >>> json = recursive(none() | booleans() | floats() | text(printable),
     ... lambda children: lists(children) | dictionaries(text(printable), children))
     >>> pprint(json.example())
-    {'': 'Me$',
-    "\r5qPZ%etF:vL'9gC": False,
-    '$KsT(( J/(wQ': [],
-    '0)G&31': False,
-    '7': [],
-    'C.i]A-I': {':?Xh>[;': None,
-                'YHT\r!\x0b': -6.801160220000663e+18,
-    ...
+    {'': 'wkP!4',
+     '\nLdy': None,
+     '"uHuds:8a{h\\:694K~{mY>a1yA:#CmDYb': {},
+     '#1J1': [')gnP',
+              inf,
+              ['6', 11881275561.716116, "v'A?qyp_sB\n$62g", ''],
+              -1e-05,
+              'aF\rl',
+              [-2.599459969184803e+250, True, True, None],
+              [True,
+               '9qP\x0bnUJH5',
+               3.0741121405774857e-131,
+               None,
+               '',
+               -inf,
+               'L&',
+               1.5,
+               False,
+               None]],
+     'cx.': None}
     >>> pprint(json.example())
-    [{"7_8'qyb": None,
-    ':': -0.3641507440748771,
-    'TI_^\n>L{T\x0c': -0.0,
-    'ZiOqQ\t': 'RKT*a]IjI/Zx2HB4ODiSUN)LsZ',
-    'n;E^^6|9=@g@@BmAi': '7j5\\'},
-    True]
+    [5.321430774293539e+16, [], 1.1045114769709281e-125]
     >>> pprint(json.example())
-    []
+    {'a': []}
 
 That is, we start with our leaf data and then we augment it by allowing lists and dictionaries of anything we can generate as JSON data.
 
@@ -185,7 +192,7 @@ we wanted to only generate really small JSON we could do this as:
     >>> small_lists.example()
     True
     >>> small_lists.example()
-    [True, False]
+    [False, False, True, True, True]
     >>> small_lists.example()
     True
 
@@ -221,12 +228,12 @@ accept all the others in the expected order. Defaults are preserved.
     >>> list_and_index()
     list_and_index()
     >>> list_and_index().example()
-    ([215, 112], 0)
+    ([-57328788235238539257894870261848707608], 0)
 
     >>> list_and_index(booleans())
     list_and_index(elements=booleans())
     >>> list_and_index(booleans()).example()
-    ([False, False], 1)
+    ([True], 0)
 
 Note that the repr will work exactly like it does for all the built-in
 strategies: it will be a function that you can call to get the strategy in

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -42,8 +42,8 @@ e.g.:
 
 .. doctest::
 
-  >>> lists(integers()).map(sorted).example()
-  [-224, -222, 16, 159, 120699286316048]
+    >>> lists(integers()).map(sorted).example()
+    [-224, -222, 16, 159, 120699286316048]
 
 Note that many things that you might use mapping for can also be done with
 :func:`~hypothesis.strategies.builds`.
@@ -59,20 +59,20 @@ example of ``s`` such that ``f(example)`` is truthy.
 
 .. doctest::
 
-  >>> integers().filter(lambda x: x > 11).example()
-  1609027033942695427531
-  >>> integers().filter(lambda x: x > 11).example()
-  251
+    >>> integers().filter(lambda x: x > 11).example()
+    1609027033942695427531
+    >>> integers().filter(lambda x: x > 11).example()
+    251
 
 It's important to note that ``filter`` isn't magic and if your condition is too
 hard to satisfy then this can fail:
 
 .. doctest::
 
-  >>> integers().filter(lambda x: False).example()
-  Traceback (most recent call last):
-    ...
-  hypothesis.errors.NoExamples: Could not find any valid examples in 20 tries
+    >>> integers().filter(lambda x: False).example()
+    Traceback (most recent call last):
+        ...
+    hypothesis.errors.NoExamples: Could not find any valid examples in 20 tries
 
 In general you should try to use ``filter`` only to avoid corner cases that you
 don't want rather than attempting to cut out a large chunk of the search space.
@@ -84,9 +84,9 @@ you wanted pairs of integers (x,y) such that x < y you could do the following:
 
 .. doctest::
 
-  >>> tuples(integers(), integers()).map(
-  ... lambda x: tuple(sorted(x))).filter(lambda x: x[0] != x[1]).example()
-  (180, 241)
+    >>> tuples(integers(), integers()).map(
+    ... lambda x: tuple(sorted(x))).filter(lambda x: x[0] != x[1]).example()
+    (180, 241)
 
 .. _flatmap:
 
@@ -106,16 +106,16 @@ length:
 
 .. code-block:: pycon
 
-  >>> rectangle_lists = integers(min_value=0, max_value=10).flatmap(
-  ... lambda n: lists(lists(integers(), min_size=n, max_size=n)))
-  >>> find(rectangle_lists, lambda x: True)
-  []
-  >>> find(rectangle_lists, lambda x: len(x) >= 10)
-  [[], [], [], [], [], [], [], [], [], []]
-  >>> find(rectangle_lists, lambda t: len(t) >= 3 and len(t[0]) >= 3)
-  [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
-  >>> find(rectangle_lists, lambda t: sum(len(s) for s in t) >= 10)
-  [[0], [0], [0], [0], [0], [0], [0], [0], [0], [0]]
+    >>> rectangle_lists = integers(min_value=0, max_value=10).flatmap(
+    ... lambda n: lists(lists(integers(), min_size=n, max_size=n)))
+    >>> find(rectangle_lists, lambda x: True)
+    []
+    >>> find(rectangle_lists, lambda x: len(x) >= 10)
+    [[], [], [], [], [], [], [], [], [], []]
+    >>> find(rectangle_lists, lambda t: len(t) >= 3 and len(t[0]) >= 3)
+    [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+    >>> find(rectangle_lists, lambda t: sum(len(s) for s in t) >= 10)
+    [[0], [0], [0], [0], [0], [0], [0], [0], [0], [0]]
 
 In this example we first choose a length for our tuples, then we build a
 strategy which generates lists containing lists precisely of that length. The
@@ -152,27 +152,27 @@ returns a new strategy for it. So for example:
 
 .. doctest::
 
-  >>> from string import printable; from pprint import pprint
-  >>> json = recursive(none() | booleans() | floats() | text(printable),
-  ... lambda children: lists(children) | dictionaries(text(printable), children))
-  >>> pprint(json.example())
-  {'': 'Me$',
-   "\r5qPZ%etF:vL'9gC": False,
-   '$KsT(( J/(wQ': [],
-   '0)G&31': False,
-   '7': [],
-   'C.i]A-I': {':?Xh>[;': None,
-               'YHT\r!\x0b': -6.801160220000663e+18,
-  ...
-  >>> pprint(json.example())
-  [{"7_8'qyb": None,
+    >>> from string import printable; from pprint import pprint
+    >>> json = recursive(none() | booleans() | floats() | text(printable),
+    ... lambda children: lists(children) | dictionaries(text(printable), children))
+    >>> pprint(json.example())
+    {'': 'Me$',
+    "\r5qPZ%etF:vL'9gC": False,
+    '$KsT(( J/(wQ': [],
+    '0)G&31': False,
+    '7': [],
+    'C.i]A-I': {':?Xh>[;': None,
+                'YHT\r!\x0b': -6.801160220000663e+18,
+    ...
+    >>> pprint(json.example())
+    [{"7_8'qyb": None,
     ':': -0.3641507440748771,
     'TI_^\n>L{T\x0c': -0.0,
     'ZiOqQ\t': 'RKT*a]IjI/Zx2HB4ODiSUN)LsZ',
     'n;E^^6|9=@g@@BmAi': '7j5\\'},
-   True]
-  >>> pprint(json.example())
-  []
+    True]
+    >>> pprint(json.example())
+    []
 
 That is, we start with our leaf data and then we augment it by allowing lists and dictionaries of anything we can generate as JSON data.
 
@@ -182,13 +182,13 @@ we wanted to only generate really small JSON we could do this as:
 
 .. doctest::
 
-  >>> small_lists = recursive(booleans(), lists, max_leaves=5)
-  >>> small_lists.example()
-  True
-  >>> small_lists.example()
-  [True, False]
-  >>> small_lists.example()
-  True
+    >>> small_lists = recursive(booleans(), lists, max_leaves=5)
+    >>> small_lists.example()
+    True
+    >>> small_lists.example()
+    [True, False]
+    >>> small_lists.example()
+    True
 
 .. _composite-strategies:
 

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -84,8 +84,7 @@ you wanted pairs of integers (x,y) such that x < y you could do the following:
 
 .. doctest::
 
-    >>> tuples(integers(), integers()).map(
-    ... lambda x: tuple(sorted(x))).filter(lambda x: x[0] != x[1]).example()
+    >>> tuples(integers(), integers()).map(sorted).filter(lambda x: x[0] < x[1]).example()
     (180, 241)
 
 .. _flatmap:

--- a/docs/details.rst
+++ b/docs/details.rst
@@ -279,17 +279,17 @@ If you want to see exactly what a strategy produces you can ask for an example:
 
 .. doctest::
 
-  >>> integers(min_value=0, max_value=10).example()
-  5
+    >>> integers(min_value=0, max_value=10).example()
+    5
 
 Many strategies are built out of other strategies. For example, if you want
 to define a tuple you need to say what goes in each element:
 
 .. doctest::
 
-  >>> from hypothesis.strategies import tuples
-  >>> tuples(integers(), integers()).example()
-  (50, 15)
+    >>> from hypothesis.strategies import tuples
+    >>> tuples(integers(), integers()).example()
+    (50, 15)
 
 Further details are :doc:`available in a separate document <data>`.
 
@@ -455,14 +455,14 @@ experimenting with conditions for filtering data.
 
 .. doctest::
 
-  >>> from hypothesis import find
-  >>> from hypothesis.strategies import sets, lists, integers
-  >>> find(lists(integers()), lambda x: sum(x) >= 10)
-  [10]
-  >>> find(lists(integers()), lambda x: sum(x) >= 10 and len(x) >= 3)
-  [0, 0, 10]
-  >>> find(sets(integers()), lambda x: sum(x) >= 10 and len(x) >= 3)
-  {0, 1, 9}
+    >>> from hypothesis import find
+    >>> from hypothesis.strategies import sets, lists, integers
+    >>> find(lists(integers()), lambda x: sum(x) >= 10)
+    [10]
+    >>> find(lists(integers()), lambda x: sum(x) >= 10 and len(x) >= 3)
+    [0, 0, 10]
+    >>> find(sets(integers()), lambda x: sum(x) >= 10 and len(x) >= 3)
+    {0, 1, 9}
 
 The first argument to :func:`~hypothesis.find` describes data in the usual way for an argument to
 :func:`~hypothesis.given`, and supports :doc:`all the same data types <data>`. The second is a
@@ -473,10 +473,10 @@ example to a condition that is always false it will raise an error:
 
 .. doctest::
 
-  >>> find(integers(), lambda x: False)
-  Traceback (most recent call last):
-  ...
-  hypothesis.errors.NoSuchExample: No examples of condition lambda x: <unknown>
+    >>> find(integers(), lambda x: False)
+    Traceback (most recent call last):
+        ...
+    hypothesis.errors.NoSuchExample: No examples of condition lambda x: <unknown>
 
 (The ``lambda x: unknown`` is because Hypothesis can't retrieve the source code
 of lambdas from the interactive python console. It gives a better error message

--- a/docs/details.rst
+++ b/docs/details.rst
@@ -280,7 +280,7 @@ If you want to see exactly what a strategy produces you can ask for an example:
 .. doctest::
 
     >>> integers(min_value=0, max_value=10).example()
-    5
+    9
 
 Many strategies are built out of other strategies. For example, if you want
 to define a tuple you need to say what goes in each element:
@@ -289,7 +289,7 @@ to define a tuple you need to say what goes in each element:
 
     >>> from hypothesis.strategies import tuples
     >>> tuples(integers(), integers()).example()
-    (50, 15)
+    (-85296636193678268231691518597782489127, 68871684356256783618296489618877951982)
 
 Further details are :doc:`available in a separate document <data>`.
 
@@ -562,7 +562,7 @@ argument, to force this inference for arguments with a default value.
     >>> def func(a: int, b: str):
     ...     return [a, b]
     >>> builds(func).example()
-    [2132, 'jZFN;']
+    [72627971792323936471739212691379790782, '']
 
 :func:`@given <hypothesis.given>` does not perform any implicit inference
 for required arguments, as this would break compatibility with pytest fixtures.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -164,13 +164,13 @@ also override them locally by using a settings object as a :ref:`context manager
 
 .. doctest::
 
-  >>> with settings(max_examples=150):
-  ...     print(settings.default.max_examples)
-  ...     print(settings().max_examples)
-  150
-  150
-  >>> settings().max_examples
-  200
+    >>> with settings(max_examples=150):
+    ...     print(settings.default.max_examples)
+    ...     print(settings().max_examples)
+    150
+    150
+    >>> settings().max_examples
+    200
 
 Note that after the block exits the default is returned to normal.
 
@@ -225,10 +225,10 @@ specific tests.
 
 .. doctest::
 
-  >>> with settings.get_profile("ci"):
-  ...     print(settings().max_examples)
-  ...
-  1000
+    >>> with settings.get_profile("ci"):
+    ...     print(settings().max_examples)
+    ...
+    1000
 
 Optionally, you may define the environment variable to load a profile for you.
 This is the suggested pattern for running your tests on CI.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -90,9 +90,34 @@ and :func:`@given <hypothesis.given>`.
     >>> from hypothesis import find, settings, Verbosity
     >>> from hypothesis.strategies import lists, booleans
     >>> find(lists(integers()), any, settings=settings(verbosity=Verbosity.verbose))
-    Found satisfying example [-208]
-    Shrunk example to [-208]
-    Shrunk example to [208]
+    Trying example []
+    Found satisfying example [-106641080167757791735701986170810016341,
+     -129665482689688858331316879188241401294,
+     -17902751879921353864928802351902980929,
+     86547910278013668694989468221154862503,
+     99789676068743906931733548810810835946,
+     -56833685188912180644827795048092269385,
+     -12891126493032945632804716628985598019,
+     57797823215504994933565345605235342532,
+     98214819714866425575119206029702237685]
+    Shrunk example to [-106641080167757791735701986170810016341,
+     -129665482689688858331316879188241401294,
+     -17902751879921353864928802351902980929,
+     86547910278013668694989468221154862503,
+     99789676068743906931733548810810835946,
+     -56833685188912180644827795048092269385,
+     -12891126493032945632804716628985598019,
+     57797823215504994933565345605235342532,
+     98214819714866425575119206029702237685]
+    Shrunk example to [-106641080167757791735701986170810016341,
+     -129665482689688858331316879188241401294,
+     -17902751879921353864928802351902980929,
+     86547910278013668694989468221154862503]
+    Shrunk example to [-106641080167757791735701986170810016341,
+     164695784672172929935660921670478470673]
+    Shrunk example to [164695784672172929935660921670478470673]
+    Shrunk example to [164695784672172929935660921670478470673]
+    Shrunk example to [164695784672172929935660921670478470673]
     Shrunk example to [1]
     [1]
 
@@ -127,7 +152,7 @@ values. Any absent ones will be set to defaults:
              strict=False, suppress_health_check=(), timeout=60,
              use_coverage=True, verbosity=Verbosity.normal)
     >>> settings().max_examples
-    200
+    100
     >>> settings(max_examples=10).max_examples
     10
 
@@ -171,7 +196,7 @@ also override them locally by using a settings object as a :ref:`context manager
     150
     150
     >>> settings().max_examples
-    200
+    100
 
 Note that after the block exits the default is returned to normal.
 
@@ -216,7 +241,7 @@ of tests that explicitly change the settings.
     >>> from hypothesis import settings
     >>> settings.register_profile("ci", settings(max_examples=1000))
     >>> settings().max_examples
-    200
+    100
     >>> settings.load_profile("ci")
     >>> settings().max_examples
     1000

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -120,11 +120,12 @@ values. Any absent ones will be set to defaults:
 
     >>> from hypothesis import settings
     >>> settings()  # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
-    settings(buffer_size=8192, database_file='...', derandomize=False,
-             max_examples=100, max_iterations=1000,
-             max_shrinks=500, min_satisfying_examples=5, perform_health_check=True,
-             phases=..., report_statistics=..., stateful_step_count=50, strict=...,
-             suppress_health_check=[], timeout=60, verbosity=Verbosity.normal)
+    settings(buffer_size=8192, database_file='...', deadline=not_set,
+             derandomize=True, max_examples=100, max_iterations=1000,
+             max_shrinks=500, min_satisfying_examples=5,
+             perform_health_check=True, phases=(...), stateful_step_count=50,
+             strict=False, suppress_health_check=(), timeout=60,
+             use_coverage=True, verbosity=Verbosity.normal)
     >>> settings().max_examples
     200
     >>> settings(max_examples=10).max_examples

--- a/guides/documentation.rst
+++ b/guides/documentation.rst
@@ -66,3 +66,17 @@ the repository root, and:
   "Thanks to <your name> for this bug fix / feature / contribution"
   (depending on which it is).  If this is your first contribution,
   don't forget to add yourself to contributors.rst!
+
+
+-----------------
+Updating Doctests
+-----------------
+
+We use the Sphinx `doctest` builder to ensure that all example code snippets
+are kept up to date.  To make this less tedious, you can run
+``scripts/fix_doctests.py`` (under Python 3) to... fix failing doctests.
+
+The script is pretty good, but doesn't handle ``+ELLIPSIS`` or
+``+NORMALIZE_WHITESPACE`` options.  Check that output is stable (running
+it again should give "All doctests are OK"), then review the diff before
+committing.

--- a/scripts/fix_doctests.py
+++ b/scripts/fix_doctests.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2017 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import os
+import re
+import sys
+from subprocess import PIPE, run
+from collections import defaultdict
+
+import hypothesistooling as tools
+
+
+class FailingExample(object):
+
+    def __init__(self, chunk):
+        """Turn a chunk of text into an object representing the test."""
+        location, *lines = [l + '\n' for l in chunk.split('\n') if l.strip()]
+        self.location = location.strip()
+        pattern = 'File "(.+?)", line (\d+?), in .+'
+        file, line = re.match(pattern, self.location).groups()
+        self.file = os.path.join('docs', file)
+        self.line = int(line) + 1
+        got = lines.index('Got:\n')
+        self.expected_lines = lines[lines.index('Expected:\n') + 1:got]
+        self.got_lines = lines[got + 1:]
+        self.checked_ok = None
+        self.adjust()
+
+    @property
+    def indices(self):
+        return slice(self.line, self.line + len(self.expected_lines))
+
+    def adjust(self):
+        with open(self.file) as f:
+            lines = f.readlines()
+        # The raw line number is the first line of *input*, so adjust to
+        # first line of output by skipping lines which start with a prompt
+        while self.line < len(lines):
+            if lines[self.line].strip()[:4] not in ('>>> ', '... '):
+                break
+            self.line += 1
+        # Sadly the filename and line number for doctests in docstrings is
+        # wrong - see https://github.com/sphinx-doc/sphinx/issues/4223
+        # Luckily, we can just cheat because they're all in one file for now!
+        # (good luck if this changes without an upstream fix...)
+        if lines[self.indices] != self.expected_lines:
+            self.file = 'src/hypothesis/strategies.py'
+            with open(self.file) as f:
+                lines = f.readlines()
+            self.line = 0
+            while self.expected_lines[0] in lines:
+                self.line = lines[self.line:].index(self.expected_lines[0])
+                if lines[self.indices] == self.expected_lines:
+                    break
+        # Finally, set the flag for location quality
+        self.checked_ok = lines[self.indices] == self.expected_lines
+
+    def __repr__(self):
+        return '{}\nExpected: {!r:.60}\nGot:      {!r:.60}'.format(
+            self.location, self.expected, self.got)
+
+
+def get_doctest_output():
+    # Return a dict of filename: list of examples, sorted from last to first
+    # so that replacing them in sequence works
+    command = run(['sphinx-build', '-b', 'doctest', 'docs', 'docs/_build'],
+                  stdout=PIPE, stderr=PIPE, encoding='utf-8')
+    output = [FailingExample(c) for c in command.stdout.split('*' * 70)
+              if c.strip().startswith('File "')]
+    if not all(ex.checked_ok for ex in output):
+        broken = '\n'.join(ex.location for ex in output if not ex.checked_ok)
+        print('Could not find some tests:\n' + broken)
+        sys.exit(1)
+    tests = defaultdict(set)
+    for ex in output:
+        tests[ex.file].add(ex)
+    return {fname: sorted(examples, key=lambda x: x.line, reverse=True)
+            for fname, examples in tests.items()}
+
+
+def main():
+    os.chdir(tools.ROOT)
+    failing = get_doctest_output()
+    if not failing:
+        print('All doctests are OK')
+        sys.exit(0)
+    if tools.has_uncommitted_changes('.'):
+        print('Cannot fix doctests in place with uncommited changes')
+        sys.exit(1)
+
+    for fname, examples in failing.items():
+        with open(fname) as f:
+            lines = f.readlines()
+        for ex in examples:
+            lines[ex.indices] = ex.got_lines
+        with open(fname, 'w') as f:
+            f.writelines(lines)
+
+    still_failing = get_doctest_output()
+    if still_failing:
+        print('Fixes failed: script broken or flaky tests.\n', still_failing)
+        sys.exit(1)
+    print('All failing doctests have been fixed.')
+    sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -1671,18 +1671,18 @@ def deferred(definition):
     >>> import hypothesis.strategies as st
     >>> x = st.deferred(lambda: st.booleans() | st.tuples(x, x))
     >>> x.example()
-    (False, (False, True))
+    (((False, (True, True)), (False, True)), (True, True))
     >>> x.example()
-    True
+    (True, True)
 
     Mutual recursion also works fine:
 
     >>> a = st.deferred(lambda: st.booleans() | b)
     >>> b = st.deferred(lambda: st.tuples(a, a))
     >>> a.example()
-    (((True, True), False), True)
+    (True, (True, False))
     >>> b.example()
-    (((( False, ((True, False), (True, True))), True), False), True)
+    (False, True)
 
     """
     from hypothesis.searchstrategy.deferred import DeferredStrategy


### PR DESCRIPTION
Closes #711, via a series of terrible hacks that work well enough for now (see comments in source, or just read source, for details).  Notably there are some not-too-rare cases that are not covered; but as an aid to manual updates I think it's good enough - I certainly don't want to spend longer writing it than is saved by its use!