### PR TITLE
Support version argument for uuids strategy

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -170,6 +170,7 @@ their individual contributions.
 * `Cristi Cobzarenco <https://github.com/cristicbz>`_ (cristi@reinfer.io)
 * `David Bonner <https://github.com/rascalking>`_ (dbonner@gmail.com)
 * `Derek Gustafson <https://www.github.com/degustaf>`_
+* `Dion Misic <https://www.github.com/kingdion>`_ (dion.misic@gmail.com)
 * `Florian Bruhin <https://www.github.com/The-Compiler>`_
 * `follower <https://www.github.com/follower>`_
 * `Jeremy Thurgood <https://github.com/jerith>`_

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: minor
+
+This minor release supports constraining :func:`~hypothesis.strategies.uuids`
+to generate :class:`~python:uuid.UUID`s of a particular version.
+(:issue:`721`)
+
+Thanks to Dion Misic for this feature.

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -1511,16 +1511,25 @@ def choices():
 
 @cacheable
 @defines_strategy_with_reusable_values
-def uuids():
+def uuids(version=None):
     """Returns a strategy that generates :class:`UUIDs <uuid.UUID>`.
+
+    If the optional version argument is given, value is passed through
+    to :class:`~python:uuid.UUID` and only UUIDs of that version will
+    be generated.
 
     All returned values from this will be unique, so e.g. if you do
     ``lists(uuids())`` the resulting list will never contain duplicates.
 
     """
     from uuid import UUID
+    if version not in (None, 1, 2, 3, 4, 5):
+        raise InvalidArgument((
+            'version=%r, but version must be in (None, 1, 2, 3, 4, 5) '
+            'to pass to the uuid.UUID constructor.') % (version, )
+        )
     return shared(randoms(), key='hypothesis.strategies.uuids.generator').map(
-        lambda r: UUID(int=r.getrandbits(128))
+        lambda r: UUID(version=version, int=r.getrandbits(128))
     )
 
 

--- a/tests/cover/test_direct_strategies.py
+++ b/tests/cover/test_direct_strategies.py
@@ -139,6 +139,7 @@ def fn_ktest(*fnkwargs):
     (ds.times, {
         'min_value': time(2, 0),
         'max_value': time(1, 0)}),
+    (ds.uuids, {'version': 6}),
 )
 def test_validates_keyword_arguments(fn, kwargs):
     with pytest.raises(InvalidArgument):

--- a/tests/cover/test_uuids.py
+++ b/tests/cover/test_uuids.py
@@ -17,6 +17,8 @@
 
 from __future__ import division, print_function, absolute_import
 
+import pytest
+
 import hypothesis.strategies as st
 from hypothesis import find, given
 
@@ -30,3 +32,12 @@ def test_are_unique(ls):
 def test_retains_uniqueness_in_simplify(ls, rnd):
     ts = find(st.lists(st.uuids()), lambda x: len(x) >= 5, random=rnd)
     assert len(ts) == len(set(ts)) == 5
+
+
+@pytest.mark.parametrize('version', (1, 2, 3, 4, 5))
+def test_can_generate_specified_version(version):
+    @given(st.uuids(version=version))
+    def inner(uuid):
+        assert version == uuid.version
+
+    inner()


### PR DESCRIPTION
Closes #721 by adding a `version` argument for `hypothesis.strategies.uuids`, which is passed through to the UUIDs constructor.