### PR TITLE
Blacklist null byte in Django string strategies

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This patch blacklists null characters (``'\x00'``) in automatically created
+strategies for Django :obj:`~django:django.db.models.CharField` and
+:obj:`~django:django.db.models.TextField`, due to a database issue which
+`was recently fixed upstream <https://code.djangoproject.com/ticket/28201>`_
+(Hypothesis :issue:`1045`).

--- a/src/hypothesis/extra/django/models.py
+++ b/src/hypothesis/extra/django/models.py
@@ -123,8 +123,12 @@ def _get_strategy_for_field(f):
                   'ipv4': ip4_addr_strings(), 'ipv6': ip6_addr_strings()}
         strategy = lookup[f.protocol.lower()]
     elif type(f) in (dm.TextField, dm.CharField):
-        strategy = st.text(min_size=(None if f.blank else 1),
-                           max_size=f.max_length)
+        strategy = st.text(
+            alphabet=st.characters(blacklist_characters=u'\x00',
+                                   blacklist_categories=('Cs',)),
+            min_size=(None if f.blank else 1),
+            max_size=f.max_length,
+        )
     elif type(f) == dm.DecimalField:
         bound = Decimal(10 ** f.max_digits - 1) / (10 ** f.decimal_places)
         strategy = st.decimals(min_value=-bound, max_value=bound,

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -790,8 +790,9 @@ def text(
     """Generates values of a unicode text type (unicode on python 2, str on
     python 3) with values drawn from alphabet, which should be an iterable of
     length one strings or a strategy generating such. If it is None it will
-    default to generating the full unicode range. If it is an empty collection
-    this will only generate empty strings.
+    default to generating the full unicode range (excluding surrogate
+    characters). If it is an empty collection this will only generate empty
+    strings.
 
     min_size, max_size and average_size have the usual interpretations.
 

--- a/tests/django/toystore/test_given_models.py
+++ b/tests/django/toystore/test_given_models.py
@@ -129,6 +129,11 @@ class TestGetsBasicModels(TestCase):
         assert isinstance(x.date, dt.date)
         assert isinstance(x.duration, dt.timedelta)
 
+    @given(models(Company))
+    def test_no_null_in_charfield(self, x):
+        # regression test for #1045.  Company just has a convenient CharField.
+        assert u'\x00' not in x.name
+
 
 class TestsNeedingRollback(TransactionTestCase):
 


### PR DESCRIPTION
Closes #1045.  Reference django/django#8670 and [Django ticket 28201](https://code.djangoproject.com/ticket/28201).

Interestingly, these cases would be rejected inside the strategy on Django 2.0 by our validator-to-filter code, which makes this change a performance optimisation only on newer versions.