### PR TITLE
More aggressively discard filtered data from the input during shrinking

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This release speeds up test case reduction in many examples by being better at
+detecting large shrinks it can use to discard redundant parts of its input.
+This will be particularly noticeable in examples that make use of filtering
+and for some integer ranges.

--- a/src/hypothesis/internal/conjecture/data.py
+++ b/src/hypothesis/internal/conjecture/data.py
@@ -77,6 +77,7 @@ class ConjectureData(object):
         self.draw_times = []
         self.__intervals = None
         self.shrinking_blocks = set()
+        self.discarded = set()
 
     def __assert_not_frozen(self, name):
         if self.frozen:
@@ -148,7 +149,7 @@ class ConjectureData(object):
         self.interval_stack.append(self.index)
         self.level += 1
 
-    def stop_example(self):
+    def stop_example(self, discard=False):
         if self.frozen:
             return
         self.level -= 1
@@ -158,6 +159,8 @@ class ConjectureData(object):
         if k != self.index:
             t = (k, self.index)
             self.intervals_by_level[self.level].append(t)
+            if discard:
+                self.discarded.add(t)
 
     def note_event(self, event):
         self.events.add(event)
@@ -170,7 +173,11 @@ class ConjectureData(object):
             for l in self.intervals_by_level:
                 intervals.update(l)
                 for i in hrange(len(l) - 1):
-                    if l[i][1] == l[i + 1][0]:
+                    if (
+                        l[i] not in self.discarded and
+                        l[i + 1] not in self.discarded and
+                        l[i][1] == l[i + 1][0]
+                    ):
                         intervals.add((l[i][0], l[i + 1][1]))
             for i in hrange(len(self.blocks) - 1):
                 intervals.add((self.blocks[i][0], self.blocks[i + 1][1]))

--- a/src/hypothesis/internal/conjecture/utils.py
+++ b/src/hypothesis/internal/conjecture/utils.py
@@ -54,7 +54,9 @@ def integer_range(data, lower, upper, center=None):
     probe = gap + 1
 
     while probe > gap:
+        data.start_example()
         probe = data.draw_bits(bits)
+        data.stop_example(discard=probe > gap)
 
     if above:
         result = center + probe
@@ -307,13 +309,15 @@ class many(object):
         self.rejections = 0
         self.drawn = False
         self.force_stop = False
+        self.rejected = False
 
     def more(self):
         """Should I draw another element to add to the collection?"""
         if self.drawn:
-            self.data.stop_example()
+            self.data.stop_example(discard=self.rejected)
 
         self.drawn = True
+        self.rejected = False
 
         if self.min_size == self.max_size:
             should_continue = self.count < self.min_size
@@ -341,6 +345,7 @@ class many(object):
         assert self.count > 0
         self.count -= 1
         self.rejections += 1
+        self.rejected = True
         if self.rejections > 2 * self.count:
             if self.count < self.min_size:
                 self.data.mark_invalid()

--- a/src/hypothesis/searchstrategy/strategies.py
+++ b/src/hypothesis/searchstrategy/strategies.py
@@ -504,8 +504,12 @@ class MappedSearchStrategy(SearchStrategy):
         for _ in range(3):
             i = data.index
             try:
-                return self.pack(data.draw(self.mapped_strategy))
+                data.start_example()
+                result = self.pack(data.draw(self.mapped_strategy))
+                data.stop_example()
+                return result
             except UnsatisfiedAssumption:
+                data.stop_example(discard=True)
                 if data.index == i:
                     raise
         reject()


### PR DESCRIPTION
Context: When drawing data we sometimes do a lot of rejection sampling, where we repeatedly (at least, for a few times. In a real random generator we'd loop infinitely because we could rely on low probability events being low probability. We bound the loops more tightly because we can't guarantee that) draw a thing until we get the right sort of value.

Each of these corresponds to an interval in the data, so when the shrinker runs it will try deleting each of the rejected regions, so this is not an obstacle to shrinking. However, if there's a lot of these regions that's a lot of shrinks to try before we do anything more useful.

So this PR lets the caller annotate a region as discarded when it finishes with it. The shrinker will now try to simultaneously delete all discarded intervals on the grounds that we've been told that those regions don't matter.

Additionally, a) it is easy to detect when this pass is applicable and b) When it is, running it is essentially always a good idea because it lets us remove data that would otherwise waste our time. So whenever we perform a shrink and it results in some discarded data (this could happen because some shrink moves some data into a place where it previously wasn't and it gets rejected when interpreted in a new way), we immediately run the discard removal again.

There is, however, a complication, which is that the discard information might be *wrong*. For example, a filter function or the strategy it draws from could have a side effect (e.g. if you filter a django model then the previous loop values will still be in the database). So we cannot actually guarantee that discarding works! If we find ourselves in this situation, then trying to run discard after every shrink potentially doubles our number of test function calls, which would be bad.

So, a refinement: Whenever discarding runs, we check if it actually worked. If it didn't, we disable automatic discarding. We will still run discarding passes as part of the normal loop because they're reasonably cheap and we might as well, and if those work we turn automatic discarding back on again (I don't have a particular scenario in mind where turning it back on matters, but it's as easy to do it that way as not and I figured it might be a good idea).

I have no idea how important this scenario is (and now that we've removed the benchmarks I have no way to demonstrate that it helps at all 😉), but I'm experimenting with some alternative uses for the shrinker for which it's important to make it as cheap as possible, and this seemed like a nice refinement.