### PR TITLE
Add support for Django 2.0; drop support for Django 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ env:
         - TASK=check-pytest28
         - TASK=check-faker070
         - TASK=check-faker-latest
+        - TASK=check-django20
         - TASK=check-django18
         - TASK=check-django110
         - TASK=check-django111

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,8 +59,8 @@ env:
         - TASK=check-faker-latest
         - TASK=check-django20
         - TASK=check-django18
-        - TASK=check-django110
         - TASK=check-django111
+        - TASK=check-django20
         - TASK=check-pandas19
         - TASK=check-pandas20
         - TASK=check-pandas21

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,6 @@ env:
         - TASK=check-django20
         - TASK=check-django18
         - TASK=check-django111
-        - TASK=check-django20
         - TASK=check-pandas19
         - TASK=check-pandas20
         - TASK=check-pandas21

--- a/Makefile
+++ b/Makefile
@@ -163,16 +163,13 @@ check-faker-latest: $(TOX)
 check-django18: $(TOX)
 	$(TOX) --recreate -e django18
 
-check-django110: $(TOX)
-	$(TOX) --recreate -e django110
-
 check-django111: $(TOX)
 	$(TOX) --recreate -e django111
 
 check-django20: $(BEST_PY3) $(TOX)
 	$(TOX) --recreate -e django20
 
-check-django: check-django18 check-django110 check-django111 check-django20
+check-django: check-django18 check-django111 check-django20
 
 check-pandas18: $(TOX)
 	$(TOX) --recreate -e pandas18

--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,10 @@ check-django110: $(TOX)
 check-django111: $(TOX)
 	$(TOX) --recreate -e django111
 
-check-django: check-django18 check-django110 check-django111
+check-django20: $(BEST_PY3) $(TOX)
+	$(TOX) --recreate -e django20
+
+check-django: check-django18 check-django110 check-django111 check-django20
 
 check-pandas18: $(TOX)
 	$(TOX) --recreate -e pandas18

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This release adds support for `Django 2`_ in
+the hypothesis-django extra.
+
+`Django 2`_: https://www.djangoproject.com/weblog/2017/dec/02/django-20-released/

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,6 +1,5 @@
 RELEASE_TYPE: patch
 
-This release adds support for `Django 2`_ in
+This release adds support for `Django 2
+<https://www.djangoproject.com/weblog/2017/dec/02/django-20-released/>`_ in
 the hypothesis-django extra.
-
-`Django 2`_: https://www.djangoproject.com/weblog/2017/dec/02/django-20-released/

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -3,3 +3,6 @@ RELEASE_TYPE: patch
 This release adds support for `Django 2
 <https://www.djangoproject.com/weblog/2017/dec/02/django-20-released/>`_ in
 the hypothesis-django extra.
+
+This release drops support for Django 1.10, as it is no longer supported by
+the Django team.

--- a/docs/django.rst
+++ b/docs/django.rst
@@ -5,7 +5,7 @@ Hypothesis for Django users
 ===========================
 
 Hypothesis offers a number of features specific for Django testing, available
-in the :mod:`hypothesis[django]` :doc:`extra </extras>`.  This is tested
+in ``hypothesis.extra.django``.  This is tested
 against each supported series with mainstream or extended support -
 if you're still getting security patches, you can test with Hypothesis.
 

--- a/docs/django.rst
+++ b/docs/django.rst
@@ -5,7 +5,7 @@ Hypothesis for Django users
 ===========================
 
 Hypothesis offers a number of features specific for Django testing, available
-in ``hypothesis.extra.django``.  This is tested
+in the :mod:`hypothesis[django]` :doc:`extra </extras>`.  This is tested
 against each supported series with mainstream or extended support -
 if you're still getting security patches, you can test with Hypothesis.
 

--- a/scripts/basic-test.sh
+++ b/scripts/basic-test.sh
@@ -57,12 +57,15 @@ $PYTEST tests/fakefactory/
 pip uninstall -y faker
 
 if [ "$(python -c 'import platform; print(platform.python_implementation())')" != "PyPy" ]; then
-  if [ "$(python -c 'import sys; print(sys.version_info[:2] >= (3, 4))')" == "True" ] ; then
+  if [ "$(python -c 'import sys; print(sys.version_info[0] == 3)')" = "True" ] ; then
     pip install .[django]
-    HYPOTHESIS_DJANGO_USETZ=TRUE python -m tests.django.manage test tests.django
-    HYPOTHESIS_DJANGO_USETZ=FALSE python -m tests.django.manage test tests.django
-    pip uninstall -y django
+  else
+    pip install django~=1.11.8
+    pip install pytz
   fi
+  HYPOTHESIS_DJANGO_USETZ=TRUE python -m tests.django.manage test tests.django
+  HYPOTHESIS_DJANGO_USETZ=FALSE python -m tests.django.manage test tests.django
+  pip uninstall -y django pytz
 
   if [ "$(python -c 'import sys; print(sys.version_info[:2] in ((2, 7), (3, 6)))')" = "True" ] ; then
     pip install numpy

--- a/scripts/basic-test.sh
+++ b/scripts/basic-test.sh
@@ -57,7 +57,7 @@ $PYTEST tests/fakefactory/
 pip uninstall -y faker
 
 if [ "$(python -c 'import platform; print(platform.python_implementation())')" != "PyPy" ]; then
-  if [ "$(python -c 'import sys; print(sys.version_info[0] == 2 or sys.version_info[:2] >= (3, 4))')" == "True" ] ; then
+  if [ "$(python -c 'import sys; print(sys.version_info[:2] >= (3, 4))')" == "True" ] ; then
     pip install .[django]
     HYPOTHESIS_DJANGO_USETZ=TRUE python -m tests.django.manage test tests.django
     HYPOTHESIS_DJANGO_USETZ=FALSE python -m tests.django.manage test tests.django

--- a/scripts/basic-test.sh
+++ b/scripts/basic-test.sh
@@ -57,15 +57,12 @@ $PYTEST tests/fakefactory/
 pip uninstall -y faker
 
 if [ "$(python -c 'import platform; print(platform.python_implementation())')" != "PyPy" ]; then
-  if [ "$(python -c 'import sys; print(sys.version_info[0] == 3)')" = "True" ] ; then
+  if [ "$(python -c 'import sys; print(sys.version_info[0] == 2 or sys.version_info[:2] >= (3, 4))')" == "True" ] ; then
     pip install .[django]
-  else
-    pip install django~=1.11.8
-    pip install pytz
+    HYPOTHESIS_DJANGO_USETZ=TRUE python -m tests.django.manage test tests.django
+    HYPOTHESIS_DJANGO_USETZ=FALSE python -m tests.django.manage test tests.django
+    pip uninstall -y django pytz
   fi
-  HYPOTHESIS_DJANGO_USETZ=TRUE python -m tests.django.manage test tests.django
-  HYPOTHESIS_DJANGO_USETZ=FALSE python -m tests.django.manage test tests.django
-  pip uninstall -y django pytz
 
   if [ "$(python -c 'import sys; print(sys.version_info[:2] in ((2, 7), (3, 6)))')" = "True" ] ; then
     pip install numpy

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ extras = {
     'datetime':  ['pytz'],
     'pytz':  ['pytz'],
     'fakefactory': ['Faker>=0.7'],
-    'django': ['pytz', 'django>=1.8,<2'],
+    'django': ['pytz', 'django>=1.8,!=1.9.*,!=1.10.*,<3'],
     'numpy': ['numpy>=1.9.0'],
     'pytest': ['pytest>=2.8.0'],
 }

--- a/setup.py
+++ b/setup.py
@@ -56,9 +56,9 @@ extras = {
 #
 # See https://github.com/HypothesisWorks/hypothesis-python/pull/1008
 if sys.version_info[0] < 3:
-    extras['django'] = ['pytz', 'django>=1.8,!=1.9.*,!=1.10.*,<2']
+    extras['django'] = ['pytz', 'django>=1.8,<2']
 else:
-    extras['django'] = ['pytz', 'django>=1.8,!=1.9.*,!=1.10.*,<3']
+    extras['django'] = ['pytz', 'django>=1.8,<3']
 
 extras['faker'] = extras['fakefactory']
 

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,18 @@ extras = {
     'datetime':  ['pytz'],
     'pytz':  ['pytz'],
     'fakefactory': ['Faker>=0.7'],
-    'django': ['pytz', 'django>=1.8,!=1.9.*,!=1.10.*,<3'],
+    'django': [
+        'pytz',
+
+        # Django 2 only supports Python 3, but doesn't have any python_requires
+        # markers in its setup.py --- so "pip install django" just fails in
+        # Python 2.  So rather than relying on pip, we pin the version of
+        # Django on Python 2 ourselves.
+        #
+        # See https://github.com/HypothesisWorks/hypothesis-python/pull/1008
+        'django>=1.8,!=1.9.*,!=1.10.*,<2:python_version<3',
+        'django>=1.8,!=1.9.*,!=1.10.*,<3:python_version>=3',
+    ],
     'numpy': ['numpy>=1.9.0'],
     'pytest': ['pytest>=2.8.0'],
 }

--- a/setup.py
+++ b/setup.py
@@ -45,21 +45,20 @@ extras = {
     'datetime':  ['pytz'],
     'pytz':  ['pytz'],
     'fakefactory': ['Faker>=0.7'],
-    'django': [
-        'pytz',
-
-        # Django 2 only supports Python 3, but doesn't have any python_requires
-        # markers in its setup.py --- so "pip install django" just fails in
-        # Python 2.  So rather than relying on pip, we pin the version of
-        # Django on Python 2 ourselves.
-        #
-        # See https://github.com/HypothesisWorks/hypothesis-python/pull/1008
-        'django>=1.8,!=1.9.*,!=1.10.*,<2:python_version<3',
-        'django>=1.8,!=1.9.*,!=1.10.*,<3:python_version>=3',
-    ],
     'numpy': ['numpy>=1.9.0'],
     'pytest': ['pytest>=2.8.0'],
 }
+
+# Django 2 only supports Python 3, but doesn't have any python_requires
+# markers in its setup.py --- so "pip install django" just fails in
+# Python 2.  So rather than relying on pip, we pin the version of
+# Django on Python 2 ourselves.
+#
+# See https://github.com/HypothesisWorks/hypothesis-python/pull/1008
+if sys.version_info[0] < 3:
+    extras['django'] = ['pytz', 'django>=1.8,!=1.9.*,!=1.10.*,<2']
+else:
+    extras['django'] = ['pytz', 'django>=1.8,!=1.9.*,!=1.10.*,<3']
 
 extras['faker'] = extras['fakefactory']
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ from __future__ import division, print_function, absolute_import
 import os
 import sys
 
-from setuptools import setup, find_packages, __version__ as setuptools_version
+import setuptools
 
 
 def local_file(name):
@@ -65,7 +65,7 @@ else:
 #
 # New versions of setuptools allow us to set very precise pins; older versions
 # of setuptools are coarser.
-major_setuptools_version = int(setuptools_version.split('.')[0])
+major_setuptools_version = int(setuptools.__version__.split('.')[0])
 if major_setuptools_version >= 8:
     django_minor_pin = '>=1.8,!=1.9.*,!=1.10.*'
 else:
@@ -85,12 +85,12 @@ install_requires = ['attrs', 'coverage']
 if sys.version_info[0] < 3:
     install_requires.append('enum34')
 
-setup(
+setuptools.setup(
     name='hypothesis',
     version=__version__,
     author='David R. MacIver',
     author_email='david@drmaciver.com',
-    packages=find_packages(SOURCE),
+    packages=setuptools.find_packages(SOURCE),
     package_dir={'': SOURCE},
     url='https://github.com/HypothesisWorks/hypothesis-python',
     license='MPL v2',

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ from __future__ import division, print_function, absolute_import
 import os
 import sys
 
-from setuptools import setup, find_packages
+from setuptools import setup, find_packages, __version__ as setuptools_version
 
 
 def local_file(name):
@@ -56,9 +56,23 @@ extras = {
 #
 # See https://github.com/HypothesisWorks/hypothesis-python/pull/1008
 if sys.version_info[0] < 3:
-    extras['django'] = ['pytz', 'django>=1.8,<2']
+    django_major_pin = '<2'
 else:
-    extras['django'] = ['pytz', 'django>=1.8,<3']
+    django_major_pin = '<3'
+
+# We only support the releases of Django that are supported by the Django
+# core team.  See https://www.djangoproject.com/download/#supported-versions
+#
+# New versions of setuptools allow us to set very precise pins; older versions
+# of setuptools are coarser.
+major_setuptools_version = int(setuptools_version.split('.')[0])
+if major_setuptools_version >= 8:
+    django_minor_pin = '>=1.8,!=1.9.*,!=1.10.*'
+else:
+    django_minor_pin = '>=1.8'
+
+django_pin = 'django%s,%s' % (django_minor_pin, django_major_pin)
+extras['django'] = ['pytz', django_pin]
 
 extras['faker'] = extras['fakefactory']
 

--- a/tox.ini
+++ b/tox.ini
@@ -127,6 +127,13 @@ commands =
     pip install django~=1.11.7
     python -m tests.django.manage test tests.django
 
+[testenv:django20]
+basepython=python3
+commands =
+    pip install .[pytz]
+    pip install django~=2.0
+    python -m tests.django.manage test tests.django
+
 [testenv:nose]
 deps =
     nose

--- a/tox.ini
+++ b/tox.ini
@@ -111,19 +111,9 @@ commands =
     pip install django~=1.8.18
     python -m tests.django.manage test tests.django
 
-[testenv:django110]
-setenv=
-  PYTHONWARNINGS={env:PYTHONWARNINGS:}
-commands =
-    pip install .[pytz]
-    pip install --no-binary :all: .[fakefactory]
-    pip install django~=1.10.8
-    python -m tests.django.manage test tests.django
-
 [testenv:django111]
 commands =
     pip install .[pytz]
-    pip install --no-binary :all: .[fakefactory]
     pip install django~=1.11.7
     python -m tests.django.manage test tests.django
 
@@ -131,7 +121,7 @@ commands =
 basepython=python3
 commands =
     pip install .[pytz]
-    pip install django~=2.0
+    pip install django~=2.0.0
     python -m tests.django.manage test tests.django
 
 [testenv:nose]

--- a/tox.ini
+++ b/tox.ini
@@ -121,7 +121,7 @@ commands =
 basepython=python3
 commands =
     pip install .[pytz]
-    pip install django~=2.0.0
+    pip install django~=2.0.1
     python -m tests.django.manage test tests.django
 
 [testenv:nose]


### PR DESCRIPTION
[Django 2.0 released](https://www.djangoproject.com/weblog/2017/dec/02/django-20-released/):

> The Django team is happy to announce the release of Django 2.0.
>
> This release starts Django’s use of a loose form of semantic versioning, but there aren’t any major backwards incompatible changes (except that support for Python 2.7 is removed). […]

This adds testing for Django 2.0 to Travis. I did a test locally; ran green with no changes or warnings.