### PR TITLE
Test Pandas 0.21 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,9 +61,9 @@ env:
         - TASK=check-django18
         - TASK=check-django110
         - TASK=check-django111
-        - TASK=check-pandas18
         - TASK=check-pandas19
         - TASK=check-pandas20
+        - TASK=check-pandas21
         - TASK=deploy
 
 script:

--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,9 @@ check-pandas19: $(TOX)
 check-pandas20: $(TOX)
 	$(TOX) --recreate -e pandas20
 
+check-pandas21: $(TOX)
+	$(TOX) --recreate -e pandas21
+
 check-examples2: $(TOX) $(PY27)
 	$(TOX) --recreate -e examples2
 

--- a/docs/extras.rst
+++ b/docs/extras.rst
@@ -16,6 +16,8 @@ and even harder to regularly test. Hypothesis is always tested against the lates
 compatible version and each package will note the expected compatibility range. If
 you run into a bug with any of these please specify the dependency version.
 
+There are seperate pages for :doc:`django` and :doc:`numpy`.
+
 --------------------
 hypothesis[pytz]
 --------------------
@@ -87,26 +89,3 @@ Generally you probably shouldn't do this unless you're reusing a provider you
 already have - Hypothesis's facilities for strategy generation are much more
 powerful and easier to use. This is only here to provide easy
 reuse of things you already have.
-
-------------------
-hypothesis[django]
-------------------
-
-hypothesis.extra.django adds support for testing your Django models with Hypothesis.
-
-It is tested extensively against all versions of Django in mainstream or
-extended support, including LTS releases.  It *may* be compatible with
-earlier versions too, but there's no support from us either and you really
-should update to get security patches.
-
-It's large enough that it is :doc:`documented elsewhere <django>`.
-
-------------------
-hypothesis[numpy]
-------------------
-
-hypothesis.extra.numpy adds support for testing your Numpy code with Hypothesis.
-
-This includes generating arrays, array shapes, and both scalar or compound dtypes.
-
-Like the Django extra, :doc:`Numpy has it's own page <numpy>`.

--- a/docs/numpy.rst
+++ b/docs/numpy.rst
@@ -45,9 +45,8 @@ Supported Versions
 
 There is quite a lot of variation between pandas versions. We only
 commit to supporting the latest version of pandas, but older minor versions are
-supported on a "best effort" basis.
-
-Hypothesis is currently confirmed to work on 0.18.1, 0.19.2, and 0.20.3.
+supported on a "best effort" basis.  Hypothesis is currently tested against
+and confirmed working with Pandas 0.19, 0.20, and 0.21.
 
 Releases that are not the latest patch release of their minor version are not
 tested or officially supported, but will probably also work unless you hit a

--- a/tox.ini
+++ b/tox.ini
@@ -95,6 +95,13 @@ deps =
 commands =
     python -m pytest tests/pandas
 
+[testenv:pandas21]
+deps =
+    -rrequirements/test.txt
+    pandas~=0.21.0
+commands =
+    python -m pytest tests/pandas
+
 
 [testenv:django18]
 setenv=

--- a/tox.ini
+++ b/tox.ini
@@ -77,21 +77,21 @@ commands =
 [testenv:pandas18]
 deps =
     -rrequirements/test.txt
-    pandas==0.18.1
+    pandas~=0.18.1
 commands =
     python -m pytest tests/pandas
 
 [testenv:pandas19]
 deps =
     -rrequirements/test.txt
-    pandas==0.19.2
+    pandas~=0.19.2
 commands =
     python -m pytest tests/pandas
 
 [testenv:pandas20]
 deps =
     -rrequirements/test.txt
-    pandas==0.20.3
+    pandas~=0.20.3
 commands =
     python -m pytest tests/pandas
 
@@ -100,24 +100,24 @@ commands =
 setenv=
   PYTHONWARNINGS={env:PYTHONWARNINGS:}
 commands =
-    pip install .[datetime]
-    pip install django>=1.8,<1.8.99
+    pip install .[pytz]
+    pip install django~=1.8.18
     python -m tests.django.manage test tests.django
 
 [testenv:django110]
 setenv=
   PYTHONWARNINGS={env:PYTHONWARNINGS:}
 commands =
-    pip install .[datetime]
+    pip install .[pytz]
     pip install --no-binary :all: .[fakefactory]
-    pip install django>=1.10,<1.10.99
+    pip install django~=1.10.8
     python -m tests.django.manage test tests.django
 
 [testenv:django111]
 commands =
-    pip install .[datetime]
+    pip install .[pytz]
     pip install --no-binary :all: .[fakefactory]
-    pip install django>=1.11,<1.11.99
+    pip install django~=1.11.7
     python -m tests.django.manage test tests.django
 
 [testenv:nose]


### PR DESCRIPTION
- Closes #983.
- For efficiency I've also dropped Pandas 0.18 from our CI suite, though it remains available to run locally.
- Minor edit to Tox environment setup; now uses latest compatible patch version of optional packages.
- Reduced redundant docs.