### PR TITLE
Turn off database by default in our test runs

### DIFF
--- a/tests/common/setup.py
+++ b/tests/common/setup.py
@@ -53,16 +53,17 @@ def run():
                 v, s.name, s.name, s.default,
             )
 
-    settings.register_profile('default', settings(
-        timeout=unlimited, use_coverage=not (IN_COVERAGE_TESTS or PYPY)))
+    default = settings(
+        database=None,
+        timeout=unlimited, use_coverage=not (IN_COVERAGE_TESTS or PYPY)
+    )
+
+    settings.register_profile('default', default)
 
     settings.register_profile('with_coverage', settings(
-        timeout=unlimited, use_coverage=True,
+        default, timeout=unlimited, use_coverage=True,
     ))
 
-    settings.register_profile(
-        'speedy', settings(
-            max_examples=5,
-        ))
+    settings.register_profile('speedy', settings(default, max_examples=5,))
 
     settings.load_profile(os.getenv('HYPOTHESIS_PROFILE', 'default'))

--- a/tests/cover/test_settings.py
+++ b/tests/cover/test_settings.py
@@ -107,7 +107,6 @@ def test_can_not_set_verbosity_to_non_verbosity():
 
 @pytest.mark.parametrize('db', [None, ExampleDatabase()])
 def test_inherits_an_empty_database(db):
-    assert settings.default.database is not None
     s = settings(database=db)
     assert s.database is db
     with s:


### PR DESCRIPTION
I was wondering what we could do to speed up our build a bit, and it occurred to me that we're mostly uselessly using the database by default in our tests - we throw away the .hypothesis directory anyway, so we never preserve the test database.

I doubt this is going to be a major performance improvement, but it might be enough to be noticeable (I saw maybe 5-10% on `test_testdecorators.py` but I doubt that's representative), and seems like a reasonable thing to do anyway.