### PR TITLE
Handle re.VERBOSE in from_regex

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This is a patch release for :func:`~hypothesis.strategies.from_regex`, which
+had a bug in handling of the :obj:`python:re.VERBOSE` flag (:issue:`992`).
+Flags are now handled correctly when parsing regex.

--- a/src/hypothesis/searchstrategy/regex.py
+++ b/src/hypothesis/searchstrategy/regex.py
@@ -236,7 +236,7 @@ def base_regex_strategy(regex, parsed=None):
     return clear_cache_after_draw(_strategy(
         parsed,
         Context(flags=regex.flags),
-        regex.pattern
+        isinstance(regex.pattern, text_type)
     ))
 
 
@@ -294,7 +294,7 @@ def regex_strategy(regex):
     return maybe_pad(regex, base, left_pad, right_pad)
 
 
-def _strategy(codes, context, pattern):
+def _strategy(codes, context, is_unicode):
     """Convert SRE regex parse tree to strategy that generates strings matching
     that regex represented by that parse tree.
 
@@ -323,9 +323,9 @@ def _strategy(codes, context, pattern):
 
     """
     def recurse(codes):
-        return _strategy(codes, context, pattern)
+        return _strategy(codes, context, is_unicode)
 
-    if isinstance(pattern, text_type):
+    if is_unicode:
         empty = u''
         to_char = hunichr
     else:
@@ -387,7 +387,7 @@ def _strategy(codes, context, pattern):
             if context.flags & re.IGNORECASE and \
                     re.match(c, c.swapcase(), re.IGNORECASE) is not None:
                 blacklist |= set(c.swapcase())
-            if isinstance(pattern, text_type):
+            if is_unicode:
                 return st.characters(blacklist_characters=blacklist)
             else:
                 return binary_char.filter(lambda c: c not in blacklist)
@@ -395,7 +395,7 @@ def _strategy(codes, context, pattern):
         elif code == sre.IN:
             # Regex '[abc0-9]' (set of characters)
             negate = value[0][0] == sre.NEGATE
-            if isinstance(pattern, text_type):
+            if is_unicode:
                 builder = CharactersBuilder(negate, context.flags)
             else:
                 builder = BytesBuilder(negate, context.flags)
@@ -425,7 +425,7 @@ def _strategy(codes, context, pattern):
 
         elif code == sre.ANY:
             # Regex '.' (any char)
-            if isinstance(pattern, text_type):
+            if is_unicode:
                 if context.flags & re.DOTALL:
                     return st.characters()
                 return st.characters(blacklist_characters=u'\n')
@@ -447,7 +447,7 @@ def _strategy(codes, context, pattern):
                 # This feature is available only in specific Python versions
                 context.flags = (context.flags | value[1]) & ~value[2]
 
-            strat = _strategy(value[-1], context, pattern)
+            strat = _strategy(value[-1], context, is_unicode)
 
             context.flags = old_flags
 

--- a/src/hypothesis/searchstrategy/regex.py
+++ b/src/hypothesis/searchstrategy/regex.py
@@ -232,7 +232,7 @@ def maybe_pad(draw, regex, strategy, left_pad_strategy, right_pad_strategy):
 
 def base_regex_strategy(regex, parsed=None):
     if parsed is None:
-        parsed = sre_parse.parse(regex.pattern)
+        parsed = sre_parse.parse(regex.pattern, flags=regex.flags)
     return clear_cache_after_draw(_strategy(
         parsed,
         Context(flags=regex.flags),
@@ -246,7 +246,7 @@ def regex_strategy(regex):
 
     is_unicode = isinstance(regex.pattern, text_type)
 
-    parsed = sre_parse.parse(regex.pattern)
+    parsed = sre_parse.parse(regex.pattern, flags=regex.flags)
 
     if not parsed:
         if is_unicode:

--- a/tests/cover/test_regex.py
+++ b/tests/cover/test_regex.py
@@ -375,3 +375,12 @@ def test_shared_union():
     # interesting feature of which is that it contains empty sub-expressions
     # in the branch.
     find_any(st.from_regex('.|.'))
+
+
+@given(st.data())
+def test_issue_992_regression(data):
+    strat = st.from_regex(re.compile(
+        r"""\d +  # the integral part
+            \.    # the decimal point
+            \d *  # some fractional digits""", re.VERBOSE))
+    data.draw(strat)


### PR DESCRIPTION
Turns out we should have been passing the flags through to `sre_parse.parse` along with the pattern, and failing to do so breaks things.  Obvious in hindsight!  Closes #992.

And I did a minor refactor while I was there, passing a bool `is_text` instead of checking the type of the pattern every time.