### PR TITLE
Handle blacklisted characters as part of the intervals

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,9 @@
+RELEASE_TYPE: patch
+
+This release improves the performance of
+:func:`hypothesis.strategies.characters` when using ``blacklist_characters``
+and :func:`hypothesis.strategies.from_regex` when using negative character
+classes.
+
+The problems this fixes were found in the course of work funded by
+`Smarkets <https://smarkets.com/>`_.

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,8 +1,8 @@
 RELEASE_TYPE: patch
 
 This release improves the performance of
-:func:`hypothesis.strategies.characters` when using ``blacklist_characters``
-and :func:`hypothesis.strategies.from_regex` when using negative character
+:func:`~hypothesis.strategies.characters` when using ``blacklist_characters``
+and :func:`~hypothesis.strategies.from_regex` when using negative character
 classes.
 
 The problems this fixes were found in the course of work funded by

--- a/src/hypothesis/internal/charmap.py
+++ b/src/hypothesis/internal/charmap.py
@@ -172,7 +172,7 @@ def _subtract_intervals(x, y):
             else:
                 i += 1
     result.extend(x[i:])
-    return list(map(tuple, result))
+    return tuple(map(tuple, result))
 
 
 def _intervals(s):

--- a/src/hypothesis/internal/charmap.py
+++ b/src/hypothesis/internal/charmap.py
@@ -142,35 +142,77 @@ def _union_intervals(x, y):
 
 
 def _subtract_intervals(x, y):
-    """Return a list of intervals that bounds everything bounded by x that is
-    not also bounded by y."""
+    """Set difference for lists of intervals. That is, returns a list of
+    intervals that bounds all values bounded by x that are not also bounded by
+    y. x and y are expected to be in sorted order.
+
+    For example _subtract_intervals([(1, 10)], [(2, 3), (9, 15)]) would
+    return [(1, 1), (4, 8)], removing the values 2, 3, 9 and 10 from the
+    interval.
+
+    """
     if not y:
-        return x
+        return tuple(x)
     x = list(map(list, x))
     i = 0
     j = 0
     result = []
     while i < len(x) and j < len(y):
+        # Iterate in parallel over x and y. j stays pointing at the smallest
+        # interval in the left hand side that could still overlap with some
+        # element of x at index >= i.
+        # Similarly, i is not incremented until we know that it does not
+        # overlap with any element of y at index >= j.
+
         xl, xr = x[i]
         assert xl <= xr
         yl, yr = y[j]
         assert yl <= yr
+
         if yr < xl:
+            # The interval at y[j] is strictly to the left of the interval at
+            # x[i], so will not overlap with it or any later interval of x.
             j += 1
         elif yl > xr:
+            # The interval at y[j] is strictly to the right of the interval at
+            # x[i], so all of x[i] goes into the result as no further intervals
+            # in y will intersect it.
             result.append(x[i])
             i += 1
         elif yl <= xl:
             if yr >= xr:
+                # x[i] is contained entirely in y[j], so we just skip over it
+                # without adding it to the result.
                 i += 1
             else:
+                # The beginning of x[i] is contained in y[j], so we update the
+                # left endpoint of x[i] to remove this, and increment j as we
+                # now have moved past it. Note that this is not added to the
+                # result as is, as more intervals from y may intersect it so it
+                # may need updating further.
                 x[i][0] = yr + 1
+                j += 1
         else:
+            # yl > xl, so the left hand part of x[i] is not contained in y[j],
+            # so there are some values we should add to the result.
             result.append((xl, yl - 1))
+
             if yr + 1 <= xr:
+                # If y[j] finishes before x[i] does, there may be some values
+                # in x[i] left that should go in the result (or they may be
+                # removed by a later interval in y), so we update x[i] to
+                # reflect that and increment j because it no longer overlaps
+                # with any remaining element of x.
                 x[i][0] = yr + 1
+                j += 1
             else:
+                # Every element of x[i] other than the initial part we have
+                # already added is contained in y[j], so we move to the next
+                # interval.
                 i += 1
+    # Any remaining intervals in x do not overlap with any of y, as if they did
+    # we would not have incremented j to the end, so can be added to the result
+    # as they are.
     result.extend(x[i:])
     return tuple(map(tuple, result))
 

--- a/src/hypothesis/searchstrategy/strings.py
+++ b/src/hypothesis/searchstrategy/strings.py
@@ -45,6 +45,7 @@ class OneCharStringStrategy(SearchStrategy):
             min_codepoint=min_codepoint,
             max_codepoint=max_codepoint,
             include_characters=whitelist_characters,
+            exclude_characters=blacklist_characters,
         )
         if not intervals:
             raise InvalidArgument(
@@ -55,28 +56,14 @@ class OneCharStringStrategy(SearchStrategy):
             self.whitelist_characters = set(whitelist_characters)
         else:
             self.whitelist_characters = set()
-        if blacklist_characters:
-            self.blacklist_characters = set(
-                b for b in blacklist_characters if ord(b) in self.intervals
-            )
-            if (len(self.whitelist_characters) == 0 and
-                    len(self.blacklist_characters) == len(self.intervals)):
-                raise InvalidArgument(
-                    'No valid characters in set'
-                )
-        else:
-            self.blacklist_characters = set()
         self.zero_point = self.intervals.index_above(ord('0'))
 
     def do_draw(self, data):
-        while True:
-            i = integer_range(
-                data, 0, len(self.intervals) - 1,
-                center=self.zero_point,
-            )
-            c = hunichr(self.intervals[i])
-            if c not in self.blacklist_characters:
-                return c
+        i = integer_range(
+            data, 0, len(self.intervals) - 1,
+            center=self.zero_point,
+        )
+        return hunichr(self.intervals[i])
 
 
 class StringStrategy(MappedSearchStrategy):

--- a/tests/cover/test_charmap.py
+++ b/tests/cover/test_charmap.py
@@ -165,3 +165,7 @@ def test_regenerate_broken_charmap_file():
 
     cm._charmap = None
     cm.charmap()
+
+
+def test_exclude_characters_are_included_in_key():
+    assert cm.query() != cm.query(exclude_characters='0')

--- a/tests/cover/test_intervalset.py
+++ b/tests/cover/test_intervalset.py
@@ -20,7 +20,8 @@ from __future__ import division, print_function, absolute_import
 import pytest
 
 import hypothesis.strategies as st
-from hypothesis import given, assume
+from hypothesis import given, assume, example
+from hypothesis.internal.charmap import _subtract_intervals
 from hypothesis.internal.intervalsets import IntervalSet
 
 
@@ -31,17 +32,19 @@ def build_intervals(ls):
         v = u + l
         if result:
             a, b = result[-1]
-            if u <= b:
+            if u <= b + 1:
                 result[-1] = (a, v)
                 continue
         result.append((u, v))
-    return IntervalSet(result)
+    return result
 
 
-Intervals = st.builds(
+IntervalLists = st.builds(
     build_intervals,
-    st.lists(st.tuples(st.integers(), st.integers(0, 20)))
+    st.lists(st.tuples(st.integers(0, 200), st.integers(0, 20)))
 )
+
+Intervals = st.builds(IntervalSet, IntervalLists)
 
 
 @given(Intervals)
@@ -86,3 +89,22 @@ def test_index_above_is_index_if_present():
 
 def test_index_above_is_length_if_higher():
     assert IntervalSet([[1, 10]]).index_above(100) == 10
+
+
+def intervals_to_set(ints):
+    return set(IntervalSet(ints))
+
+
+@example(x=[(0, 1), (3, 3)], y=[(1, 3)])
+@example(x=[(0, 1)], y=[(0, 0), (1, 1)])
+@example(x=[(0, 1)], y=[(1, 1)])
+@given(IntervalLists, IntervalLists)
+def test_subtraction_of_intervals(x, y):
+    xs = intervals_to_set(x)
+    ys = intervals_to_set(x)
+    assume(not xs.isdisjoint(ys))
+    z = _subtract_intervals(x, y)
+    assert z == sorted(z)
+    for a, b in z:
+        assert a <= b
+    assert intervals_to_set(z) == intervals_to_set(x) - intervals_to_set(y)

--- a/tests/cover/test_intervalset.py
+++ b/tests/cover/test_intervalset.py
@@ -104,7 +104,7 @@ def test_subtraction_of_intervals(x, y):
     ys = intervals_to_set(x)
     assume(not xs.isdisjoint(ys))
     z = _subtract_intervals(x, y)
-    assert z == sorted(z)
+    assert z == tuple(sorted(z))
     for a, b in z:
         assert a <= b
     assert intervals_to_set(z) == intervals_to_set(x) - intervals_to_set(y)

--- a/tests/nocover/test_characters.py
+++ b/tests/nocover/test_characters.py
@@ -1,0 +1,45 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2017 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import string
+
+from hypothesis import strategies as st
+from hypothesis import given
+
+IDENTIFIER_CHARS = string.ascii_letters + string.digits + '_'
+
+
+@given(st.characters(blacklist_characters=IDENTIFIER_CHARS))
+def test_large_blacklist(c):
+    assert c not in IDENTIFIER_CHARS
+
+
+@given(st.data())
+def test_arbitrary_blacklist(data):
+    blacklist = data.draw(
+        st.text(st.characters(max_codepoint=1000), min_size=1))
+    ords = list(map(ord, blacklist))
+    c = data.draw(
+        st.characters(
+            blacklist_characters=blacklist,
+            min_codepoint=max(0, min(ords) - 1),
+            max_codepoint=max(0, max(ords) + 1),
+        )
+    )
+    assert c not in blacklist


### PR DESCRIPTION
Instead of supporting blacklisted characters with rejection sampling, this updates the interval set we use to generate characters to remove them. This should significantly improve the efficiency in some cases, particularly when shrinking if the blacklisted characters include a bunch of small codepoints.

Extracted from #996, where this code triggered a new health check.