### PR TITLE
Clean up tests/cover/test_numerics.py

### DIFF
--- a/tests/cover/test_numerics.py
+++ b/tests/cover/test_numerics.py
@@ -88,10 +88,7 @@ def test_decimals_include_nan():
 
 
 def test_decimals_include_inf():
-    find_any(
-        decimals(),
-        lambda x: assume(not x.is_snan()) and x.is_infinite()
-    )
+    find_any(decimals(), lambda x: x.is_infinite())
 
 
 @given(decimals(allow_nan=False))

--- a/tests/cover/test_numerics.py
+++ b/tests/cover/test_numerics.py
@@ -24,7 +24,7 @@ import pytest
 
 from hypothesis import given, assume, reject
 from hypothesis.errors import InvalidArgument
-from tests.common.utils import fails
+from tests.common.debug import find_any
 from hypothesis.strategies import data, none, tuples, decimals, integers, \
     fractions
 
@@ -72,11 +72,11 @@ def test_fuzz_decimals_bounds(data):
         assert val.as_tuple().exponent == -places
 
 
-@fails
-@given(decimals())
-def test_all_decimals_can_be_exact_floats(x):
-    assume(x.is_finite())
-    assert decimal.Decimal(float(x)) == x
+def test_all_decimals_can_be_exact_floats():
+    find_any(
+        decimals(),
+        lambda x: assume(x.is_finite()) and decimal.Decimal(float(x)) == x
+    )
 
 
 @given(fractions(), fractions(), fractions())
@@ -84,17 +84,15 @@ def test_fraction_addition_is_well_behaved(x, y, z):
     assert x + y + z == y + x + z
 
 
-@fails
-@given(decimals())
-def test_decimals_include_nan(x):
-    assert not math.isnan(x)
+def test_decimals_include_nan():
+    find_any(decimals(), lambda x: x.is_nan())
 
 
-@fails
-@given(decimals())
-def test_decimals_include_inf(x):
-    assume(not x.is_snan())
-    assert not math.isinf(x)
+def test_decimals_include_inf():
+    find_any(
+        decimals(),
+        lambda x: assume(not x.is_snan()) and math.isinf(x)
+    )
 
 
 @given(decimals(allow_nan=False))

--- a/tests/cover/test_numerics.py
+++ b/tests/cover/test_numerics.py
@@ -17,7 +17,6 @@
 
 from __future__ import division, print_function, absolute_import
 
-import math
 import decimal
 
 import pytest
@@ -91,19 +90,18 @@ def test_decimals_include_nan():
 def test_decimals_include_inf():
     find_any(
         decimals(),
-        lambda x: assume(not x.is_snan()) and math.isinf(x)
+        lambda x: assume(not x.is_snan()) and x.is_infinite()
     )
 
 
 @given(decimals(allow_nan=False))
 def test_decimals_can_disallow_nan(x):
-    assert not math.isnan(x)
+    assert not x.is_nan()
 
 
 @given(decimals(allow_infinity=False))
 def test_decimals_can_disallow_inf(x):
-    assume(not x.is_snan())
-    assert not math.isinf(x)
+    assert not x.is_infinite()
 
 
 @pytest.mark.parametrize('places', range(10))


### PR DESCRIPTION
This:

* Replaces use of `@fails` to assert the ability to find certain examples with the more modern `find_any` 
* Replaces all use of math functions (which convert to floats) with the corresponding decimal methods

As a result fixes #1033 