### PR TITLE
Improve interactions between example database and seeding

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,15 @@
+RELEASE_TYPE: minor
+
+This release improves how various ways of seeding Hypothesis interact with the
+example database:
+
+* Using the example database with :func:`~hypothesis.seed` is now deprecated.
+  You should set ``database=None`` if you are doing that. This will only warn
+  if you actually load examples from the database while using ``@seed``.
+* The :attr:`~hypothesis.settings.derandomize` will behave the same way as
+  ``@seed``.
+* Using ``--hypothesis-seed`` will disable use of the database.
+* If a test used examples from the database, it will not suggest using a seed
+  to reproduce it, because that won't work.
+
+This work was funded by `Smarkets <https://smarkets.com/>`_.

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -625,7 +625,10 @@ class StateForActualGivenExecution(object):
     def run(self):
         # Tell pytest to omit the body of this function from tracebacks
         __tracebackhide__ = True
-        database_key = str_to_bytes(fully_qualified_name(self.test))
+        if global_force_seed is None:
+            database_key = str_to_bytes(fully_qualified_name(self.test))
+        else:
+            database_key = None
         self.start_time = time.time()
         global in_given
         runner = ConjectureRunner(

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -388,7 +388,9 @@ FORCE_PURE_TRACER = os.getenv('HYPOTHESIS_FORCE_PURE_TRACER') == 'true'
 
 class StateForActualGivenExecution(object):
 
-    def __init__(self, test_runner, search_strategy, test, settings, random):
+    def __init__(
+        self, test_runner, search_strategy, test, settings, random, had_seed
+    ):
         self.test_runner = test_runner
         self.search_strategy = search_strategy
         self.settings = settings
@@ -400,11 +402,14 @@ class StateForActualGivenExecution(object):
         self.__warned_deadline = False
         self.__existing_collector = None
         self.__test_runtime = None
+        self.__had_seed = had_seed
 
         self.test = test
 
         self.coverage_data = CoverageData()
         self.files_to_propagate = set()
+
+        self.used_examples_from_database = False
 
         if settings.use_coverage and not IN_COVERAGE_TESTS:  # pragma: no cover
             if Collector._collectors:
@@ -650,6 +655,25 @@ class StateForActualGivenExecution(object):
                 sys.settrace(original_trace)
         note_engine_for_statistics(runner)
         run_time = time.time() - self.start_time
+
+        self.used_examples_from_database = runner.used_examples_from_database
+
+        if runner.used_examples_from_database:
+            if self.settings.derandomize:
+                note_deprecation(
+                    'In future derandomize will imply database=None, but your '
+                    'test is currently using examples from the database. To '
+                    'get the future behaviour, update your settings to '
+                    'include database=None.'
+                )
+            if self.__had_seed:
+                note_deprecation(
+                    'In future use of @seed will imply database=None in your '
+                    'settings, but your test is currently using examples from '
+                    'the database. To get the future behaviour, update your '
+                    'settings for this test to include database=None.'
+                )
+
         timed_out = runner.exit_reason == ExitReason.timeout
         if runner.last_data is None:
             return
@@ -830,12 +854,17 @@ def given(*given_arguments, **given_kwargs):
 
             try:
                 state = StateForActualGivenExecution(
-                    test_runner, search_strategy, test, settings, random)
+                    test_runner, search_strategy, test, settings, random,
+                    had_seed=wrapped_test._hypothesis_internal_use_seed
+                )
                 state.run()
             except BaseException:
                 generated_seed = \
                     wrapped_test._hypothesis_internal_use_generated_seed
-                if generated_seed is not None:
+                if (
+                    generated_seed is not None and
+                    not state.used_examples_from_database
+                ):
                     if running_under_pytest:
                         report((
                             'You can add @seed(%(seed)d) to this test or run '

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -136,6 +136,8 @@ class ConjectureRunner(object):
 
         self.health_check_state = None
 
+        self.used_examples_from_database = False
+
     def __tree_is_exhausted(self):
         return 0 in self.dead
 
@@ -727,6 +729,8 @@ class ConjectureRunner(object):
                         extra = self.random.sample(extra_corpus, shortfall)
                     extra.sort(key=sort_key)
                     corpus.extend(extra)
+
+            self.used_examples_from_database = len(corpus) > 0
 
             for existing in corpus:
                 self.last_data = ConjectureData.for_buffer(existing)

--- a/tests/cover/test_database_seed_deprecation.py
+++ b/tests/cover/test_database_seed_deprecation.py
@@ -1,0 +1,42 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2017 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import pytest
+
+from hypothesis import strategies as st
+from hypothesis import seed, given, settings
+from tests.common.utils import validate_deprecation
+from hypothesis.database import InMemoryExampleDatabase
+
+
+@pytest.mark.parametrize('dec', [
+    settings(database=InMemoryExampleDatabase(), derandomize=True), seed(1)
+])
+def test_deprecated_determinism_with_database(dec):
+    @dec
+    @given(st.booleans())
+    def test(i):
+        raise ValueError()
+
+    with pytest.raises(ValueError):
+        test()
+
+    with validate_deprecation():
+        with pytest.raises(ValueError):
+            test()

--- a/tests/cover/test_database_usage.py
+++ b/tests/cover/test_database_usage.py
@@ -20,12 +20,12 @@ from __future__ import division, print_function, absolute_import
 import pytest
 
 import hypothesis.strategies as st
-from hypothesis import Verbosity, find, given, assume, settings, unlimited
+from hypothesis import Verbosity, core, find, given, assume, settings, \
+    unlimited
 from hypothesis.errors import NoSuchExample, Unsatisfiable
 from tests.common.utils import all_values, non_covering_examples
 from hypothesis.database import InMemoryExampleDatabase
 from hypothesis.internal.compat import hbytes
-from hypothesis import core
 
 
 def has_a_non_zero_byte(x):

--- a/tests/cover/test_database_usage.py
+++ b/tests/cover/test_database_usage.py
@@ -25,6 +25,7 @@ from hypothesis.errors import NoSuchExample, Unsatisfiable
 from tests.common.utils import all_values, non_covering_examples
 from hypothesis.database import InMemoryExampleDatabase
 from hypothesis.internal.compat import hbytes
+from hypothesis import core
 
 
 def has_a_non_zero_byte(x):
@@ -173,3 +174,16 @@ def test_clears_out_everything_smaller_than_the_interesting_example():
 
     for s in saved:
         assert s >= target
+
+
+def test_does_not_use_database_when_seed_is_forced(monkeypatch):
+    monkeypatch.setattr(core, 'global_force_seed', 42)
+    database = InMemoryExampleDatabase()
+    database.fetch = None
+
+    @settings(database=database)
+    @given(st.integers())
+    def test(i):
+        pass
+
+    test()

--- a/tests/cover/test_settings.py
+++ b/tests/cover/test_settings.py
@@ -29,7 +29,8 @@ from hypothesis.errors import InvalidState, InvalidArgument, \
 from tests.common.utils import checks_deprecated_behaviour
 from hypothesis.database import ExampleDatabase, \
     DirectoryBasedExampleDatabase
-from hypothesis._settings import Verbosity, settings, note_deprecation
+from hypothesis._settings import Verbosity, settings, default_variable, \
+    note_deprecation
 
 
 def test_has_docstrings():
@@ -119,6 +120,12 @@ def test_inherits_an_empty_database(db):
 def test_can_assign_database(db):
     x = settings(database=db)
     assert x.database is db
+
+
+def test_will_reload_profile_when_default_is_absent():
+    original = settings.default
+    default_variable.value = None
+    assert settings.default is original
 
 
 def test_load_profile():

--- a/tests/nocover/test_floating.py
+++ b/tests/nocover/test_floating.py
@@ -24,10 +24,9 @@ from __future__ import division, print_function, absolute_import
 import sys
 import math
 
-from hypothesis import HealthCheck, seed, given, assume, reject, settings
-from hypothesis.errors import Unsatisfiable
+from hypothesis import HealthCheck, given, assume, settings
 from tests.common.utils import fails
-from hypothesis.strategies import lists, floats, integers
+from hypothesis.strategies import data, lists, floats
 
 TRY_HARDER = settings(
     max_examples=1000, max_iterations=2000,
@@ -149,21 +148,14 @@ def test_can_find_floats_that_do_not_round_trip_through_reprs(x):
     assert float(repr(x)) == x
 
 
+finite_floats = floats(allow_infinity=False, allow_nan=False)
+
+
 @settings(deadline=None)
-@given(floats(), floats(), integers())
-def test_floats_are_in_range(x, y, s):
-    assume(not (math.isnan(x) or math.isnan(y)))
-    assume(not (math.isinf(x) or math.isinf(y)))
+@given(finite_floats, finite_floats, data())
+def test_floats_are_in_range(x, y, data):
     x, y = sorted((x, y))
     assume(x < y)
 
-    @given(floats(x, y))
-    @seed(s)
-    @settings(max_examples=10)
-    def test_is_in_range(t):
-        assert x <= t <= y
-
-    try:
-        test_is_in_range()
-    except Unsatisfiable:
-        reject()
+    t = data.draw(floats(x, y))
+    assert x <= t <= y


### PR DESCRIPTION
Turns out that telling someone the seed isn't very helpful if they then need the entire example database to recreate it!

This is kinda an interim "just make things not broken" release. It patches a lot of little interactions, adds some deprecations, and tries to make things not terrible. A proper fix is out of scope for now - it requires us to think about example DB workflows a lot better than we currently have.