### PR TITLE
Special case decorators when extracting lambdas

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,9 @@
+RELEASE_TYPE: patch
+
+This fixes the repr of strategies using lambda that are defined inside
+decorators to include the lambda source.
+
+This would mostly have been visible when using the
+:ref:`statistics <statistics>` functionality - lambdas used for e.g. filtering
+would have shown up with a ``<unknown>`` as their body. This can still happen,
+but it should happen less often now.

--- a/src/hypothesis/internal/reflection.py
+++ b/src/hypothesis/internal/reflection.py
@@ -282,6 +282,7 @@ def extract_lambda_source(f):
     source = LINE_CONTINUATION.sub(' ', source)
     source = WHITESPACE.sub(' ', source)
     source = source.strip()
+    assert 'lambda' in source
 
     tree = None
 
@@ -300,7 +301,12 @@ def extract_lambda_source(f):
                 continue
     if tree is None:
         if source.startswith('@'):
-            for i in hrange(len(source) + 1):
+            # This will always eventually find a valid expression because we
+            # the decorator must be a valid Python function call, so will
+            # eventually be syntactically valid and break out of the loop. Thus
+            # this loop can never terminate normally, so a no branch pragma is
+            # appropriate.
+            for i in hrange(len(source) + 1):  # pragma: no branch
                 p = source[1:i]
                 if 'lambda' in p:
                     try:

--- a/src/hypothesis/internal/reflection.py
+++ b/src/hypothesis/internal/reflection.py
@@ -301,7 +301,7 @@ def extract_lambda_source(f):
                 continue
     if tree is None:
         if source.startswith('@'):
-            # This will always eventually find a valid expression because we
+            # This will always eventually find a valid expression because
             # the decorator must be a valid Python function call, so will
             # eventually be syntactically valid and break out of the loop. Thus
             # this loop can never terminate normally, so a no branch pragma is

--- a/tests/cover/test_lambda_formatting.py
+++ b/tests/cover/test_lambda_formatting.py
@@ -141,3 +141,15 @@ def test_can_extract_two_lambdas_from_a_decorator_if_args_differ():
     a, b = two_decorators
     assert get_pretty_function_description(a) == 'lambda x: x + 1'
     assert get_pretty_function_description(b) == 'lambda y: y * 2'
+
+
+@arg_decorator(
+    lambda x: x + 1
+)
+def decorator_with_space():
+    pass
+
+
+def test_can_extract_lambda_repr_in_a_decorator_with_spaces():
+    assert get_pretty_function_description(
+        decorator_with_space[0]) == 'lambda x: x + 1'

--- a/tests/cover/test_lambda_formatting.py
+++ b/tests/cover/test_lambda_formatting.py
@@ -115,3 +115,18 @@ def test_lambda_source_break_after_def_with_line_continuation():
 
     source = get_pretty_function_description(f)
     assert source == "lambda n: 'aaa'"
+
+
+def arg_decorator(s):
+    def accept(f):
+        return s
+    return accept
+
+
+@arg_decorator(lambda x: x + 1)
+def plus_one():
+    pass
+
+
+def test_can_extract_lambda_repr_in_a_decorator():
+    assert get_pretty_function_description(plus_one) == 'lambda x: x + 1'

--- a/tests/cover/test_lambda_formatting.py
+++ b/tests/cover/test_lambda_formatting.py
@@ -117,7 +117,7 @@ def test_lambda_source_break_after_def_with_line_continuation():
     assert source == "lambda n: 'aaa'"
 
 
-def arg_decorator(s):
+def arg_decorator(*s):
     def accept(f):
         return s
     return accept
@@ -128,5 +128,16 @@ def plus_one():
     pass
 
 
+@arg_decorator(lambda x: x + 1, lambda y: y * 2)
+def two_decorators():
+    pass
+
+
 def test_can_extract_lambda_repr_in_a_decorator():
-    assert get_pretty_function_description(plus_one) == 'lambda x: x + 1'
+    assert get_pretty_function_description(plus_one[0]) == 'lambda x: x + 1'
+
+
+def test_can_extract_two_lambdas_from_a_decorator_if_args_differ():
+    a, b = two_decorators
+    assert get_pretty_function_description(a) == 'lambda x: x + 1'
+    assert get_pretty_function_description(b) == 'lambda y: y * 2'

--- a/tests/cover/test_lambda_formatting.py
+++ b/tests/cover/test_lambda_formatting.py
@@ -42,6 +42,7 @@ def test_can_get_descriptions_of_nested_lambdas_with_different_names():
     assert get_pretty_function_description(ordered_pair) == \
         'lambda right: [].map(lambda length: ())'
 
+
 def test_does_not_error_on_unparsable_source():
     t = [
         lambda x: \
@@ -49,6 +50,7 @@ def test_does_not_error_on_unparsable_source():
         # parser to accept this lambda
         x][0]
     assert get_pretty_function_description(t) == 'lambda x: <unknown>'
+
 
 def test_source_of_lambda_is_pretty():
     assert get_pretty_function_description(
@@ -153,3 +155,26 @@ def decorator_with_space():
 def test_can_extract_lambda_repr_in_a_decorator_with_spaces():
     assert get_pretty_function_description(
         decorator_with_space[0]) == 'lambda x: x + 1'
+
+
+@arg_decorator(lambda: ())
+def to_brackets():
+    pass
+
+
+def test_can_handle_brackets_in_decorator_argument():
+    assert get_pretty_function_description(to_brackets[0]) == "lambda: ()"
+
+
+def identity(x):
+    return x
+
+
+@arg_decorator(identity(lambda x: x + 1))
+def decorator_with_wrapper():
+    pass
+
+
+def test_can_handle_nested_lambda_in_decorator_argument():
+    assert get_pretty_function_description(
+        decorator_with_wrapper[0]) == "lambda x: x + 1"

--- a/tests/cover/test_statistical_events.py
+++ b/tests/cover/test_statistical_events.py
@@ -158,3 +158,15 @@ def test_draw_time_percentage(draw_delay, test_delay):
         assert stats.draw_time_percentage == '~ 50%'
     else:
         assert stats.draw_time_percentage == '~ 100%'
+
+
+def test_has_lambdas_in_output():
+    @given(st.integers().filter(lambda x: x % 2 == 0))
+    def test(i):
+        pass
+
+    stats = call_for_statistics(test)
+    print(stats.events)
+    assert any(
+        'lambda x: x % 2 == 0' in e for e in stats.events
+    )

--- a/tests/cover/test_statistical_events.py
+++ b/tests/cover/test_statistical_events.py
@@ -166,7 +166,6 @@ def test_has_lambdas_in_output():
         pass
 
     stats = call_for_statistics(test)
-    print(stats.events)
     assert any(
         'lambda x: x % 2 == 0' in e for e in stats.events
     )


### PR DESCRIPTION
Special case lambdas inside decorators using exciting regular expressions as a fallback.

I could attempt to justify myself, but I think we'd both be happier if I didn't, so I'm just going to say sorry instead.

Fixes #981.