### PR TITLE
Don't count interactive draw towards deadline time.

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This release changes the behaviour of the :attr:`~hypothesis.settings.deadline`
+setting when used with :func:`~hypothesis.strategies.data`: Time spent inside
+calls to ``data.draw`` will no longer be counted towards the deadline time.
+
+This work was funded by `Smarkets <https://smarkets.com/>`_.

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -4,4 +4,8 @@ This release changes the behaviour of the :attr:`~hypothesis.settings.deadline`
 setting when used with :func:`~hypothesis.strategies.data`: Time spent inside
 calls to ``data.draw`` will no longer be counted towards the deadline time.
 
+As a side effect of some refactoring required for this work, the way flaky
+tests are handled has changed slightly. You are unlikely to see much difference
+from this, but some error messages will have changed.
+
 This work was funded by `Smarkets <https://smarkets.com/>`_.

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -76,7 +76,7 @@ def new_random():
     return random.Random(random.getrandbits(128))
 
 
-def test_is_flaky(test, expected_repr):
+def test_is_flaky(test):
     @functools.wraps(test)
     def test_or_flaky(*args, **kwargs):
         text_repr = arg_string(test, args, kwargs)
@@ -407,7 +407,6 @@ class StateForActualGivenExecution(object):
         self.settings = settings
         self.at_least_one_success = False
         self.last_exception = None
-        self.repr_for_last_exception = None
         self.falsifying_examples = ()
         self.__was_flaky = False
         self.random = random
@@ -739,8 +738,7 @@ class StateForActualGivenExecution(object):
                 try:
                     self.execute(
                         ConjectureData.for_buffer(falsifying_example.buffer),
-                        test_is_flaky(
-                            self.test, self.repr_for_last_exception),
+                        test_is_flaky(self.test),
                         print_example=True, is_final=True
                     )
                 except (UnsatisfiedAssumption, StopTest):

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -431,7 +431,7 @@ class StateForActualGivenExecution(object):
         self, data,
         print_example=False,
         is_final=False,
-        expected_failure=None,
+        expected_failure=None, collect=False,
     ):
         text_repr = [None]
         if self.settings.deadline is None:
@@ -488,16 +488,14 @@ class StateForActualGivenExecution(object):
                             lambda: 'Trying example: %s(%s)' % (
                                 test.__name__, arg_string(test, args, kwargs)))
 
-                    collector = self.collector
-
-                    if collector is None:
+                    if self.collector is None or not collect:
                         return test(*args, **kwargs)
                     else:  # pragma: no cover
                         try:
-                            collector.start()
+                            self.collector.start()
                             return test(*args, **kwargs)
                         finally:
-                            collector.stop()
+                            self.collector.stop()
 
         result = self.test_runner(data, run)
         if expected_failure is not None:
@@ -584,7 +582,7 @@ class StateForActualGivenExecution(object):
                 sys.settrace(None)
                 try:
                     self.collector.data = {}
-                    result = self.execute(data)
+                    result = self.execute(data, collect=True)
                 finally:
                     sys.settrace(original)
                     covdata = CoverageData()

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -724,29 +724,6 @@ class StateForActualGivenExecution(object):
                 if len(self.falsifying_examples) <= 1:
                     raise
                 report(traceback.format_exc())
-
-                filter_message = (
-                    'Unreliable test data: Failed to reproduce a failure '
-                    'and then when it came to recreating the example in '
-                    'order to print the test data with a flaky result '
-                    'the example was filtered out (by e.g. a '
-                    'call to filter in your strategy) when we didn\'t '
-                    'expect it to be.'
-                )
-
-                try:
-                    self.execute(
-                        ConjectureData.for_buffer(falsifying_example.buffer),
-                        print_example=True, is_final=True
-                    )
-                except (UnsatisfiedAssumption, StopTest):
-                    self.__flaky(filter_message)
-                except Flaky as e:
-                    if len(self.falsifying_examples) > 1:
-                        self.__flaky(e.args[0])
-                    else:
-                        raise
-
             if self.__was_flaky:
                 flaky += 1
 

--- a/tests/cover/test_deadline.py
+++ b/tests/cover/test_deadline.py
@@ -133,3 +133,26 @@ def test_gives_a_deadline_specific_flaky_error_message():
             slow_once()
     assert 'Unreliable test timing' in o.getvalue()
     assert 'took 2' in o.getvalue()
+
+
+@pytest.mark.parametrize('slow_strategy', [False, True])
+@pytest.mark.parametrize('slow_test', [False, True])
+def test_should_only_fail_a_deadline_if_the_test_is_slow(
+    slow_strategy, slow_test
+):
+    s = st.integers()
+    if slow_strategy:
+        s = s.map(lambda x: time.sleep(1))
+
+    @settings(deadline=200)
+    @given(st.data())
+    def test(data):
+        data.draw(s)
+        if slow_test:
+            time.sleep(1)
+
+    if slow_test:
+        with pytest.raises(DeadlineExceeded):
+            test()
+    else:
+        test()

--- a/tests/cover/test_deadline.py
+++ b/tests/cover/test_deadline.py
@@ -142,14 +142,14 @@ def test_should_only_fail_a_deadline_if_the_test_is_slow(
 ):
     s = st.integers()
     if slow_strategy:
-        s = s.map(lambda x: time.sleep(1))
+        s = s.map(lambda x: time.sleep(0.08))
 
-    @settings(deadline=200)
+    @settings(deadline=50)
     @given(st.data())
     def test(data):
         data.draw(s)
         if slow_test:
-            time.sleep(1)
+            time.sleep(0.1)
 
     if slow_test:
         with pytest.raises(DeadlineExceeded):


### PR DESCRIPTION
This changes the deadline feature to subtract the amount of time spent in drawing data (which we now have as a result of #973) from the run time of the test.

This was a surprisingly involved change and necessitated a bunch of refactoring. A bunch of logic got moved from top level functions to `StateForActualGivenExecution` and some of this was inlined. This was largely because the place where the deadline code was being calculated didn't have access to the data object. I've tried to make sure this refactoring makes the code better rather than worse, but core.py remains a bit of a horror show...

Fixes #911.