### PR TITLE
Use the parent collector's notion of what files it cares about where applicable

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This release fixes :issue:`997`, in which under some circumstances the body of
+tests run under Hypothesis would not show up when run under coverage even
+though the tests were run and the code they called outside of the test file
+would show up normally.

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -413,7 +413,9 @@ class StateForActualGivenExecution(object):
 
         if settings.use_coverage and not IN_COVERAGE_TESTS:  # pragma: no cover
             if Collector._collectors:
-                self.hijack_collector(Collector._collectors[-1])
+                parent = Collector._collectors[-1]
+                self.files_to_propagate = set(parent.data)
+                self.hijack_collector(parent)
 
             self.collector = Collector(
                 branch=True,
@@ -563,7 +565,7 @@ class StateForActualGivenExecution(object):
                 covdata.add_arcs({
                     filename: {
                         arc: None
-                        for arc in self.coverage_data.arcs(filename)}
+                        for arc in self.coverage_data.arcs(filename) or ()}
                     for filename in self.files_to_propagate
                 })
             else:

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -414,6 +414,19 @@ class StateForActualGivenExecution(object):
         if settings.use_coverage and not IN_COVERAGE_TESTS:  # pragma: no cover
             if Collector._collectors:
                 parent = Collector._collectors[-1]
+
+                # We include any files the collector has already decided to
+                # trace whether or not on re-investigation we still think it
+                # wants to trace them. The reason for this is that in some
+                # cases coverage gets the wrong answer when we run it
+                # ourselves due to reasons that are our fault but are hard to
+                # fix (we lie about where certain functions come from).
+                # This causes us to not record the actual test bodies as
+                # covered. But if we intended to trace test bodies then the
+                # file must already have been traced when getting to this point
+                # and so will already be in the collector's data. Hence we can
+                # use that information to get the correct answer here.
+                # See issue 997 for more context.
                 self.files_to_propagate = set(parent.data)
                 self.hijack_collector(parent)
 

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -572,7 +572,7 @@ class StateForActualGivenExecution(object):
                 covdata.add_lines({
                     filename: {
                         line: None
-                        for line in self.coverage_data.lines(filename)}
+                        for line in self.coverage_data.lines(filename) or ()}
                     for filename in self.files_to_propagate
                 })
             collector.save_data = original_save_data


### PR DESCRIPTION
Fixes #997.

You may note that this fix does not come with an associated test. This bug is *incredibly* fiddly to create an isolated test case for, and after about an hour trying I decided I simply didn't care enough to do so - as far as I can tell we would basically have to create a Python package in our test suite and install it into the current virtualenv, and ain't nobody got time for that.

The bug is easy to reproduce in situ in the affected projects, and I've manually done so and verified that this fix works for them.

The root issue is as described in #997 but basically when running under Hypothesis the test file doesn't "look" like part of the right package to coverage. This fixes the problem by using the fact that part of the test file must already have been loaded into coverage in order to get here, so we can just use the existing collector's list of files to prime the pump about what it cares about, so we can avoid this problem rather than fix it (because fixing it is really hard and runs into other annoying issues).

This is a bad patch and I am not happy with it, but it's probably the best we're going to get for this problem. `¯\_(ツ)_/¯`