### PR TITLE
More reliable handling of shrinking of strategies with length parameters

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This release improves the shrinker in cases where examples drawn earlier can
+affect how much data is drawn later (e.g. when you draw a length parameter in
+a composite and then draw that many elements). Examples found in cases like
+this should now be much closer to minimal.

--- a/src/hypothesis/internal/conjecture/data.py
+++ b/src/hypothesis/internal/conjecture/data.py
@@ -76,6 +76,7 @@ class ConjectureData(object):
         self.tags = set()
         self.draw_times = []
         self.__intervals = None
+        self.shrinking_blocks = set()
 
     def __assert_not_frozen(self, name):
         if self.frozen:

--- a/tests/quality/test_poisoned_lists.py
+++ b/tests/quality/test_poisoned_lists.py
@@ -1,0 +1,114 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2017 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+from random import Random
+
+import pytest
+
+import hypothesis.strategies as st
+import hypothesis.internal.conjecture.utils as cu
+from hypothesis import settings, unlimited
+from hypothesis.searchstrategy import SearchStrategy
+from hypothesis.internal.compat import ceil, hrange
+from hypothesis.internal.conjecture.engine import ConjectureData, \
+    ConjectureRunner, uniform
+
+POISON = 'POISON'
+
+
+class Poisoned(SearchStrategy):
+    def __init__(self, poison_chance):
+        SearchStrategy.__init__(self)
+        self.__poison_chance = poison_chance
+        self.__ints = st.integers(0, 10)
+
+    def do_draw(self, data):
+        if cu.biased_coin(data, self.__poison_chance):
+            return POISON
+        else:
+            return data.draw(self.__ints)
+
+
+class LinearLists(SearchStrategy):
+    def __init__(self, elements, size):
+        SearchStrategy.__init__(self)
+        self.__length = st.integers(0, size)
+        self.__elements = elements
+
+    def do_draw(self, data):
+        return [
+            data.draw(self.__elements)
+            for _ in hrange(data.draw(self.__length))
+        ]
+
+
+class Matrices(SearchStrategy):
+    def __init__(self, elements, size):
+        SearchStrategy.__init__(self)
+        self.__length = st.integers(0, ceil(size ** 0.5))
+        self.__elements = elements
+
+    def do_draw(self, data):
+        n = data.draw(self.__length)
+        m = data.draw(self.__length)
+
+        return [
+            data.draw(self.__elements) for _ in hrange(n * m)
+        ]
+
+
+class TrialRunner(ConjectureRunner):
+    def generate_new_examples(self):
+        def draw_bytes(data, n):
+            return uniform(self.random, n)
+
+        while not self.interesting_examples:
+            self.test_function(ConjectureData(
+                draw_bytes=draw_bytes, max_length=self.settings.buffer_size))
+
+
+LOTS = 10 ** 6
+
+TRIAL_SETTINGS = settings(
+    max_examples=LOTS, max_shrinks=LOTS, timeout=unlimited, database=None
+)
+
+
+@pytest.mark.parametrize('seed', [
+    2282791295271755424, 1284235381287210546, 14202812238092722246,
+])
+@pytest.mark.parametrize('size', [5, 10, 20])
+@pytest.mark.parametrize('p', [0.01, 0.1])
+@pytest.mark.parametrize('strategy_class', [LinearLists, Matrices])
+def test_minimal_poisoned_containers(seed, size, p, strategy_class):
+    elements = Poisoned(p)
+    strategy = strategy_class(elements, size)
+
+    def test_function(data):
+        v = data.draw(strategy)
+        data.output = repr(v)
+        if POISON in v:
+            data.mark_interesting()
+
+    runner = TrialRunner(
+        test_function, random=Random(seed), settings=TRIAL_SETTINGS)
+    runner.run()
+    v, = runner.interesting_examples.values()
+    result = ConjectureData.for_buffer(v.buffer).draw(strategy)
+    assert len(result) == 1

--- a/tox.ini
+++ b/tox.ini
@@ -198,4 +198,4 @@ commands=
     python -m pytest examples
 
 [pytest]
-addopts=--strict --tb=short -vv -p pytester --runpytest=subprocess --durations=20 -n 2
+addopts=--strict --tb=native -vv -p pytester --runpytest=subprocess --durations=20 -n 2


### PR DESCRIPTION
(Built on top of #1023)

In doing some evaluation for my upcoming paper on the Hypothesis shrinker, I managed to find a class of examples which the shrinker does quite badly on - "poison lists", which are strategies that generate a list of elements via some slightly awkward process and try to minimize based on whether they contain a single low probability poison value. In particular in this example the poison value has the problem that it's smaller than the other elements, so it defeats the heuristic we use to detect whether we can delete intervals.

After some tinkering I've improved the shrinker so that it can detect and deal with length parameters more reliably.

The idea is this: We're currently paying the cost for attempted deletion for subsequent intervals every attempt to lexicographically shrink a block. This is actually quite expensive and mostly won't work. e.g. if we shrink the length by 3 on a length-prefixed list then we're only ever going to try deleting two elements from the list as part of the interval deletion, so it will just overrun.

So lets not do that then, but instead have a pass where we delete intervals and simultaneously shrink an earlier block by one (i.e. replace it with the lexicographic predecessor). This is expensive-ish, but mostly not too bad.

We then do two things to reduce the cost:

* We still try the pass where we delete the bytes immediately after the shrunk point. This is particularly useful for cases where a shrink by 1 can remove a lot more than one element (e.g. matrices)
* During the lexicographic shrinking process we annotate the conjecture data object with the blocks that cause a length shrink. This won't necessarily get preserved if we successfully shrink the list in some other way, but that's OK because either we make progress by shrinking or we keep the value around. Then when it comes to do the lower + delete we only attempt to lower blocks that we know affect the length.