### PR TITLE
Handle forward references and recursion in from_type

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+:func:`~hypothesis.strategies.from_type` can now resolve recursive types
+such as binary trees (:issue:`1004`).  Detection of non-type arguments has
+also improved, leading to better error messages in many cases involving
+:pep:`forward references <484#forward-references>`.


### PR DESCRIPTION
This patch improves handling of forward references in `from_type()`, and thus fixes #1004.
 
- Forward references are detected in more cases, and uniformly result in errors as they're not a type
- Self-referential types (such as trees) now resolve without recursion errors.

Unfortunately the original motivating case involves a little too much magic to resolve, but if you define `__init__` manually it works.