### PR TITLE
Integrate health checks into normal test execution

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,6 +1,7 @@
 RELEASE_TYPE: minor
 
-This release overhauls the health check system in a variety of small ways.
+This release overhauls :doc:`the health check system <healthchecks>`
+in a variety of small ways.
 It adds no new features, but is nevertheless a minor release because it changes
 which tests are likely to fail health checks.
 
@@ -9,8 +10,8 @@ will now pass, and some that used to pass will fail. These should all be
 improvements in accuracy. In particular:
 
 * New failures will usually be because they are now taking into account things
-  like use of :func:`~hypothesis.strategies.data()` and
-  :func:`~hypothesis.assume()` inside the test body.
+  like use of :func:`~hypothesis.strategies.data` and
+  :func:`~hypothesis.assume` inside the test body.
 * New failures *may* also be because for some classes of example the way data
   generation performance was measured was artificially faster than real data
   generation (for most examples that are hitting performance health checks the

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,27 @@
+RELEASE_TYPE: minor
+
+This release overhauls the health check system in a variety of small ways.
+It adds no new features, but is nevertheless a minor release because it changes
+which tests are likely to fail health checks.
+
+The most noticeable effect is that some tests that used to fail health checks
+will now pass, and some that used to pass will fail. These should all be
+improvements in accuracy. In particular:
+
+* New failures will usually be because they are now taking into account things
+  like use of :func:`~hypothesis.strategies.data()` and
+  :func:`~hypothesis.assume()` inside the test body.
+* New failures *may* also be because for some classes of example the way data
+  generation performance was measured was artificially faster than real data
+  generation (for most examples that are hitting performance health checks the
+  opposite should be the case).
+* Tests that used to fail health checks and now pass do so because the health
+  check system used to run in a way that was subtly different than the main
+  Hypothesis data generation and lacked some of its support for e.g. large
+  examples.
+
+If your data generation is especially slow, you may also see your tests get
+somewhat faster, as there is no longer a separate health check phase. This will
+be particularly noticeable when rerunning test failures.
+
+This work was funded by `Smarkets <https://smarkets.com/>`_.

--- a/scripts/benchmarks.py
+++ b/scripts/benchmarks.py
@@ -50,6 +50,7 @@ DATA_DIR = os.path.join(
 BENCHMARK_SETTINGS = settings(
     max_examples=100, max_iterations=1000, max_shrinks=1000,
     database=None, timeout=unlimited, use_coverage=False,
+    perform_health_check=False,
 )
 
 

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -903,6 +903,7 @@ def find(specifier, condition, settings=None, random=None, database_key=None):
         min_satisfying_examples=0,
         max_shrinks=2000,
     )
+    settings = Settings(settings, perform_health_check=False)
 
     if database_key is None and settings.database is not None:
         database_key = function_digest(condition)

--- a/src/hypothesis/internal/compat.py
+++ b/src/hypothesis/internal/compat.py
@@ -23,6 +23,7 @@ import os
 import re
 import sys
 import math
+import time
 import codecs
 import platform
 import importlib
@@ -114,7 +115,8 @@ def quiet_raise(exc):
     struct_pack = struct.pack
     struct_unpack = struct.unpack
 
-    from time import monotonic as benchmark_time
+    def benchmark_time():
+        return time.monotonic()
 else:
     import struct
 
@@ -240,7 +242,8 @@ else:
     def quiet_raise(exc):
         raise exc
 
-    from time import time as benchmark_time
+    def benchmark_time():
+        return time.time()
 
 
 # coverage mixes unicode and str filepaths on Python 2, which causes us

--- a/src/hypothesis/internal/conjecture/data.py
+++ b/src/hypothesis/internal/conjecture/data.py
@@ -75,6 +75,7 @@ class ConjectureData(object):
         self.capped_indices = {}
         self.interesting_origin = None
         self.tags = set()
+        self.draw_times = []
 
     def __assert_not_frozen(self, name):
         if self.frozen:
@@ -129,11 +130,14 @@ class ConjectureData(object):
             if not at_top_level:
                 return strategy.do_draw(self)
             else:
+                start_time = benchmark_time()
                 try:
                     return strategy.do_draw(self)
                 except BaseException as e:
                     mark_for_escalation(e)
                     raise
+                finally:
+                    self.draw_times.append(benchmark_time() - start_time)
         finally:
             if not self.frozen:
                 self.stop_example()

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -737,11 +737,6 @@ class ConjectureRunner(object):
         self.exit_reason = reason
         raise RunIsComplete()
 
-    def begin_health_checks(self):
-        if not self.settings.perform_health_check:
-            return
-        self.health_check_state = HealthCheckState()
-
     def generate_new_examples(self):
         if Phase.generate not in self.settings.phases:
             return
@@ -752,6 +747,8 @@ class ConjectureRunner(object):
                 data, hbytes(n)))
         self.test_function(zero_data)
         self.begin_health_checks()
+        if self.settings.perform_health_check:
+            self.health_check_state = HealthCheckState()
 
         count = 0
         while count < 10 and not self.interesting_examples:

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -37,6 +37,11 @@ from hypothesis.internal.conjecture.data import MAX_DEPTH, Status, \
     StopTest, ConjectureData
 from hypothesis.internal.conjecture.minimizer import minimize
 
+# Tell pytest to omit the body of this module from tracebacks
+# http://doc.pytest.org/en/latest/example/simple.html#writing-well-integrated-assertion-helpers
+__tracebackhide__ = True
+
+
 HUNG_TEST_TIME_LIMIT = 5 * 60
 
 

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -319,8 +319,8 @@ class ConjectureRunner(object):
                 'Examples routinely exceeded the max allowable size. '
                 '(%d examples overran while generating %d valid ones)'
                 '. Generating examples this large will usually lead to'
-                ' bad results. You should try setting average_size or '
-                'max_size parameters on your collections and turning '
+                ' bad results. You could try setting max_size parameters '
+                'on your collections and turning '
                 'max_leaves down on recursive() calls.') % (
                 state.overrun_examples, state.valid_examples
             ), HealthCheck.data_too_large)
@@ -344,7 +344,7 @@ class ConjectureRunner(object):
                 '%d valid examples in %.2f seconds (%d invalid ones '
                 'and %d exceeded maximum size). Try decreasing '
                 "size of the data you're generating (with e.g."
-                'average_size or max_leaves parameters).'
+                'max_size or max_leaves parameters).'
             ) % (
                 state.valid_examples, draw_time, state.invalid_examples,
                 state.overrun_examples), HealthCheck.too_slow,)

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -746,7 +746,6 @@ class ConjectureRunner(object):
             draw_bytes=lambda data, n: self.__rewrite_for_novelty(
                 data, hbytes(n)))
         self.test_function(zero_data)
-        self.begin_health_checks()
         if self.settings.perform_health_check:
             self.health_check_state = HealthCheckState()
 

--- a/src/hypothesis/internal/healthcheck.py
+++ b/src/hypothesis/internal/healthcheck.py
@@ -1,0 +1,38 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2017 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+from hypothesis.errors import FailedHealthCheck
+
+
+def fail_health_check(settings, message, label):
+    # Tell pytest to omit the body of this function from tracebacks
+    # http://doc.pytest.org/en/latest/example/simple.html#writing-well-integrated-assertion-helpers
+    __tracebackhide__ = True
+
+    if label in settings.suppress_health_check:
+        return
+    if not settings.perform_health_check:
+        return
+    message += (
+        '\nSee https://hypothesis.readthedocs.io/en/latest/health'
+        'checks.html for more information about this. '
+        'If you want to disable just this health check, add %s '
+        'to the suppress_health_check settings for this test.'
+    ) % (label,)
+    raise FailedHealthCheck(message)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,6 +64,10 @@ def consistently_increment_time(monkeypatch):
         current_time[0] += naptime
 
     monkeypatch.setattr(time_module, 'time', time)
+    try:
+        monkeypatch.setattr(time_module, 'monotonic', time)
+    except AttributeError:
+        assert sys.version_info[0] == 2
     monkeypatch.setattr(time_module, 'sleep', sleep)
 
 

--- a/tests/cover/test_cache_implementation.py
+++ b/tests/cover/test_cache_implementation.py
@@ -22,7 +22,7 @@ from random import Random
 import pytest
 
 import hypothesis.strategies as st
-from hypothesis import note, given, assume, example
+from hypothesis import HealthCheck, note, given, assume, example, settings
 from hypothesis.internal.cache import GenericCache, LRUReusedCache
 
 
@@ -108,6 +108,7 @@ def test_behaves_like_a_dict_with_losses(implementation, writes, size):
         assert len(target) <= min(len(model), size)
 
 
+@settings(suppress_health_check=[HealthCheck.too_slow], deadline=None)
 @given(write_pattern(min_size=2), st.data())
 def test_always_evicts_the_lowest_scoring_value(writes, data):
     scores = {}

--- a/tests/cover/test_conjecture_engine.py
+++ b/tests/cover/test_conjecture_engine.py
@@ -39,7 +39,7 @@ def run_to_buffer(f):
     runner = ConjectureRunner(f, settings=settings(
         max_examples=5000, max_iterations=10000, max_shrinks=MAX_SHRINKS,
         buffer_size=1024,
-        database=None,
+        database=None, perform_health_check=False,
     ))
     runner.run()
     assert runner.last_data.status == Status.INTERESTING
@@ -250,7 +250,7 @@ def test_stops_after_max_iterations_when_generating():
 
     runner = ConjectureRunner(f, settings=settings(
         max_examples=1, max_iterations=max_iterations,
-        database=db,
+        database=db, perform_health_check=False,
     ), database_key=key)
     runner.run()
     assert len(seen) == max_iterations
@@ -485,7 +485,7 @@ def test_garbage_collects_the_database():
 
 
 @given(st.randoms(), st.random_module())
-@settings(max_shrinks=0)
+@settings(max_shrinks=0, deadline=None)
 def test_maliciously_bad_generator(rnd, seed):
     @run_to_buffer
     def x(data):
@@ -498,6 +498,7 @@ def test_maliciously_bad_generator(rnd, seed):
 
 
 @given(st.random_module())
+@settings(max_shrinks=0, deadline=None, perform_health_check=False)
 def test_lot_of_dead_nodes(rnd):
     @run_to_buffer
     def x(data):

--- a/tests/cover/test_conjecture_float_encoding.py
+++ b/tests/cover/test_conjecture_float_encoding.py
@@ -109,13 +109,11 @@ def test_floats_round_trip(f):
     assert float_to_int(f) == float_to_int(g)
 
 
-finite_floats = st.floats(allow_infinity=False, allow_nan=False, min_value=0.0)
-
-
-@example(1.5)
-@given(finite_floats)
-def test_floats_order_worse_than_their_integral_part(f):
-    assume(f != int(f))
+@example(1, 0.5)
+@given(st.integers(1, 2 ** 53), st.floats(0, 1))
+def test_floats_order_worse_than_their_integral_part(n, g):
+    f = n + g
+    assume(int(f) != f)
     assume(int(f) != 0)
     i = flt.float_to_lex(f)
     if f < 0:
@@ -126,7 +124,9 @@ def test_floats_order_worse_than_their_integral_part(f):
     assert flt.float_to_lex(float(g)) < i
 
 
-integral_floats = finite_floats.map(lambda x: float(int(x)))
+integral_floats = st.floats(
+    allow_infinity=False, allow_nan=False, min_value=0.0
+).map(lambda x: float(int(x)))
 
 
 @given(integral_floats, integral_floats)

--- a/tests/cover/test_conjecture_float_encoding.py
+++ b/tests/cover/test_conjecture_float_encoding.py
@@ -110,7 +110,9 @@ def test_floats_round_trip(f):
 
 
 @example(1, 0.5)
-@given(st.integers(1, 2 ** 53), st.floats(0, 1))
+@given(
+    st.integers(1, 2 ** 53), st.floats(0, 1).filter(lambda x: x not in (0, 1))
+)
 def test_floats_order_worse_than_their_integral_part(n, g):
     f = n + g
     assume(int(f) != f)

--- a/tests/cover/test_core.py
+++ b/tests/cover/test_core.py
@@ -95,11 +95,5 @@ def test_settings_are_default_in_given(x):
     assert settings.default is some_normal_settings
 
 
-def test_settings_are_default_in_find():
-    find(
-        s.booleans(), lambda x: settings.default is some_normal_settings,
-        settings=some_normal_settings)
-
-
 def test_arc_is_memoized():
     assert arc('foo', 1, 2) is arc('foo', 1, 2)

--- a/tests/cover/test_example.py
+++ b/tests/cover/test_example.py
@@ -23,12 +23,13 @@ from decimal import Decimal
 import pytest
 
 import hypothesis.strategies as st
-from hypothesis import find, given, example
+from hypothesis import find, given, example, settings
 from hypothesis.errors import NoExamples
 from hypothesis.control import _current_build_context
 from tests.common.utils import checks_deprecated_behaviour
 
 
+@settings(deadline=None)
 @given(st.integers())
 def test_deterministic_examples_are_deterministic(seed):
     with _current_build_context.with_value(None):

--- a/tests/cover/test_given_error_conditions.py
+++ b/tests/cover/test_given_error_conditions.py
@@ -41,7 +41,7 @@ def test_raises_timeout_on_slow_test():
 
 def test_raises_unsatisfiable_if_all_false():
     @given(integers())
-    @settings(max_examples=50)
+    @settings(max_examples=50, perform_health_check=False)
     def test_assume_false(x):
         reject()
 

--- a/tests/cover/test_health_checks.py
+++ b/tests/cover/test_health_checks.py
@@ -40,6 +40,16 @@ def test_slow_generation_fails_a_health_check():
         test()
 
 
+def test_slow_generation_inline_fails_a_health_check():
+    @settings(deadline=None)
+    @given(st.data())
+    def test(data):
+        data.draw(st.integers().map(lambda x: time.sleep(0.2)))
+
+    with raises(FailedHealthCheck):
+        test()
+
+
 def test_default_health_check_can_weaken_specific():
     import random
 

--- a/tests/cover/test_integer_ranges.py
+++ b/tests/cover/test_integer_ranges.py
@@ -40,7 +40,7 @@ class interval(SearchStrategy):
     st.tuples(st.integers(), st.integers(), st.integers()).map(sorted),
     st.random_module(),
 )
-@settings(max_examples=100, max_shrinks=0)
+@settings(max_examples=100, max_shrinks=0, deadline=None)
 def test_intervals_shrink_to_center(inter, rnd):
     lower, center, upper = inter
     s = interval(lower, upper, center)

--- a/tests/cover/test_interleaving.py
+++ b/tests/cover/test_interleaving.py
@@ -25,7 +25,9 @@ from tests.common.utils import checks_deprecated_behaviour
 @checks_deprecated_behaviour
 def test_can_eval_stream_inside_find():
     @given(st.streaming(st.integers(min_value=0)), st.random_module())
-    @settings(buffer_size=200, max_shrinks=5, max_examples=10)
+    @settings(
+        buffer_size=200, max_shrinks=5, max_examples=10,
+        perform_health_check=False)
     def test(stream, rnd):
         x = find(
             st.lists(st.integers(min_value=0), min_size=10),

--- a/tests/cover/test_seed_printing.py
+++ b/tests/cover/test_seed_printing.py
@@ -46,7 +46,7 @@ def test_prints_seed_on_exception(monkeypatch, in_pytest, fail_healthcheck):
 
     @given(strategy)
     def test(i):
-        assert False
+        assert fail_healthcheck
 
     with capture_out() as o:
         with pytest.raises(expected_exc):

--- a/tests/cover/test_sets.py
+++ b/tests/cover/test_sets.py
@@ -30,7 +30,7 @@ def test_unique_lists_error_on_too_large_average_size():
 
 
 @given(randoms())
-@settings(max_examples=5)
+@settings(max_examples=5, deadline=None)
 def test_can_draw_sets_of_hard_to_find_elements(rnd):
     rarebool = floats(0, 1).map(lambda x: x <= 0.01)
     find(

--- a/tests/cover/test_simple_numbers.py
+++ b/tests/cover/test_simple_numbers.py
@@ -22,7 +22,7 @@ import math
 
 import pytest
 
-from hypothesis import given
+from hypothesis import given, settings
 from tests.common.debug import minimal
 from hypothesis.strategies import lists, floats, randoms, integers, \
     complex_numbers
@@ -169,6 +169,7 @@ def test_list_of_fractional_float():
     )
 
 
+@settings(deadline=None)
 @given(randoms())
 def test_minimal_fractional_float(rnd):
     assert minimal(

--- a/tests/cover/test_target_selector.py
+++ b/tests/cover/test_target_selector.py
@@ -48,6 +48,7 @@ def fake_randoms(draw):
     return FakeRandom()
 
 
+@settings(deadline=None)
 @given(fake_randoms())
 def test_selects_non_universal_tag(rnd):
     selector = TargetSelector(rnd)
@@ -79,7 +80,7 @@ def check_bounded_cycle(selector):
     assert not tags
 
 
-@settings(use_coverage=False)
+@settings(use_coverage=False, deadline=None)
 @given(fake_randoms(), data_lists)
 def test_cycles_through_all_tags_in_bounded_time(rnd, datas):
     selector = TargetSelector(rnd)
@@ -88,7 +89,7 @@ def test_cycles_through_all_tags_in_bounded_time(rnd, datas):
     check_bounded_cycle(selector)
 
 
-@settings(use_coverage=False)
+@settings(use_coverage=False, deadline=None)
 @given(fake_randoms(), data_lists, data_lists)
 def test_cycles_through_all_tags_in_bounded_time_mixed(rnd, d1, d2):
     selector = TargetSelector(rnd)
@@ -100,6 +101,7 @@ def test_cycles_through_all_tags_in_bounded_time_mixed(rnd, d1, d2):
     check_bounded_cycle(selector)
 
 
+@settings(deadline=None)
 @given(fake_randoms())
 def test_a_negated_tag_is_also_interesting(rnd):
     selector = TargetSelector(rnd)
@@ -110,6 +112,7 @@ def test_a_negated_tag_is_also_interesting(rnd):
     assert not data.tags
 
 
+@settings(deadline=None)
 @given(fake_randoms(), st.integers(1, 10))
 def test_always_starts_with_rare_tags(rnd, n):
     selector = TargetSelector(rnd)

--- a/tests/cover/test_testdecorators.py
+++ b/tests/cover/test_testdecorators.py
@@ -26,7 +26,7 @@ from hypothesis import Verbosity, note, seed, given, assume, reject, \
     settings
 from hypothesis.errors import Unsatisfiable
 from tests.common.utils import fails, raises, fails_with, capture_out
-from hypothesis.strategies import just, sets, text, lists, binary, \
+from hypothesis.strategies import data, just, sets, text, lists, binary, \
     builds, floats, one_of, booleans, integers, frozensets, sampled_from
 
 
@@ -203,7 +203,7 @@ def test_contains_the_test_function_name_in_the_exception_string():
     ) in e.value.args[0]
 
 
-@given(lists(integers()), integers())
+@given(lists(integers(), unique=True), integers())
 def test_removing_an_element_from_a_unique_list(xs, y):
     assume(len(set(xs)) == len(xs))
 
@@ -216,9 +216,9 @@ def test_removing_an_element_from_a_unique_list(xs, y):
 
 
 @fails
-@given(lists(integers(), average_size=25.0), integers())
-def test_removing_an_element_from_a_non_unique_list(xs, y):
-    assume(y in xs)
+@given(lists(integers(), average_size=25.0), data())
+def test_removing_an_element_from_a_non_unique_list(xs, data):
+    y = data.draw(sampled_from(xs))
     xs.remove(y)
     assert y not in xs
 

--- a/tests/cover/test_uuids.py
+++ b/tests/cover/test_uuids.py
@@ -20,7 +20,7 @@ from __future__ import division, print_function, absolute_import
 import pytest
 
 import hypothesis.strategies as st
-from hypothesis import find, given
+from hypothesis import find, given, settings
 
 
 @given(st.lists(st.uuids()))
@@ -28,6 +28,7 @@ def test_are_unique(ls):
     assert len(set(ls)) == len(ls)
 
 
+@settings(deadline=None)
 @given(st.lists(st.uuids()), st.randoms())
 def test_retains_uniqueness_in_simplify(ls, rnd):
     ts = find(st.lists(st.uuids()), lambda x: len(x) >= 5, random=rnd)

--- a/tests/django/manage.py
+++ b/tests/django/manage.py
@@ -20,6 +20,7 @@ from __future__ import division, print_function, absolute_import
 import os
 import sys
 
+from hypothesis import HealthCheck, settings, unlimited
 from tests.common.setup import run
 
 if __name__ == u'__main__':
@@ -27,6 +28,14 @@ if __name__ == u'__main__':
 
     django_version = tuple(int(n) for n in django.__version__.split('.')[:2])
     run(deprecations_as_errors=django_version >= (1, 11))
+
+    settings.register_profile('default', settings(
+        timeout=unlimited, use_coverage=False,
+        suppress_health_check=[HealthCheck.too_slow],
+    ))
+
+    settings.load_profile(os.getenv('HYPOTHESIS_PROFILE', 'default'))
+
     os.environ.setdefault(
         u'DJANGO_SETTINGS_MODULE', u'tests.django.toys.settings')
 

--- a/tests/nocover/test_boundary_exploration.py
+++ b/tests/nocover/test_boundary_exploration.py
@@ -20,12 +20,16 @@ from __future__ import division, print_function, absolute_import
 import pytest
 
 import hypothesis.strategies as st
-from hypothesis import Verbosity, find, given, reject, settings
+from hypothesis import Verbosity, HealthCheck, find, given, reject, \
+    settings
 from hypothesis.errors import NoSuchExample
 
 
 @pytest.mark.parametrize('strat', [st.text(min_size=5)])
-@settings(max_shrinks=0)
+@settings(
+    max_shrinks=0, deadline=None, suppress_health_check=[
+        HealthCheck.too_slow, HealthCheck.hung_test]
+)
 @given(st.data())
 def test_explore_arbitrary_function(strat, data):
     cache = {}

--- a/tests/nocover/test_float_shrinking.py
+++ b/tests/nocover/test_float_shrinking.py
@@ -42,7 +42,7 @@ def test_can_shrink_in_variable_sized_context(n):
 
 @example(1.5)
 @given(st.floats(min_value=0, allow_infinity=False, allow_nan=False))
-@settings(use_coverage=False)
+@settings(use_coverage=False, deadline=None, perform_health_check=False)
 def test_shrinks_downwards_to_integers(f):
     g = minimal(
         st.floats(), lambda x: x >= f, random=Random(0),
@@ -53,7 +53,7 @@ def test_shrinks_downwards_to_integers(f):
 
 @example(1)
 @given(st.integers(1, 2 ** 16 - 1))
-@settings(use_coverage=False)
+@settings(use_coverage=False, deadline=None, perform_health_check=False)
 def test_shrinks_downwards_to_integers_when_fractional(b):
     g = minimal(
         st.floats(),

--- a/tests/nocover/test_floating.py
+++ b/tests/nocover/test_floating.py
@@ -24,12 +24,15 @@ from __future__ import division, print_function, absolute_import
 import sys
 import math
 
-from hypothesis import seed, given, assume, reject, settings
+from hypothesis import HealthCheck, seed, given, assume, reject, settings
 from hypothesis.errors import Unsatisfiable
 from tests.common.utils import fails
 from hypothesis.strategies import lists, floats, integers
 
-TRY_HARDER = settings(max_examples=1000, max_iterations=2000)
+TRY_HARDER = settings(
+    max_examples=1000, max_iterations=2000,
+    suppress_health_check=[HealthCheck.filter_too_much]
+)
 
 
 @given(floats())

--- a/tests/nocover/test_recursive.py
+++ b/tests/nocover/test_recursive.py
@@ -84,7 +84,9 @@ def test_drawing_many_near_boundary():
 
 
 @given(st.randoms())
-@settings(max_examples=50, max_shrinks=0)
+@settings(
+    max_examples=50, max_shrinks=0, perform_health_check=False, deadline=None
+)
 @example(Random(-1363972488426139))
 @example(Random(-4))
 def test_can_use_recursive_data_in_sets(rnd):
@@ -129,7 +131,9 @@ def test_can_form_sets_of_recursive_data():
 
 
 @given(st.randoms())
-@settings(max_examples=2, database=None)
+@settings(
+    max_examples=50, max_shrinks=0, perform_health_check=False, deadline=None
+)
 def test_can_flatmap_to_recursive_data(rnd):
     stuff = st.lists(st.integers(), min_size=1).flatmap(
         lambda elts: st.recursive(

--- a/tests/nocover/test_streams.py
+++ b/tests/nocover/test_streams.py
@@ -19,7 +19,7 @@ from __future__ import division, print_function, absolute_import
 
 from itertools import islice
 
-from hypothesis import given
+from hypothesis import HealthCheck, given, settings
 from tests.common.utils import checks_deprecated_behaviour
 from hypothesis.strategies import integers, streaming
 from hypothesis.internal.compat import integer_types
@@ -27,6 +27,7 @@ from hypothesis.internal.compat import integer_types
 
 @checks_deprecated_behaviour
 def test_streams_are_arbitrarily_long():
+    @settings(suppress_health_check=[HealthCheck.too_slow])
     @given(streaming(integers()))
     def test(ss):
         for i in islice(ss, 100):

--- a/tests/numpy/test_gen_data.py
+++ b/tests/numpy/test_gen_data.py
@@ -129,6 +129,7 @@ def test_can_generate_array_shapes(shape):
     assert all(isinstance(i, int) for i in shape)
 
 
+@settings(deadline=None)
 @given(st.integers(1, 10), st.integers(0, 9), st.integers(1), st.integers(0))
 def test_minimise_array_shapes(min_dims, dim_range, min_side, side_range):
     smallest = minimal(nps.array_shapes(min_dims, min_dims + dim_range,

--- a/tests/pandas/test_indexes.py
+++ b/tests/pandas/test_indexes.py
@@ -24,7 +24,7 @@ import pandas
 import hypothesis.strategies as st
 import hypothesis.extra.numpy as npst
 import hypothesis.extra.pandas as pdst
-from hypothesis import given, assume, reject
+from hypothesis import HealthCheck, given, assume, reject, settings
 from hypothesis.errors import NoExamples
 from tests.pandas.helpers import supported_by_pandas
 
@@ -63,6 +63,7 @@ def test_basic_range_indexes(ix):
     assert isinstance(ix, pandas.RangeIndex)
 
 
+@settings(suppress_health_check=[HealthCheck.too_slow])
 @given(st.data())
 def test_generate_arbitrary_indices(data):
     min_size = data.draw(st.integers(0, 10), 'min_size')

--- a/tests/pytest/test_statistics.py
+++ b/tests/pytest/test_statistics.py
@@ -43,7 +43,9 @@ def test_slow(x):
     time.sleep(0.1)
 
 
-@settings(max_examples=1000, min_satisfying_examples=1)
+@settings(
+    max_examples=1000, min_satisfying_examples=1, perform_health_check=False
+)
 @given(integers())
 def test_iterations(x):
     assume(x % 50 == 0)


### PR DESCRIPTION
Previously most health checks ran as a separate phase in which the test body was not executed and the data generation was run in a weird way that didn't take into account the ways in which Hypothesis data generation is clever.

This has a number of disadvantages:

* It adds a bunch of extra time to the beginning of the run
* It doesn't actually agree with the details of how Hypothesis really generates data, so its measurements are all off - it will pass things that it should fail and vice versa
* It ignores things it shouldn't be ignoring such as data() and assume().

This fixes all that by instead integrating this part of the health check into the engine. We now keep track of the details of examples generated as use them to perform the same failure checks as we did before, but based on real test executions.

One thing that is important to note is where we do this. We don't do it from the first test that is run. Instead we do it after we have tried the trivial example (and thus, necessarily, after we have replayed any previous examples). This serves a roughly equivalent role to the way we previously generated and discard one example prior to running health checks, which potentially warms some caches to guard against the problem where running the first example can be slow and all subsequent ones are fine.