### PR TITLE
Docs updates - use https links, don't suggest strict mode

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -8,7 +8,7 @@ on pip.
 
 Hypothesis APIs come in three flavours:
 
-* Public: Hypothesis releases since 1.0 are `semantically versioned <http://semver.org/>`_
+* Public: Hypothesis releases since 1.0 are `semantically versioned <https://semver.org/>`_
   with respect to these parts of the API. These will not break except between
   major version bumps. All APIs mentioned in this documentation are public unless
   explicitly noted otherwise.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -30,8 +30,8 @@ Hypothesis releases follow `semantic versioning <http://semver.org/>`_.
 
 We maintain backwards-compatibility wherever possible, and use deprecation
 warnings to mark features that have been superseded by a newer alternative.
-If you want to detect this, the :py:meth:`strict setting <hypothesis.settings.strict>`
-upgrades all Hypothesis warnings to errors.
+If you want to detect this, you can
+:mod:`upgrade warnings to errors in the usual ways <python:warnings>`.
 
 We use continuous deployment to ensure that you can always use our newest and
 shiniest features - every change to the source tree is automatically built and

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -2,7 +2,7 @@
 Ongoing Hypothesis Development
 ==============================
 
-Hypothesis development is managed by me, `David R. MacIver <http://www.drmaciver.com>`_.
+Hypothesis development is managed by me, `David R. MacIver <https://www.drmaciver.com>`_.
 I am the primary author of Hypothesis.
 
 *However*, I no longer do unpaid feature development on Hypothesis. My roles as leader of the project are:
@@ -26,7 +26,7 @@ details and :pull:`154` for an example of how the process goes). This isn't
 Release Policy
 ==============
 
-Hypothesis releases follow `semantic versioning <http://semver.org/>`_.
+Hypothesis releases follow `semantic versioning <https://semver.org/>`_.
 
 We maintain backwards-compatibility wherever possible, and use deprecation
 warnings to mark features that have been superseded by a newer alternative.

--- a/docs/extras.rst
+++ b/docs/extras.rst
@@ -50,7 +50,7 @@ hypothesis[fakefactory]
     :func:`~hypothesis.strategies.sampled_from` strategies may be particularly
     useful.
 
-:pypi:`faker` (previously :pypi:`fake-factory`) is a Python package that
+:pypi:`Faker` (previously :pypi:`fake-factory`) is a Python package that
 generates fake data for you. It's great for bootstraping your database,
 creating good-looking XML documents, stress-testing a database, or anonymizing
 production data.  However, it's not designed for automated testing - data from

--- a/docs/packaging.rst
+++ b/docs/packaging.rst
@@ -54,7 +54,7 @@ Hypothesis has *mandatory* dependencies on the following libraries:
 Hypothesis has *optional* dependencies on the following libraries:
 
 * :pypi:`pytz` (almost any version should work)
-* :pypi:`faker`, version 0.7
+* :pypi:`Faker`, version 0.7 or later
 * `Django <https://www.djangoproject.com>`_, all supported versions
 * :pypi:`numpy`, 1.10 or later (earlier versions will probably work fine)
 * :pypi:`pandas`, 1.8 or later

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -304,7 +304,7 @@ are some good starting points:
    the same thing with multiple different examples? Can you generalise that to
    a single test using Hypothesis?
 3. `This piece is designed for an F# implementation
-   <http://fsharpforfunandprofit.com/posts/property-based-testing-2/>`_, but
+   <https://fsharpforfunandprofit.com/posts/property-based-testing-2/>`_, but
    is still very good advice which you may find helps give you good ideas for
    using Hypothesis.
 


### PR DESCRIPTION
Hopefully nothing controversial here.  @DRMacIver might take note though - http://www.drmaciver.com does not (yet) redirect to https.