### PR TITLE
Add README files to our tests to help new contributors

### DIFF
--- a/guides/testing-hypothesis.rst
+++ b/guides/testing-hypothesis.rst
@@ -27,7 +27,7 @@ a starting point, not the final goal.
   because when it was found and fixed, someone wrote a test to make sure it
   couldn't come back!
 
-The ``tests/`` directory has some notes in the README files on where various
+The ``tests/`` directory has some notes in the README file on where various
 kinds of tests can be found or added.  Go there for the practical stuff, or
 just ask one of the maintainers for help on a pull request!
 

--- a/guides/testing-hypothesis.rst
+++ b/guides/testing-hypothesis.rst
@@ -1,0 +1,39 @@
+==============================
+Writing Tests *for* Hypothesis
+==============================
+
+The test suite for Hypothesis is unusually powerful - as you might hope! -
+but the secret is actually more about attitude than technology.
+
+The key is that we treat any bug in Hypothesis as a bug in our test suite
+too - and think about the kinds of bugs that might not be caught, then write
+tests that would catch them.
+
+We also use a variety of tools to check our code automatically.  This includes
+formatting, import order, linting, and doctests (so examples in docs don't
+break).  All of this is checked in CI - which means that once the build is
+green, humans can all focus on meaningful review rather than nitpicking
+operator spacing.
+
+Similarly, we require all code to have tests with 100% branch coverage - as
+a starting point, not the final goal.
+
+- Requiring full coverage can't guarantee that we've written all the tests
+  worth writing (for example, maybe we left off a useful assertion about the
+  result), but less than full coverage guarantees that there's some code we're
+  not testing at all.
+- Tests beyond full coverage generally aim to demonstrate that a particular
+  feature works, or that some subtle failure case is not present - often
+  because when it was found and fixed, someone wrote a test to make sure it
+  couldn't come back!
+
+The ``tests/`` directory has some notes in the README files on where various
+kinds of tests can be found or added.  Go there for the practical stuff, or
+just ask one of the maintainers for help on a pull request!
+
+Further reading: How `SQLite is tested <https://sqlite.org/testing.html>`_,
+`how the Space Shuttle was tested <https://www.fastcompany.com/28121/they-write-right-stuff>`_,
+`how to misuse code coverage <http://www.exampler.com/testing-com/writings/coverage.pdf>`_
+(for inspiration, *not* implementation).
+Dan Luu writes about `fuzz testing <https://danluu.com/testing/>`_ and
+`broken processes <https://danluu.com/wat/>`_, among other things.

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -53,7 +53,7 @@ can be tricky.  Tips:
 - Use ``git grep`` to search for keywords, e.g. the name of a strategy you've changed.
 - Deliberately break something related to your code, and see which tests fail.
 - Ask a maintainer!  Sometimes the structure is just arbitrary, and other tactics
-  don't work - but as I keep saying, we *want* to help!
+  don't work - but we *want* to help!
 
 
 About each group of tests
@@ -69,17 +69,13 @@ Still here?  Here's a note on what to expect in each directory.
     for other functions that are often useful when writing tests.
 
 ``cover/``
-    The home of enough tests to get 100% branch coverage - you'll probably
-    spend most of your time here.  Ideally this would be as quick as possible
-    while remaining comprehensive.  More details inside.
+    The home of enough tests to get 100% branch coverage, as quickly as possible
+    without compromising on test power.  This can be an intimidating target,
+    but it's entirely achievable and the maintainers are (still) here to help.
 
     This directory alone has around two-thirds of the tests for Hypothesis
     (~8k of ~12k lines of code).  If you're adding or fixing tests, chances
     are therefore good that they're in here!
-
-    We require every change to come with tests in this directory that ensure
-    100% branch coverage.  This can be an intimidating target, but it's entirely
-    achievable and this document is here to help you out.
 
 ``datetime/``
     Tests for the deprecated ``hypothesis.extra.datetime`` module, which
@@ -96,6 +92,9 @@ Still here?  Here's a note on what to expect in each directory.
     More expensive and longer-running tests, typically used to test trickier
     interactions or check for regressions in expensive bugs.  Lots of tests
     about how values shrink, databases, compatibility, etc.
+
+    New tests that are not required for full coverage of code branches or
+    behaviour should also go in ``nocover``, to keep ``cover`` reasonably fast.
 
 ``numpy/``
     Tests for the Numpy extra.

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -1,0 +1,124 @@
+===========
+Don't Panic
+===========
+
+The Hypothesis test suite is large, but we've written these notes to help you
+out.  It's aimed at contributors (new and old!) who know they need to add tests
+*somewhere*, but aren't sure where - or maybe need some hints on what kinds of
+tests might be useful.  Others might just be interested in how a testing
+library tests itself!
+
+
+The very short version
+======================
+
+- To improve code coverage (eg because ``make check-coverage`` / the Travis
+  build is failing), go to ``cover/``
+- For longer / system / integration tests, look in ``nocover/``
+- For tests that require an optional dependency, look in the directory
+  named for that dependency.
+
+.. note::
+    If you get stuck, just ask a maintainer to help out by mentioning
+    ``@HypothesisWorks/hypothesis-python-contributors`` on GitHub.
+    We'd love to help - and also get feedback on how this document could
+    be better!
+
+
+Some scenarios
+==============
+
+**I'm adding or changing a strategy**
+    Check for a file specific to that strategy (eg ``test_uuids.py`` for
+    the ``uuids()`` strategy).  Write tests for all invalid argument handling
+    in ``test_direct_strategies.py``.  Strategies with optional dependencies
+    should go in ``hypothesis.extras``, and the tests in their own module
+    (ie not in ``cover``).  When you think you might be done, push and let
+    Travis point out any failing tests or non-covered code!
+
+**I've made some internal changes**
+    That's not very specific - you should probably refer to the test-finding
+    tips in the next section.  Remember that ``tests/cover`` is reasonably
+    quick unit-test style tests - you should consider writing more intensive
+    integration tests too, but put them in ``tests/nocover`` with the others.
+
+
+Finding particular tests
+========================
+
+With the sheer size and variety in this directory finding a specific thing
+can be tricky.  Tips:
+
+- Check for filenames that are relevant to your contribution.
+- Use ``git grep`` to search for keywords, e.g. the name of a strategy you've changed.
+- Deliberately break something related to your code, and see which tests fail.
+- Ask a maintainer!  Sometimes the structure is just arbitrary, and other tactics
+  don't work - but as I keep saying, we *want* to help!
+
+
+About each group of tests
+=========================
+
+Still here?  Here's a note on what to expect in each directory.
+
+``common/``
+    Useful shared testing code, including test setup and a few helper
+    functions in ``utils.py``.  Also read up on
+    `pytest <https://docs.pytest.org/en/latest/contents.html>`_
+    features such as ``mark.parametrize``, ``mark.skipif``, and ``raises``
+    for other functions that are often useful when writing tests.
+
+``cover/``
+    The home of enough tests to get 100% branch coverage - you'll probably
+    spend most of your time here.  Ideally this would be as quick as possible
+    while remaining comprehensive.  More details inside.
+
+    This directory alone has around two-thirds of the tests for Hypothesis
+    (~8k of ~12k lines of code).  If you're adding or fixing tests, chances
+    are therefore good that they're in here!
+
+    We require every change to come with tests in this directory that ensure
+    100% branch coverage.  This can be an intimidating target, but it's entirely
+    achievable and this document is here to help you out.
+
+``datetime/``
+    Tests for the deprecated ``hypothesis.extra.datetime`` module, which
+    depends on the ``pytz`` package.
+
+``django/``
+    Tests for the Django extra.  Includes a toy application, to give us lots
+    of models to generate.
+
+``fakefactory/``
+    Tests for the deprecated Faker extra.
+
+``nocover/``
+    More expensive and longer-running tests, typically used to test trickier
+    interactions or check for regressions in expensive bugs.  Lots of tests
+    about how values shrink, databases, compatibility, etc.
+
+``numpy/``
+    Tests for the Numpy extra.
+
+``pandas/``
+    Tests for the Pandas extra.
+
+``py2/``
+    Tests that require Python 2.  This is a small group, because almost all
+    of our code and tests are also compatible with Python 3.
+
+``py3/``
+    Tests that require Python 3.  Includes checking that unicode identifiers
+    and function annotations don't break anything, asyncio tests, and tests
+    for inference from type hints.
+
+``pytest/``
+    Hypothesis has excellent integration with ``py.test``, though we are careful
+    to support other test runners including unittest and nose.  This is where we
+    test that our pytest integration is working properly.
+
+``quality/``
+    Tests that various hard-to-find examples do in fact get found by Hypothesis,
+    as well as some stuff about example shrinking.  Mostly intended for tests
+    of the form "Hypothesis finds an example of this condition" + assertions
+    about which example it finds.

--- a/tests/nocover/test_pretty_repr.py
+++ b/tests/nocover/test_pretty_repr.py
@@ -84,9 +84,7 @@ Strategies = st.recursive(
         builds_ignoring_invalid(
             st.dictionaries, x, x,
             dict_class=st.sampled_from([dict, OrderedDict]),
-            min_size=st.integers(min_value=0, max_value=100) | st.none(),
-            max_size=st.integers(min_value=0, max_value=100) | st.none(),
-            average_size=st.floats(min_value=0.0, max_value=100.0) | st.none()
+            **size_strategies
         ),
         st.builds(lambda s, f: s.map(f), x, st.sampled_from(fns)),
     )


### PR DESCRIPTION
> I remember the first time I opened the tests directory. I was working on my first feature to contribute, needed to write tests, and... I just stared at it for a while. The volume is really intimidating for newcomers, and I had no idea where to start!
>
> Adding a tests/README.rst describing the contents and purpose of each sub-directory would be really helpful - with the aim that reading it provides just enough info to direct a new contributor to the right place. For the tests root, this probably includes a brief note on what we try to test and our test philosophy. I'd also add another readme to each subdirectory with a note on the various files - equivalent to a short module docstring but visible in one place.

Closes #975.  The best way to review this might be to check [the branch in my fork](https://github.com/Zac-HD/hypothesis-python/tree/tests-notes/tests), which shows how it will render on GitHub.