### PR TITLE
De-tuplize arguments to lazy strategies

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch fixes :issue:`1017`, where instances of a list or tuple subtype
+used as an argument to a strategy would be coerced to tuple.

--- a/src/hypothesis/searchstrategy/lazy.py
+++ b/src/hypothesis/searchstrategy/lazy.py
@@ -22,14 +22,6 @@ from hypothesis.internal.reflection import arg_string, \
     convert_keyword_arguments, convert_positional_arguments
 from hypothesis.searchstrategy.strategies import SearchStrategy
 
-
-def tupleize(x):
-    if isinstance(x, (tuple, list)):
-        return tuple(x)
-    else:
-        return x
-
-
 unwrap_cache = {}
 unwrap_depth = 0
 
@@ -85,10 +77,8 @@ class LazyStrategy(SearchStrategy):
         self.__wrapped_strategy = None
         self.__representation = None
         self.__function = function
-        self.__args = tuple(map(tupleize, args))
-        self.__kwargs = dict(
-            (k, tupleize(v)) for k, v in kwargs.items()
-        )
+        self.__args = args
+        self.__kwargs = kwargs
 
     @property
     def supports_find(self):

--- a/tests/cover/test_composite.py
+++ b/tests/cover/test_composite.py
@@ -129,3 +129,18 @@ def test_can_shrink_matrices_with_length_param():
     assert len(value) == 2
     assert len(value[0]) == 2
     assert sorted(value[0] + value[1]) == [0, 0, 0, 1]
+
+
+class MyList(list):
+    pass
+
+
+@given(st.data(), st.lists(st.integers()).map(MyList))
+def test_does_not_change_arguments(data, ls):
+    # regression test for issue #1017 or other argument mutation
+    @st.composite
+    def strat(draw, arg):
+        return arg
+
+    ex = data.draw(strat(ls))
+    assert ex is ls

--- a/tests/cover/test_custom_reprs.py
+++ b/tests/cover/test_custom_reprs.py
@@ -37,8 +37,8 @@ def test_supports_positional_and_keyword_args_in_builds():
         'builds(hi, integers(), there=booleans())'
 
 
-def test_includes_a_trailing_comma_in_single_element_sampling():
-    assert repr(st.sampled_from([0])) == 'sampled_from((0,))'
+def test_preserves_sequence_type_of_argument():
+    assert repr(st.sampled_from([0])) == 'sampled_from([0])'
 
 
 class IHaveABadRepr(object):


### PR DESCRIPTION
Fixes #1017.

As far as I can tell from digging through the history of `lazy.py`, this function originally used a custom tuple subclass which fixed the reprs of its elements.  That didn't last, but the general tupleize function did.

~~Notably, there are *no tests* specifically for this change.  Pretty weird for Hypothesis, but the basic functionality is well covered by other tests.  As there's essentially no chance of accidental regression, I declined to write a super-specific test purely for it's own sake - and writing a test just to have written a test is rather missing the point.~~