### PR TITLE
Always escalate exceptions in data generation

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -12,8 +12,8 @@ The following are now deprecated:
 * Passing :attr:`~hypothesis.HealthCheck.random_module` to
   :attr:`~hypothesis.settings.suppress_health_check`. This hasn't done anything
   for a long time, but was never explicitly deprecated. Hypothesis always seeds
-  the random module when running tests, so this is no longer an error and
-  suppressing it doesn't do anything.
+  the random module when running @given tests, so this is no longer an error
+  and suppressing it doesn't do anything.
 * Passing non-:class:`~hypothesis.HealthCheck` values in
   :attr:`~hypothesis.settings.suppress_health_check`. This was previously
   allowed but never did anything useful.

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,25 @@
+RELEASE_TYPE: minor
+
+This is a deprecation release for some health check related features.
+
+The following are now deprecated:
+
+* Passing :attr:`~hypothesis.HealthCheck.exception_in_generation` to
+  :attr:`~hypothesis.settings.suppress_health_check`. This no longer does
+  anything even when passed -  All errors that occur during data generation
+  will now be immediately reraised rather than going through the health check
+  mechanism.
+* Passing :attr:`~hypothesis.HealthCheck.random_module` to
+  :attr:`~hypothesis.settings.suppress_health_check`. This hasn't done anything
+  for a long time, but was never explicitly deprecated. Hypothesis always seeds
+  the random module when running tests, so this is no longer an error and
+  suppressing it doesn't do anything.
+* Passing non-:class:`~hypothesis.HealthCheck` values in
+  :attr:`~hypothesis.settings.suppress_health_check`. This was previously
+  allowed but never did anything useful.
+
+In addition, passing a non-iterable value as :attr:`~hypothesis.settings.suppress_health_check`
+will now raise an error immediately (it would never have worked correctly, but
+it would previously have failed later).
+
+This work was funded by `Smarkets <https://smarkets.com/>`_.

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -20,6 +20,7 @@ The following are now deprecated:
 
 In addition, passing a non-iterable value as :attr:`~hypothesis.settings.suppress_health_check`
 will now raise an error immediately (it would never have worked correctly, but
-it would previously have failed later).
+it would previously have failed later). Some validation error messages have
+also been updated.
 
 This work was funded by `Smarkets <https://smarkets.com/>`_.

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -48,7 +48,7 @@ e.g.:
 Note that many things that you might use mapping for can also be done with
 :func:`~hypothesis.strategies.builds`.
 
-.. _filter
+.. _filtering:
 
 ---------
 Filtering

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -48,6 +48,8 @@ e.g.:
 Note that many things that you might use mapping for can also be done with
 :func:`~hypothesis.strategies.builds`.
 
+.. _filter
+
 ---------
 Filtering
 ---------

--- a/docs/healthchecks.rst
+++ b/docs/healthchecks.rst
@@ -23,3 +23,8 @@ the class-level attributes of the HealthCheck class.
 
 To disable all health checks, set the perform_health_check settings parameter
 to False.
+
+.. module:: hypothesis
+.. autoclass:: HealthCheck
+   :undoc-members:
+   :inherited-members:

--- a/src/hypothesis/_settings.py
+++ b/src/hypothesis/_settings.py
@@ -490,7 +490,7 @@ class HealthCheck(Enum):
 
     exception_in_generation = 0
     """Deprecated and no longer does anything. It used to convert errors in
-    data generation into FailedHealthCheck error"""
+    data generation into FailedHealthCheck error."""
 
     data_too_large = 1
     """Check for when the typical size of the examples you are generating
@@ -498,8 +498,8 @@ class HealthCheck(Enum):
 
     filter_too_much = 2
     """Check for when the test is filtering out too many examples, either
-    through use of :func:`~hypothesis.assume()` or `filter() <_filter>`, or
-    occasionally for Hypothesis internal reasons."""
+    through use of :func:`~hypothesis.assume()` or :ref:`filter() <filtering>`,
+    or occasionally for Hypothesis internal reasons."""
 
     too_slow = 3
     """Check for when your data generation is extremely slow and likely to hurt
@@ -642,7 +642,7 @@ def validate_health_check_suppressions(suppressions):
         ):
             note_deprecation((
                 '%s is now ignored and suppressing it is a no-op. This will '
-                'become an error in a fugure version of Hypothesis. Simply '
+                'become an error in a future version of Hypothesis. Simply '
                 'remove it from your list of suppressions to get the same '
                 'effect.') % (s,))
     return suppressions

--- a/src/hypothesis/_settings.py
+++ b/src/hypothesis/_settings.py
@@ -35,6 +35,7 @@ import attr
 from hypothesis.errors import InvalidArgument, HypothesisDeprecationWarning
 from hypothesis.configuration import hypothesis_home_dir
 from hypothesis.utils.conventions import UniqueIdentifier, not_set
+from hypothesis.internal.validation import try_convert
 from hypothesis.utils.dynamicvariables import DynamicVariable
 
 __all__ = [
@@ -481,13 +482,42 @@ class Phase(IntEnum):
 
 @unique
 class HealthCheck(Enum):
+    """Classes of health check that Hypothesis performs, for use in.
+
+    :attr:`~hypothesis.settings.suppress_health_check`
+
+    """
+
     exception_in_generation = 0
+    """Deprecated and no longer does anything. It used to convert errors in
+    data generation into FailedHealthCheck error"""
+
     data_too_large = 1
+    """Check for when the typical size of the examples you are generating
+    exceeds the configured maximum size too often. You may wish to raise
+    :attr:`~hypothesis.settings.buffer_size` in preference to supppressing this
+    health check."""
+
     filter_too_much = 2
+    """Check for when the test is filtering out too many examples, either
+    through use of assume() or filter(), or occasionally for Hypothesis
+    internal reasons."""
+
     too_slow = 3
+    """Check for when your data generation is extremely slow and likely to hurt
+    testing."""
+
     random_module = 4
+    """Deprecated and no longer does anything. It used to check for whether
+    your tests used the global random module. Now tests automatically seed
+    random so this is no longer an error."""
+
     return_value = 5
+    """Checks if your tests return a non-None value (which will be ignored and
+    is unlikely to do what you want."""
+
     hung_test = 6
+    """Checks if your tests have been running for a very long time."""
 
 
 @unique
@@ -598,10 +628,32 @@ attempting to actually execute your test.
 """
 )
 
+
+def validate_health_check_suppressions(suppressions):
+    suppressions = try_convert(list, suppressions, 'suppress_health_check')
+    for s in suppressions:
+        if not isinstance(s, HealthCheck):
+            note_deprecation((
+                'Non-HealthCheck value %r of type %s in suppress_health_check '
+                'will be ignored, and will become an error in a future '
+                'version of Hypothesis') % (
+                s, type(s).__name__,
+            ))
+        elif s in (
+            HealthCheck.exception_in_generation, HealthCheck.random_module
+        ):
+            note_deprecation((
+                '%s is now ignored and suppressing it is a no-op. Simply '
+                'remove it from your list of suppressions to get the same '
+                'effect.') % (s,))
+    return suppressions
+
+
 settings.define_setting(
     'suppress_health_check',
-    default=[],
-    description="""A list of health checks to disable."""
+    default=(),
+    description="""A list of health checks to disable.""",
+    validator=validate_health_check_suppressions
 )
 
 settings.define_setting(

--- a/src/hypothesis/_settings.py
+++ b/src/hypothesis/_settings.py
@@ -484,7 +484,7 @@ class Phase(IntEnum):
 class HealthCheck(Enum):
     """Arguments for :attr:`~hypothesis.settings.suppress_health_check`.
 
-    Each member of this enum is a type of health check to supppress.
+    Each member of this enum is a type of health check to suppress.
 
     """
 
@@ -512,7 +512,7 @@ class HealthCheck(Enum):
 
     return_value = 5
     """Checks if your tests return a non-None value (which will be ignored and
-    is unlikely to do what you want."""
+    is unlikely to do what you want)."""
 
     hung_test = 6
     """Checks if your tests have been running for a very long time."""

--- a/src/hypothesis/_settings.py
+++ b/src/hypothesis/_settings.py
@@ -498,8 +498,8 @@ class HealthCheck(Enum):
 
     filter_too_much = 2
     """Check for when the test is filtering out too many examples, either
-    through use of assume() or filter(), or occasionally for Hypothesis
-    internal reasons."""
+    through use of :func:`~hypothesis.assume()` or `filter() <_filter>`, or
+    occasionally for Hypothesis internal reasons."""
 
     too_slow = 3
     """Check for when your data generation is extremely slow and likely to hurt
@@ -641,7 +641,8 @@ def validate_health_check_suppressions(suppressions):
             HealthCheck.exception_in_generation, HealthCheck.random_module
         ):
             note_deprecation((
-                '%s is now ignored and suppressing it is a no-op. Simply '
+                '%s is now ignored and suppressing it is a no-op. This will '
+                'become an error in a fugure version of Hypothesis. Simply '
                 'remove it from your list of suppressions to get the same '
                 'effect.') % (s,))
     return suppressions

--- a/src/hypothesis/_settings.py
+++ b/src/hypothesis/_settings.py
@@ -507,8 +507,8 @@ class HealthCheck(Enum):
 
     random_module = 4
     """Deprecated and no longer does anything. It used to check for whether
-    your tests used the global random module. Now tests automatically seed
-    random so this is no longer an error."""
+    your tests used the global random module. Now @given tests automatically
+    seed random so this is no longer an error."""
 
     return_value = 5
     """Checks if your tests return a non-None value (which will be ignored and

--- a/src/hypothesis/_settings.py
+++ b/src/hypothesis/_settings.py
@@ -482,9 +482,9 @@ class Phase(IntEnum):
 
 @unique
 class HealthCheck(Enum):
-    """Classes of health check that Hypothesis performs, for use in.
+    """Arguments for :attr:`~hypothesis.settings.suppress_health_check`.
 
-    :attr:`~hypothesis.settings.suppress_health_check`
+    Each member of this enum is a type of health check to supppress.
 
     """
 
@@ -494,9 +494,7 @@ class HealthCheck(Enum):
 
     data_too_large = 1
     """Check for when the typical size of the examples you are generating
-    exceeds the configured maximum size too often. You may wish to raise
-    :attr:`~hypothesis.settings.buffer_size` in preference to supppressing this
-    health check."""
+    exceeds the maximum allowed size too often."""
 
     filter_too_much = 2
     """Check for when the test is filtering out too many examples, either

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -41,8 +41,7 @@ from hypothesis.control import BuildContext
 from hypothesis._settings import settings as Settings
 from hypothesis._settings import Phase, Verbosity, HealthCheck, \
     note_deprecation
-from hypothesis.executors import new_style_executor, \
-    default_new_style_executor
+from hypothesis.executors import new_style_executor
 from hypothesis.reporting import report, verbose_report, current_verbosity
 from hypothesis.statistics import note_engine_for_statistics
 from hypothesis.internal.compat import ceil, str_to_bytes, \
@@ -323,7 +322,7 @@ def perform_health_checks(random, settings, test_runner, search_strategy):
                 lambda *args, **kwargs: None,
             ))
         except BaseException:
-            pass
+            escalate_hypothesis_internal_error()
     count = 0
     overruns = 0
     filtered_draws = 0
@@ -353,39 +352,7 @@ def perform_health_checks(random, settings, test_runner, search_strategy):
                 overruns += 1
         except InvalidArgument:
             raise
-        except Exception:
-            escalate_hypothesis_internal_error()
-            if (
-                HealthCheck.exception_in_generation in
-                settings.suppress_health_check
-            ):
-                raise
-            report(traceback.format_exc())
-            if test_runner is default_new_style_executor:
-                fail_health_check(
-                    settings,
-                    'An exception occurred during data '
-                    'generation in initial health check. '
-                    'This indicates a bug in the strategy. '
-                    'This could either be a Hypothesis bug or '
-                    "an error in a function you've passed to "
-                    'it to construct your data.',
-                    HealthCheck.exception_in_generation,
-                )
-            else:
-                fail_health_check(
-                    settings,
-                    'An exception occurred during data '
-                    'generation in initial health check. '
-                    'This indicates a bug in the strategy. '
-                    'This could either be a Hypothesis bug or '
-                    'an error in a function you\'ve passed to '
-                    'it to construct your data. Additionally, '
-                    'you have a custom executor, which means '
-                    'that this could be your executor failing '
-                    'to handle a function which returns None. ',
-                    HealthCheck.exception_in_generation,
-                )
+
     if overruns >= 20 or (
         not count and overruns > 0
     ):

--- a/src/hypothesis/errors.py
+++ b/src/hypothesis/errors.py
@@ -202,3 +202,10 @@ class DeadlineExceeded(HypothesisException):
             '%.2fms') % (runtime, deadline))
         self.runtime = runtime
         self.deadline = deadline
+
+
+class StopTest(BaseException):
+
+    def __init__(self, testcounter):
+        super(StopTest, self).__init__(repr(testcounter))
+        self.testcounter = testcounter

--- a/src/hypothesis/extra/pandas/impl.py
+++ b/src/hypothesis/extra/pandas/impl.py
@@ -31,6 +31,7 @@ from hypothesis.errors import InvalidArgument
 from hypothesis.control import reject
 from hypothesis.internal.compat import hrange
 from hypothesis.internal.coverage import check, check_function
+from hypothesis.internal.validation import check_valid_size
 
 try:
     from pandas.api.types import is_categorical_dtype
@@ -156,8 +157,8 @@ def range_indexes(min_size=0, max_size=None):
       it will default to some suitable value based on min_size.
 
     """
-    st.check_valid_size(min_size, 'min_size')
-    st.check_valid_size(max_size, 'max_size')
+    check_valid_size(min_size, 'min_size')
+    check_valid_size(max_size, 'max_size')
     if max_size is None:
         max_size = min([min_size + DEFAULT_MAX_SIZE, 2 ** 63 - 1])
     st.check_valid_interval(min_size, max_size, 'min_size', 'max_size')
@@ -189,8 +190,8 @@ def indexes(
       should be distinct.
 
     """
-    st.check_valid_size(min_size, 'min_size')
-    st.check_valid_size(max_size, 'max_size')
+    check_valid_size(min_size, 'min_size')
+    check_valid_size(max_size, 'max_size')
     st.check_valid_interval(min_size, max_size, 'min_size', 'max_size')
     st.check_type(bool, unique, 'unique')
 

--- a/src/hypothesis/internal/validation.py
+++ b/src/hypothesis/internal/validation.py
@@ -104,9 +104,9 @@ def check_valid_size(value, name):
         return
     check_type(integer_types + (float,), value)
     if value < 0:
-        raise InvalidArgument(u'Invalid size %s %r < 0' % (value, name))
+        raise InvalidArgument(u'Invalid size %s=%r < 0' % (name, value))
     if isinstance(value, float) and math.isnan(value):
-        raise InvalidArgument(u'Invalid size %s %r' % (value, name))
+        raise InvalidArgument(u'Invalid size %s=%r' % (name, value))
 
 
 @check_function
@@ -141,6 +141,6 @@ def check_valid_sizes(min_size, average_size, max_size):
             average_size is not None and average_size <= 0.0
         ):
             raise InvalidArgument(
-                'Cannot have average_size=%r < min_size=%r' % (
+                'Cannot have average_size=%r with non-zero max_size=%r' % (
                     average_size, min_size
                 ))

--- a/src/hypothesis/internal/validation.py
+++ b/src/hypothesis/internal/validation.py
@@ -1,0 +1,146 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2017 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import math
+from numbers import Rational
+
+from hypothesis.errors import InvalidArgument
+from hypothesis.internal.compat import integer_types
+from hypothesis.internal.coverage import check_function
+
+
+@check_function
+def check_type(typ, arg, name=''):
+    if name:
+        name += '='
+    if not isinstance(arg, typ):
+        if isinstance(typ, type):
+            typ_string = typ.__name__
+        else:
+            typ_string = 'one of %s' % (
+                ', '.join(t.__name__ for t in typ))
+        raise InvalidArgument('Expected %s but got %s%r (type=%s)'
+                              % (typ_string, name, arg, type(arg).__name__))
+
+
+@check_function
+def check_strategy(arg, name=''):
+    from hypothesis.searchstrategy import SearchStrategy
+    check_type(SearchStrategy, arg, name)
+
+
+@check_function
+def check_valid_integer(value):
+    """Checks that value is either unspecified, or a valid integer.
+
+    Otherwise raises InvalidArgument.
+
+    """
+    if value is None:
+        return
+    check_type(integer_types, value)
+
+
+@check_function
+def check_valid_bound(value, name):
+    """Checks that value is either unspecified, or a valid interval bound.
+
+    Otherwise raises InvalidArgument.
+
+    """
+    if value is None or isinstance(value, integer_types + (Rational,)):
+        return
+    if math.isnan(value):
+        raise InvalidArgument(u'Invalid end point %s=%r' % (name, value))
+
+
+@check_function
+def try_convert(typ, value, name):
+    if value is None:
+        return None
+    if isinstance(value, typ):
+        return value
+    try:
+        return typ(value)
+    except TypeError:
+        raise InvalidArgument(
+            'Cannot convert %s=%r of type %s to type %s' % (
+                name, value, type(value).__name__, typ.__name__
+            )
+        )
+    except (OverflowError, ValueError):
+        raise InvalidArgument(
+            'Cannot convert %s=%r to type %s' % (
+                name, value, typ.__name__
+            )
+        )
+
+
+@check_function
+def check_valid_size(value, name):
+    """Checks that value is either unspecified, or a valid non-negative size
+    expressed as an integer/float.
+
+    Otherwise raises InvalidArgument.
+
+    """
+    if value is None:
+        return
+    check_type(integer_types + (float,), value)
+    if value < 0:
+        raise InvalidArgument(u'Invalid size %s %r < 0' % (value, name))
+    if isinstance(value, float) and math.isnan(value):
+        raise InvalidArgument(u'Invalid size %s %r' % (value, name))
+
+
+@check_function
+def check_valid_interval(lower_bound, upper_bound, lower_name, upper_name):
+    """Checks that lower_bound and upper_bound are either unspecified, or they
+    define a valid interval on the number line.
+
+    Otherwise raises InvalidArgument.
+
+    """
+    if lower_bound is None or upper_bound is None:
+        return
+    if upper_bound < lower_bound:
+        raise InvalidArgument(
+            'Cannot have %s=%r < %s=%r' % (
+                upper_name, upper_bound, lower_name, lower_bound
+            ))
+
+
+@check_function
+def check_valid_sizes(min_size, average_size, max_size):
+    check_valid_size(min_size, 'min_size')
+    check_valid_size(max_size, 'max_size')
+    check_valid_size(average_size, 'average_size')
+    check_valid_interval(min_size, max_size, 'min_size', 'max_size')
+    check_valid_interval(average_size, max_size, 'average_size', 'max_size')
+    check_valid_interval(min_size, average_size, 'min_size', 'average_size')
+
+    if average_size is not None:
+        if (
+            (max_size is None or max_size > 0) and
+            average_size is not None and average_size <= 0.0
+        ):
+            raise InvalidArgument(
+                'Cannot have average_size=%r < min_size=%r' % (
+                    average_size, min_size
+                ))

--- a/src/hypothesis/internal/validation.py
+++ b/src/hypothesis/internal/validation.py
@@ -135,12 +135,13 @@ def check_valid_sizes(min_size, average_size, max_size):
     check_valid_interval(average_size, max_size, 'average_size', 'max_size')
     check_valid_interval(min_size, average_size, 'min_size', 'average_size')
 
-    if average_size is not None:
-        if (
-            (max_size is None or max_size > 0) and
-            average_size is not None and average_size <= 0.0
-        ):
-            raise InvalidArgument(
-                'Cannot have average_size=%r with non-zero max_size=%r' % (
-                    average_size, min_size
-                ))
+    if (
+        average_size == 0 and (
+            max_size is None or
+            max_size > 0
+        )
+    ):
+        raise InvalidArgument(
+            'Cannot have average_size=%r with non-zero max_size=%r' % (
+                average_size, min_size
+            ))

--- a/tests/cover/test_health_checks.py
+++ b/tests/cover/test_health_checks.py
@@ -174,3 +174,8 @@ def test_noop_health_checks(check):
 def test_it_is_an_error_to_suppress_non_iterables():
     with raises(InvalidArgument):
         settings(suppress_health_check=1)
+
+
+@checks_deprecated_behaviour
+def test_is_is_deprecated_to_suppress_non_healthchecks():
+    settings(suppress_health_check=[1])

--- a/tests/cover/test_health_checks.py
+++ b/tests/cover/test_health_checks.py
@@ -19,14 +19,14 @@ from __future__ import division, print_function, absolute_import
 
 import time
 
+import pytest
 from pytest import raises
 
-import hypothesis.reporting as reporting
 import hypothesis.strategies as st
 from hypothesis import HealthCheck, given, settings
-from hypothesis.errors import FailedHealthCheck
+from hypothesis.errors import InvalidArgument, FailedHealthCheck
 from hypothesis.control import assume
-from tests.common.utils import capture_out
+from tests.common.utils import checks_deprecated_behaviour
 from hypothesis.internal.compat import int_from_bytes
 from hypothesis.searchstrategy.strategies import SearchStrategy
 
@@ -49,36 +49,6 @@ def test_default_health_check_can_weaken_specific():
 
     with settings(perform_health_check=False):
         test()
-
-
-def test_error_in_strategy_produces_health_check_error():
-    def boom(x):
-        raise ValueError()
-
-    @given(st.integers().map(boom))
-    def test(x):
-        pass
-
-    with raises(FailedHealthCheck) as e:
-        with reporting.with_reporter(reporting.default):
-            test()
-    assert 'executor' not in e.value.args[0]
-
-
-def test_suppressing_error_in_value_generation():
-    def boom(x):
-        raise ValueError()
-
-    @settings(suppress_health_check=[HealthCheck.exception_in_generation])
-    @given(st.integers().map(boom))
-    def test(x):
-        pass
-
-    with capture_out() as out:
-        with reporting.with_reporter(reporting.default):
-            with raises(ValueError):
-                test()
-    assert 'ValueError' not in out.getvalue()
 
 
 def test_suppressing_filtering_health_check():
@@ -105,25 +75,6 @@ def test_suppressing_filtering_health_check():
 
     with raises(ValueError):
         test2()
-
-
-def test_error_in_strategy_with_custom_executor():
-    def boom(x):
-        raise ValueError()
-
-    class Foo(object):
-
-        def execute_example(self, f):
-            return f()
-
-        @given(st.integers().map(boom))
-        @settings(database=None)
-        def test(self, x):
-            pass
-
-    with raises(FailedHealthCheck) as e:
-        Foo().test()
-    assert 'executor' in e.value.args[0]
 
 
 def test_filtering_everything_fails_a_health_check():
@@ -211,3 +162,15 @@ def test_returning_non_none_does_not_fail_if_health_check_disabled():
         return 1
 
     a()
+
+
+@pytest.mark.parametrize(
+    'check', [HealthCheck.random_module, HealthCheck.exception_in_generation])
+@checks_deprecated_behaviour
+def test_noop_health_checks(check):
+    settings(suppress_health_check=[check])
+
+
+def test_it_is_an_error_to_suppress_non_iterables():
+    with raises(InvalidArgument):
+        settings(suppress_health_check=1)

--- a/tests/cover/test_setup_teardown.py
+++ b/tests/cover/test_setup_teardown.py
@@ -19,8 +19,7 @@ from __future__ import division, print_function, absolute_import
 
 import pytest
 
-from hypothesis import given, assume, settings
-from hypothesis.errors import FailedHealthCheck
+from hypothesis import given, assume
 from hypothesis.strategies import text, integers
 
 
@@ -88,14 +87,6 @@ def test_calls_setup_and_teardown_on_failure():
     x = HasSetupAndTeardown()
     with pytest.raises(AssertionError):
         x.give_me_a_positive_int()
-    assert x.setups > 0
-    assert x.teardowns == x.setups
-
-
-def test_still_tears_down_on_failed_reify():
-    x = HasSetupAndTeardown()
-    with pytest.raises(AttributeError):
-        x.fail_in_reify()
     assert x.setups > 0
     assert x.teardowns == x.setups
 

--- a/tests/cover/test_setup_teardown.py
+++ b/tests/cover/test_setup_teardown.py
@@ -95,15 +95,14 @@ def test_calls_setup_and_teardown_on_failure():
 def test_still_tears_down_on_failed_reify():
     x = HasSetupAndTeardown()
     with pytest.raises(AttributeError):
-        with settings(perform_health_check=False):
-            x.fail_in_reify()
+        x.fail_in_reify()
     assert x.setups > 0
     assert x.teardowns == x.setups
 
 
-def test_still_tears_down_on_failed_health_check():
+def test_still_tears_down_on_error_in_generation():
     x = HasSetupAndTeardown()
-    with pytest.raises(FailedHealthCheck):
+    with pytest.raises(AttributeError):
         x.fail_in_reify()
     assert x.setups > 0
     assert x.teardowns == x.setups


### PR DESCRIPTION
As part of the Smarkets funded work I'm going to be doing a bunch of rationalisation and consolidation of the health check code. This is the first casualty of that work - getting rid of the health check which catches exceptions thrown during data generation and rethrows them as a less useful error.

Uh, yeah, I don't know why I ever thought that was a good idea either.

This turned out to be a surprisingly involved change. It has two major parts to it:

* A bunch of new deprecation warnings.
* Changes to the escalation code to always reraise errors inside draw.

Additionally:

* A bunch of refactoring in support of that (extracted the validation code from hypothesis.strategies into its own module because I wanted to use some from settings, moved StopTest into hypothesis.errors).
* I realised that the HealthCheck options weren't documented, so now they are.