### PR TITLE
Allow downstream to disable deprecations-as-errors with environment var

### DIFF
--- a/tests/common/setup.py
+++ b/tests/common/setup.py
@@ -22,17 +22,15 @@ import warnings
 from tempfile import mkdtemp
 
 from hypothesis import settings, unlimited
+from hypothesis.errors import HypothesisDeprecationWarning
 from hypothesis.configuration import set_hypothesis_home_dir
 from hypothesis.internal.charmap import charmap, charmap_file
 from hypothesis.internal.coverage import IN_COVERAGE_TESTS
 
 
-def run(deprecations_as_errors=True):
+def run():
     warnings.filterwarnings('error', category=UnicodeWarning)
-    # This catches deprecations in our dependencies, as well as internally
-    # (because HypothesisDeprecationWarning subclasses DeprecationWarning)
-    if deprecations_as_errors:  # disabled for old versions of Django
-        warnings.filterwarnings('error', category=DeprecationWarning)
+    warnings.filterwarnings('error', category=HypothesisDeprecationWarning)
 
     set_hypothesis_home_dir(mkdtemp())
 

--- a/tests/django/manage.py
+++ b/tests/django/manage.py
@@ -24,10 +24,7 @@ from hypothesis import HealthCheck, settings, unlimited
 from tests.common.setup import run
 
 if __name__ == u'__main__':
-    import django
-
-    django_version = tuple(int(n) for n in django.__version__.split('.')[:2])
-    run(deprecations_as_errors=django_version >= (1, 11))
+    run()
 
     settings.register_profile('default', settings(
         timeout=unlimited, use_coverage=False,

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,9 @@ passenv=
   LC_ALL
   COVERAGE_FILE
 
+setenv=
+  PYTHONWARNINGS={env:PYTHONWARNINGS:error::DeprecationWarning}
+
 [testenv]
 deps =
     -rrequirements/test.txt
@@ -94,12 +97,16 @@ commands =
 
 
 [testenv:django18]
+setenv=
+  PYTHONWARNINGS={env:PYTHONWARNINGS:}
 commands =
     pip install .[datetime]
     pip install django>=1.8,<1.8.99
     python -m tests.django.manage test tests.django
 
 [testenv:django110]
+setenv=
+  PYTHONWARNINGS={env:PYTHONWARNINGS:}
 commands =
     pip install .[datetime]
     pip install --no-binary :all: .[fakefactory]
@@ -145,7 +152,7 @@ setenv=
 commands =
     python -m coverage --version
     python -m coverage debug sys
-    python -m coverage run --rcfile=.coveragerc -m pytest -n0 --strict tests/cover tests/datetime tests/py3 tests/numpy tests/pandas --maxfail=1 --ff {posargs} 
+    python -m coverage run --rcfile=.coveragerc -m pytest -n0 --strict tests/cover tests/datetime tests/py3 tests/numpy tests/pandas --maxfail=1 --ff {posargs}
     python -m coverage report -m --fail-under=100 --show-missing
     python scripts/validate_branch_check.py
 


### PR DESCRIPTION
Closes #969 - the Arch package has unbundled some upstream dependencies, so this option will be useful for @felixonmars 😄 

CC @DRMacIver in case this is one of those things where we have divergent taste in solutions.