### PR TITLE
Use FutureWarning for user-facing warnings, per PEP 565

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,8 @@
+RELEASE_TYPE: minor
+
+:exc:`~hypothesis.errors.HypothesisDeprecationWarning` now inherits from
+:exc:`python:FutureWarning` instead of :exc:`python:DeprecationWarning`,
+as recommended by :pep:`565` for user-facing warnings (:issue:`618`).
+If you have not changed the default warnings settings, you will now see
+each distinct :exc:`~hypothesis.errors.HypothesisDeprecationWarning`
+instead of only the first.

--- a/src/hypothesis/errors.py
+++ b/src/hypothesis/errors.py
@@ -17,8 +17,6 @@
 
 from __future__ import division, print_function, absolute_import
 
-import warnings
-
 
 class HypothesisException(Exception):
 
@@ -179,11 +177,8 @@ class FailedHealthCheck(HypothesisException, Warning):
         self.health_check = check
 
 
-class HypothesisDeprecationWarning(HypothesisException, DeprecationWarning):
+class HypothesisDeprecationWarning(HypothesisException, FutureWarning):
     pass
-
-
-warnings.simplefilter('once', HypothesisDeprecationWarning)
 
 
 class Frozen(HypothesisException):

--- a/tests/cover/test_timeout.py
+++ b/tests/cover/test_timeout.py
@@ -22,7 +22,7 @@ import time
 import pytest
 
 from hypothesis import given, settings
-from hypothesis.errors import Unsatisfiable
+from hypothesis.errors import Unsatisfiable, HypothesisDeprecationWarning
 from tests.common.utils import fails, fails_with, validate_deprecation
 from hypothesis.strategies import integers
 
@@ -86,13 +86,11 @@ def test_slow_failing_test_4(x):
 
 
 with validate_deprecation():
-    default_timeout_settings = settings(timeout=60)
+    strict_timeout_settings = settings(timeout=60)
 
 
-strict_timeout_settings = default_timeout_settings
-
-
-@fails_with(DeprecationWarning)
+# @checks_deprecated_behaviour only works if test passes otherwise
+@fails_with(HypothesisDeprecationWarning)
 @strict_timeout_settings
 @given(integers())
 def test_deprecated_behaviour(i):

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ passenv=
   COVERAGE_FILE
 
 setenv=
-  PYTHONWARNINGS={env:PYTHONWARNINGS:error::DeprecationWarning}
+  PYTHONWARNINGS={env:PYTHONWARNINGS:error::DeprecationWarning,error::FutureWarning}
 
 [testenv]
 deps =


### PR DESCRIPTION
Closes #618, based on the recently accepted [PEP 565](https://www.python.org/dev/peps/pep-0565/).

Strictly speaking this may change behaviour of people's tests if they had a warnings filter configured to catch `DeprecationWarning` but not `FutureWarning`, but there's no gradual path anyway in that case -
 inheriting from both gets the default, silent, behaviour of the former.