### PR TITLE
Internal code cleanup

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release has some internal cleanup, which makes reading the code
+more pleasant and may shrink large examples slightly faster.

--- a/src/hypothesis/_settings.py
+++ b/src/hypothesis/_settings.py
@@ -151,9 +151,7 @@ class settings(settingsMeta('settings', (object,), {})):
                     kwargs[setting.name] = getattr(defaults, setting.name)
                 else:
                     if kwargs[setting.name] != setting.future_default:
-                        if (
-                            setting.deprecation_message is not None
-                        ):
+                        if setting.deprecation_message is not None:
                             deprecations.append(setting)
                     if setting.validator:
                         kwargs[setting.name] = setting.validator(

--- a/src/hypothesis/database.py
+++ b/src/hypothesis/database.py
@@ -21,10 +21,11 @@ import os
 import re
 import binascii
 import threading
+from hashlib import sha1
 from contextlib import contextmanager
 
 from hypothesis._settings import note_deprecation
-from hypothesis.internal.compat import FileNotFoundError, sha1, hbytes, \
+from hypothesis.internal.compat import FileNotFoundError, hbytes, \
     b64decode, b64encode
 
 sqlite3 = None

--- a/src/hypothesis/internal/compat.py
+++ b/src/hypothesis/internal/compat.py
@@ -27,7 +27,6 @@ import codecs
 import platform
 import importlib
 from base64 import b64encode
-from decimal import Context, Decimal, Inexact
 from collections import namedtuple
 
 try:
@@ -52,10 +51,6 @@ if sys.version_info[:2] <= (2, 6):
 
 def bit_length(n):
     return n.bit_length()
-
-
-def float_to_decimal(f):
-    return Decimal(f)
 
 
 if PY3:

--- a/src/hypothesis/internal/compat.py
+++ b/src/hypothesis/internal/compat.py
@@ -29,7 +29,6 @@ import platform
 import importlib
 from base64 import b64encode
 from decimal import Context, Decimal, Inexact
-from hashlib import sha1
 from collections import namedtuple
 
 try:

--- a/src/hypothesis/internal/compat.py
+++ b/src/hypothesis/internal/compat.py
@@ -19,7 +19,6 @@
 
 from __future__ import division, print_function, absolute_import
 
-import os
 import re
 import sys
 import math

--- a/src/hypothesis/internal/compat.py
+++ b/src/hypothesis/internal/compat.py
@@ -98,9 +98,6 @@ def quiet_raise(exc):
     def int_to_bytes(i, size):
         return i.to_bytes(size, 'big')
 
-    def bytes_from_list(ls):
-        return bytes(ls)
-
     def to_bytes_sequence(ls):
         return bytes(ls)
 
@@ -164,9 +161,6 @@ else:
         return hbytes(result)
 
     int_to_byte = chr
-
-    def bytes_from_list(ls):
-        return hbytes(bytearray(ls))
 
     def to_bytes_sequence(ls):
         return bytearray(ls)

--- a/src/hypothesis/internal/compat.py
+++ b/src/hypothesis/internal/compat.py
@@ -66,7 +66,6 @@ if PY3:
     ARG_NAME_ATTRIBUTE = 'arg'
     integer_types = (int,)
     hunichr = chr
-    from functools import reduce
 
     def unicode_safe_repr(x):
         return repr(x)
@@ -210,7 +209,6 @@ else:
     ARG_NAME_ATTRIBUTE = 'id'
     integer_types = (int, long)
     hunichr = unichr
-    reduce = reduce
 
     def escape_unicode_characters(s):
         return codecs.encode(s, 'string_escape')

--- a/src/hypothesis/internal/compat.py
+++ b/src/hypothesis/internal/compat.py
@@ -94,9 +94,6 @@ def quiet_raise(exc):
     def to_bytes_sequence(ls):
         return bytes(ls)
 
-    def zero_byte_sequence(n):
-        return bytes(n)
-
     def int_to_byte(i):
         return bytes([i])
 
@@ -119,9 +116,6 @@ else:
     else:
         def struct_unpack(fmt, string):
             return struct.unpack(fmt, str(string))
-
-    def zero_byte_sequence(n):
-        return hbytes(b'\0' * n)
 
     def int_from_bytes(data):
         assert isinstance(data, bytearray)

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -142,9 +142,7 @@ class ConjectureRunner(object):
         return 0 in self.dead
 
     def test_function(self, data):
-        if (
-            benchmark_time() - self.start_time >= HUNG_TEST_TIME_LIMIT
-        ):
+        if benchmark_time() - self.start_time >= HUNG_TEST_TIME_LIMIT:
             fail_health_check(self.settings, (
                 'Your test has been running for at least five minutes. This '
                 'is probably not what you intended, so by default Hypothesis '
@@ -563,9 +561,7 @@ class ConjectureRunner(object):
         ]
 
         def draw_mutated(data, n):
-            if (
-                data.index + n > len(self.last_data.buffer)
-            ):
+            if data.index + n > len(self.last_data.buffer):
                 result = uniform(self.random, n)
             else:
                 result = self.random.choice(bits)(data, n)

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -937,8 +937,7 @@ class ConjectureRunner(object):
         if len(initial_data.buffer) < v:
             return False
 
-        lost_data = len(self.last_data.buffer) - \
-            len(initial_data.buffer)
+        lost_data = len(self.last_data.buffer) - len(initial_data.buffer)
 
         # If this did not in fact cause the data size to shrink we
         # bail here because it's not worth trying to delete stuff from
@@ -995,7 +994,6 @@ class ConjectureRunner(object):
 
     def greedy_interval_deletion(self):
         """Attempt to delete every interval in the example."""
-
         self.debug('greedy interval deletes')
         i = 0
         while i < len(self.last_data.intervals):
@@ -1025,9 +1023,7 @@ class ConjectureRunner(object):
             assert u < v
             block = buf[u:v]
             if any(block):
-                self.incorporate_new_buffer(
-                    buf[:u] + hbytes(v - u) + buf[v:]
-                )
+                self.incorporate_new_buffer(buf[:u] + hbytes(v - u) + buf[v:])
             i += 1
 
     def minimize_duplicated_blocks(self):
@@ -1038,11 +1034,7 @@ class ConjectureRunner(object):
         counts = Counter(
             self.last_data.buffer[u:v] for u, v in self.last_data.blocks
         )
-        blocks = [
-            k for k, count in
-            counts.items()
-            if count > 1
-        ]
+        blocks = [buffer for buffer, count in counts.items() if count > 1]
 
         thresholds = {}
         for u, v in self.last_data.blocks:

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -30,7 +30,7 @@ from hypothesis import Phase, HealthCheck
 from hypothesis.reporting import debug_report
 from hypothesis.internal.compat import EMPTY_BYTES, Counter, ceil, \
     hbytes, hrange, int_to_text, int_to_bytes, benchmark_time, \
-    bytes_from_list, to_bytes_sequence, unicode_safe_repr
+    to_bytes_sequence, unicode_safe_repr
 from hypothesis.utils.conventions import UniqueIdentifier
 from hypothesis.internal.healthcheck import fail_health_check
 from hypothesis.internal.conjecture.data import MAX_DEPTH, Status, \
@@ -539,9 +539,7 @@ class ConjectureRunner(object):
             return hbytes([255]) * n
 
         def draw_constant(data, n):
-            return bytes_from_list([
-                self.random.randint(0, 255)
-            ] * n)
+            return hbytes([self.random.randint(0, 255)]) * n
 
         def redraw_last(data, n):
             u = self.last_data.blocks[-1][0]

--- a/src/hypothesis/internal/conjecture/minimizer.py
+++ b/src/hypothesis/internal/conjecture/minimizer.py
@@ -197,9 +197,7 @@ class Minimizer(object):
         # ensures we can always move to integer boundaries and shrink past a
         # change that would require shifting the exponent while not changing
         # the float value much.
-        for g in [
-            floor(f), ceil(f),
-        ]:
+        for g in [floor(f), ceil(f)]:
             if self.incorporate_float(g):
                 return
 
@@ -311,6 +309,8 @@ def binsearch(_lo, _hi):
 
 
 def minimize_byte(c, f):
+    """Return the smallest byte for which a function `f` returns True, starting
+    with the byte `c` as an unsigned integer."""
     if f(0):
         return 0
     if c == 1 or f(1):
@@ -327,5 +327,4 @@ def minimize_byte(c, f):
             else:
                 lo = mid
         return hi
-    else:
-        return c
+    return c

--- a/tests/cover/test_conjecture_engine.py
+++ b/tests/cover/test_conjecture_engine.py
@@ -27,8 +27,7 @@ from hypothesis import strategies as st
 from hypothesis import Phase, HealthCheck, given, settings, unlimited
 from tests.common.utils import all_values, checks_deprecated_behaviour
 from hypothesis.database import ExampleDatabase, InMemoryExampleDatabase
-from hypothesis.internal.compat import hbytes, hrange, int_from_bytes, \
-    bytes_from_list
+from hypothesis.internal.compat import hbytes, hrange, int_from_bytes
 from hypothesis.internal.conjecture.data import Status, ConjectureData
 from hypothesis.internal.conjecture.engine import ConjectureRunner
 
@@ -73,7 +72,7 @@ def test_duplicate_buffers():
         s = data.draw_bytes(10)
         if s == t:
             data.mark_interesting()
-    assert x == bytes_from_list([0] * 9 + [1]) * 2
+    assert x == hbytes([0] * 9 + [1]) * 2
 
 
 def test_clone_into_variable_draws():

--- a/tests/cover/test_direct_strategies.py
+++ b/tests/cover/test_direct_strategies.py
@@ -27,7 +27,6 @@ import pytest
 import hypothesis.strategies as ds
 from hypothesis import find, given, settings
 from hypothesis.errors import InvalidArgument
-from hypothesis.internal.compat import float_to_decimal
 from hypothesis.internal.reflection import nicerepr
 
 
@@ -303,7 +302,7 @@ def test_decimals():
 def test_non_float_decimal():
     find(
         ds.decimals(),
-        lambda d: d.is_finite() and float_to_decimal(float(d)) != d)
+        lambda d: d.is_finite() and decimal.Decimal(float(d)) != d)
 
 
 def test_produces_dictionaries_of_at_least_minimum_size():

--- a/tests/cover/test_numerics.py
+++ b/tests/cover/test_numerics.py
@@ -27,7 +27,6 @@ from hypothesis.errors import InvalidArgument
 from tests.common.utils import fails
 from hypothesis.strategies import data, none, tuples, decimals, integers, \
     fractions
-from hypothesis.internal.compat import float_to_decimal
 
 
 @given(data())
@@ -77,7 +76,7 @@ def test_fuzz_decimals_bounds(data):
 @given(decimals())
 def test_all_decimals_can_be_exact_floats(x):
     assume(x.is_finite())
-    assert float_to_decimal(float(x)) == x
+    assert decimal.Decimal(float(x)) == x
 
 
 @given(fractions(), fractions(), fractions())

--- a/tests/quality/test_shrink_quality.py
+++ b/tests/quality/test_shrink_quality.py
@@ -18,8 +18,8 @@
 from __future__ import division, print_function, absolute_import
 
 import sys
-import operator
 from fractions import Fraction
+from functools import reduce
 
 import pytest
 from flaky import flaky
@@ -30,7 +30,7 @@ from tests.common.debug import minimal
 from hypothesis.strategies import just, sets, text, lists, tuples, \
     booleans, integers, fractions, frozensets, dictionaries, \
     sampled_from
-from hypothesis.internal.compat import PY3, OrderedDict, hrange, reduce
+from hypothesis.internal.compat import PY3, OrderedDict, hrange
 
 
 def test_integers_from_minimizes_leftwards():
@@ -202,20 +202,16 @@ def test_minimize_long():
 
 def test_find_large_union_list():
     def large_mostly_non_overlapping(xs):
-        union = reduce(operator.or_, xs)
+        union = reduce(set.union, xs)
         return len(union) >= 30
 
     result = minimal(
         lists(sets(integers(), min_size=1), min_size=1),
         large_mostly_non_overlapping, timeout_after=120)
     assert len(result) == 1
-    union = reduce(operator.or_, result)
+    union = reduce(set.union, result)
     assert len(union) == 30
     assert max(union) == min(union) + len(union) - 1
-    for x in result:
-        for y in result:
-            if x is not y:
-                assert not (x & y)
 
 
 @pytest.mark.parametrize('n', [0, 1, 10, 100, 1000])


### PR DESCRIPTION
My yak stack was deep enough that I forget why, but I noticed that `bytes_from_list` was literally just `hbytes`.  Pulling on the thread revealed several other things that could easily be deleted from compat.py, and pulling *those* threads led to cleaning up some unidiomatic code in the conjecture engine.

There should be no change to behaviour, ~~but shrinking passes may be slightly faster in a few places - sorting once instead of twice in `minimize_duplicated_blocks`, and iterating directly over blocks instead of accessing each index in a list in `coarse_block_replacement` and `minimize_individual_blocks`.~~

For the compat changes, I took the view that if the Python 3 idiom works on Python 2, we should just use that - and therefore eg. import reduce from functools rather than compat.py.