### PR TITLE
Improve tests covering ConjectureRunner.

### DIFF
--- a/tests/common/strategies.py
+++ b/tests/common/strategies.py
@@ -1,0 +1,60 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2017 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import time
+
+from hypothesis.searchstrategy import SearchStrategy
+from hypothesis.internal.compat import hrange
+
+
+class _Slow(SearchStrategy):
+    def do_draw(self, data):
+        time.sleep(1.0)
+        data.draw_bytes(2)
+        return None
+
+
+SLOW = _Slow()
+
+
+class HardToShrink(SearchStrategy):
+    def __init__(self):
+        self.__last = None
+        self.accepted = set()
+
+    def do_draw(self, data):
+        x = data.draw_bytes(100)
+        if x in self.accepted:
+            return True
+        ls = self.__last
+        if ls is None:
+            if all(x):
+                self.__last = x
+                self.accepted.add(x)
+                return True
+            else:
+                return False
+        diffs = [i for i in hrange(len(x)) if x[i] != ls[i]]
+        if len(diffs) == 1:
+            i = diffs[0]
+            if x[i] + 1 == ls[i]:
+                self.__last = x
+                self.accepted.add(x)
+                return True
+        return False

--- a/tests/nocover/test_conjecture_engine.py
+++ b/tests/nocover/test_conjecture_engine.py
@@ -1,0 +1,120 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2017 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+from hypothesis import strategies as st
+from hypothesis import HealthCheck, given, settings, unlimited
+from hypothesis.database import InMemoryExampleDatabase
+from hypothesis.internal.compat import hbytes
+from tests.cover.test_conjecture_engine import run_to_buffer, slow_shrinker
+from hypothesis.internal.conjecture.data import Status
+from hypothesis.internal.conjecture.engine import ConjectureRunner
+
+
+@given(st.random_module())
+@settings(max_shrinks=0, deadline=None, perform_health_check=False)
+def test_lot_of_dead_nodes(rnd):
+    @run_to_buffer
+    def x(data):
+        for i in range(5):
+            if data.draw_bytes(1)[0] != i:
+                data.mark_invalid()
+        data.mark_interesting()
+    assert x == hbytes([0, 1, 2, 3, 4])
+
+
+def test_saves_data_while_shrinking():
+    key = b'hi there'
+    n = 5
+    db = InMemoryExampleDatabase()
+    assert list(db.fetch(key)) == []
+    seen = set()
+
+    def f(data):
+        x = data.draw_bytes(512)
+        if sum(x) >= 5000 and len(seen) < n:
+            seen.add(hbytes(x))
+        if hbytes(x) in seen:
+            data.mark_interesting()
+    runner = ConjectureRunner(
+        f, settings=settings(database=db), database_key=key)
+    runner.run()
+    assert runner.last_data.status == Status.INTERESTING
+    assert len(seen) == n
+    in_db = set(
+        v
+        for vs in db.data.values()
+        for v in vs
+    )
+    assert in_db.issubset(seen)
+    assert in_db == seen
+
+
+@given(st.randoms(), st.random_module())
+@settings(
+    max_shrinks=0, deadline=None, suppress_health_check=[HealthCheck.hung_test]
+)
+def test_maliciously_bad_generator(rnd, seed):
+    @run_to_buffer
+    def x(data):
+        for _ in range(rnd.randint(1, 100)):
+            data.draw_bytes(rnd.randint(1, 10))
+        if rnd.randint(0, 1):
+            data.mark_invalid()
+        else:
+            data.mark_interesting()
+
+
+def test_garbage_collects_the_database():
+    key = b'hi there'
+    n = 200
+    db = InMemoryExampleDatabase()
+
+    local_settings = settings(
+        database=db, max_shrinks=n, timeout=unlimited)
+
+    runner = ConjectureRunner(
+        slow_shrinker(), settings=local_settings, database_key=key)
+    runner.run()
+    assert runner.last_data.status == Status.INTERESTING
+
+    def in_db():
+        return set(
+            v
+            for vs in db.data.values()
+            for v in vs
+        )
+
+    assert len(in_db()) == n + 1
+    runner = ConjectureRunner(
+        lambda data: data.draw_bytes(4),
+        settings=local_settings, database_key=key)
+    runner.run()
+    assert 0 < len(in_db()) < n
+
+
+def test_can_discard():
+    n = 32
+
+    @run_to_buffer
+    def x(data):
+        seen = set()
+        while len(seen) < n:
+            seen.add(hbytes(data.draw_bytes(1)))
+        data.mark_interesting()
+    assert len(x) == n


### PR DESCRIPTION
As part of debugging why #1023 is being screwy I wanted better tests for the core engine. This PR implements that.

I wanted to keep this separate from any implementation changes, so this *just* touches testing. No release is involved.

Things this implements:

1. `tests/cover/test_conjecture_engine.py` now gives 100% coverage of `src/hypothesis/internal/conjecture/engine.py`
2. Tests in there should be much faster now, partly due to some judicious use of stubbing and other poking at engine internals to put it in the right state rather than relying on chance.
3. Some tests that don't meaningfully contribute to coverage are moved into tests/nocover.

There is an xfail in the tests because I didn't want to make source changes, let alone open the can of worms that is `__rewrite_for_novelty`. I'm pretty sure this is the same root issue as #995, and I plan to get rid of both of them in one fell swoop by deleting `__rewrite_for_novelty` and using a better approach, but there are several things on the critical path between now and then.