### PR TITLE
Fix a terrible pluralisation bug

### DIFF
--- a/scripts/hypothesistooling.py
+++ b/scripts/hypothesistooling.py
@@ -364,8 +364,6 @@ def changed_files_from_master():
 
 def should_run_ci_task(task, is_pull_request):
     """Given a task name, should we run this task?"""
-    print('Considering whether we should run make %s...' % task)
-
     if not is_pull_request:
         print('We only skip tests if the job is a pull request.')
         return True
@@ -388,8 +386,6 @@ def should_run_ci_task(task, is_pull_request):
     # than skip tests when it was important, we remove any files which we
     # know are safe to ignore, and run tests if there's anything left.
     changed_files = changed_files_from_master()
-
-    print('@@AWLC changed_files = %r' % changed_files)
 
     interesting_changed_files = [
         f for f in changed_files if could_affect_tests(f)

--- a/scripts/hypothesistooling.py
+++ b/scripts/hypothesistooling.py
@@ -364,6 +364,8 @@ def changed_files_from_master():
 
 def should_run_ci_task(task, is_pull_request):
     """Given a task name, should we run this task?"""
+    print('Considering whether we should run make %s...' % task)
+
     if not is_pull_request:
         print('We only skip tests if the job is a pull request.')
         return True
@@ -386,6 +388,8 @@ def should_run_ci_task(task, is_pull_request):
     # than skip tests when it was important, we remove any files which we
     # know are safe to ignore, and run tests if there's anything left.
     changed_files = changed_files_from_master()
+
+    print('@@AWLC changed_files = %r' % changed_files)
 
     interesting_changed_files = [
         f for f in changed_files if could_affect_tests(f)

--- a/scripts/run_circle.py
+++ b/scripts/run_circle.py
@@ -27,9 +27,6 @@ from hypothesistooling import should_run_ci_task
 
 if __name__ == '__main__':
 
-    from pprint import pprint
-    pprint(os.environ)
-
     if (
         os.environ['CIRCLE_BRANCH'] != 'master' and
         os.environ['CI_PULL_REQUESTS'] == ''

--- a/scripts/run_circle.py
+++ b/scripts/run_circle.py
@@ -29,12 +29,12 @@ if __name__ == '__main__':
 
     if (
         os.environ['CIRCLE_BRANCH'] != 'master' and
-        os.environ['CI_PULL_REQUEST'] == ''
+        os.environ['CI_PULL_REQUESTS'] == ''
     ):
         print('We only run CI builds on the master branch or in pull requests')
         sys.exit(0)
 
-    is_pull_request = (os.environ['CI_PULL_REQUEST'] != '')
+    is_pull_request = (os.environ['CI_PULL_REQUESTS'] != '')
 
     for task in ['check-pypy', 'check-py36', 'check-py27']:
         if should_run_ci_task(task=task, is_pull_request=is_pull_request):

--- a/scripts/run_circle.py
+++ b/scripts/run_circle.py
@@ -27,6 +27,9 @@ from hypothesistooling import should_run_ci_task
 
 if __name__ == '__main__':
 
+    from pprint import pprint
+    pprint(os.environ)
+
     if (
         os.environ['CIRCLE_BRANCH'] != 'master' and
         os.environ['CI_PULL_REQUESTS'] == ''


### PR DESCRIPTION
I noticed in #1021 that the Circle build was giving the wrong message as to why it wasn’t running tests.

After staring *really hard* at the diff for #1014, I spotted what might be the issue:

```diff
-if [ "$CIRCLE_BRANCH" != "master" ] && [ "$CI_PULL_REQUESTS" == "" ] ; then
-  exit 0;
-fi

+    if (
+        os.environ['CIRCLE_BRANCH'] != 'master' and
+        os.environ['CI_PULL_REQUEST'] == ''
+    ):
```

Looking at [the Circle docs](https://circleci.com/docs/1.0/environment-variables/#build-details), I’m struggling to see why this would make a difference:

> `CI_PULL_REQUESTS`
>
> Comma-separated list of pull requests this build is a part of.
>
> `CI_PULL_REQUEST`
>
> If this build is part of only one pull request, its URL will be populated here. If there was more than one pull request, it will contain one of the pull request URLs (picked randomly).

(Let’s put aside the questionable decision to have two different environment variables who differ only by one character, especially given shell’s poor habits around missing variables.)

I’d expect both variables to be populated, but seems like they weren’t. So I’m going to use the original variable, and see if that fixes the Circle build.