### PR TITLE
Misc. minor refactoring

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch has a variety of non-user-visible refactorings, removing various
+minor warts ranging from indirect imports to typos in comments.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -115,8 +115,7 @@ This release adds a setting to the public API, and does some internal cleanup:
 -------------------
 
 This minor release supports constraining :func:`~hypothesis.strategies.uuids`
-to generate :class:`~python:uuid.UUID`s of a particular version.
-(:issue:`721`)
+to generate a particular version of :class:`~python:uuid.UUID` (:issue:`721`).
 
 Thanks to Dion Misic for this feature.
 

--- a/src/hypothesis/internal/cache.py
+++ b/src/hypothesis/internal/cache.py
@@ -55,7 +55,7 @@ class GenericCache(object):
         self.max_size = max_size
 
         # Implementation: We store a binary heap of Entry objects in self.data,
-        # with the heap property requirnig that a parent's score is <= that of
+        # with the heap property requiring that a parent's score is <= that of
         # its children. keys_to_index then maps keys to their index in the
         # heap. We keep these two in sync automatically - the heap is never
         # reordered without updating the index.

--- a/src/hypothesis/internal/charmap.py
+++ b/src/hypothesis/internal/charmap.py
@@ -65,8 +65,8 @@ def charmap():
                     rs[-1][-1] += 1
                 else:
                     rs.append([i, i])
-            _charmap = {k: tuple((map(tuple, v)))
-                        for k, v in tmp_charmap.items()}
+            _charmap = {k: tuple(tuple(pair) for pair in pairs)
+                        for k, pairs in tmp_charmap.items()}
 
             try:
                 # Write the Unicode table atomically
@@ -87,10 +87,10 @@ _categories = None
 
 
 def categories():
-    """Return a list of Unicode categories in a normalised order.
+    """Return a tuple of Unicode categories in a normalised order.
 
     >>> categories() # doctest: +ELLIPSIS
-    ['Zl', 'Zp', 'Co', 'Me', 'Pc', ..., 'Cc', 'Cs']
+    ('Zl', 'Zp', 'Co', 'Me', 'Pc', ..., 'Cc', 'Cs')
 
     """
     global _categories
@@ -103,7 +103,7 @@ def categories():
         _categories.remove('Cs')  # Other, Surrogate
         _categories.append('Cc')
         _categories.append('Cs')
-    return _categories
+    return tuple(_categories)
 
 
 def _union_intervals(x, y):
@@ -149,7 +149,7 @@ def _intervals(s):
     ((48, 57), (97, 102))
 
     """
-    intervals = [(ord(c), ord(c)) for c in sorted(s)]
+    intervals = tuple((ord(c), ord(c)) for c in sorted(s))
     return _union_intervals(intervals, intervals)
 
 
@@ -184,8 +184,7 @@ def _query_for_key(key):
     """Return a tuple of codepoint intervals covering characters that match one
     or more categories in the tuple of categories `key`.
 
-    >>> all_categories = tuple(categories())
-    >>> _query_for_key(all_categories)
+    >>> _query_for_key(categories())
     ((0, 1114111),)
     >>> _query_for_key(('Zl', 'Zp', 'Co'))
     ((8232, 8233), (57344, 63743), (983040, 1048573), (1048576, 1114109))
@@ -196,8 +195,7 @@ def _query_for_key(key):
     except KeyError:
         pass
     assert key
-    cs = categories()
-    if len(key) == len(cs):
+    if set(key) == set(categories()):
         result = ((0, sys.maxunicode),)
     else:
         result = _union_intervals(

--- a/src/hypothesis/internal/reflection.py
+++ b/src/hypothesis/internal/reflection.py
@@ -316,10 +316,9 @@ def extract_lambda_source(f):
             parsed = ast.parse(source[:i])
             assert len(parsed.body) == 1
             assert parsed.body
-            if not isinstance(parsed.body[0].value, ast.Lambda):
-                continue
-            source = source[:i]
-            break
+            if isinstance(parsed.body[0].value, ast.Lambda):
+                source = source[:i]
+                break
         except SyntaxError:
             pass
     lines = source.split('\n')

--- a/src/hypothesis/searchstrategy/lazy.py
+++ b/src/hypothesis/searchstrategy/lazy.py
@@ -17,7 +17,7 @@
 
 from __future__ import division, print_function, absolute_import
 
-from hypothesis.internal.compat import hrange, getfullargspec
+from hypothesis.internal.compat import getfullargspec
 from hypothesis.internal.reflection import arg_string, \
     convert_keyword_arguments, convert_positional_arguments
 from hypothesis.searchstrategy.strategies import SearchStrategy
@@ -144,8 +144,9 @@ class LazyStrategy(SearchStrategy):
             argspec = getfullargspec(self.__function)
             defaults = dict(argspec.kwonlydefaults or {})
             if argspec.defaults is not None:
-                for k in hrange(1, len(argspec.defaults) + 1):
-                    defaults[argspec.args[-k]] = argspec.defaults[-k]
+                for name, value in zip(reversed(argspec.args),
+                                       reversed(argspec.defaults)):
+                    defaults[name] = value
             if len(argspec.args) > 1 or argspec.defaults:
                 _args, _kwargs = convert_positional_arguments(
                     self.__function, _args, _kwargs)

--- a/src/hypothesis/searchstrategy/regex.py
+++ b/src/hypothesis/searchstrategy/regex.py
@@ -20,7 +20,8 @@ from __future__ import division, print_function, absolute_import
 import re
 import sys
 import operator
-import sre_parse as sre
+import sre_parse
+import sre_constants as sre
 
 import hypothesis.strategies as st
 from hypothesis import reject
@@ -231,7 +232,7 @@ def maybe_pad(draw, regex, strategy, left_pad_strategy, right_pad_strategy):
 
 def base_regex_strategy(regex, parsed=None):
     if parsed is None:
-        parsed = sre.parse(regex.pattern)
+        parsed = sre_parse.parse(regex.pattern)
     return clear_cache_after_draw(_strategy(
         parsed,
         Context(flags=regex.flags),
@@ -245,7 +246,7 @@ def regex_strategy(regex):
 
     is_unicode = isinstance(regex.pattern, text_type)
 
-    parsed = sre.parse(regex.pattern)
+    parsed = sre_parse.parse(regex.pattern)
 
     if not parsed:
         if is_unicode:


### PR DESCRIPTION
Includes removing indirect imports, style fixes/clarification, fixing typos in comments, etc.

This should have no user-visible impact beyond the formatting fix in the changelog, but I'll be happier browsing certain bits of code.  For maintainers, the various parts of `charmap.py` now consistently return tuples, and importing `sre_constants` from the correct module should ease static analysis.