### PR TITLE
Switch back to a vose alias method sampler

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This changes Hypothesis's internal implementation of weighted sampling. This
+will affect example distribution and quality, but you shouldn't see any other
+effects.

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -180,22 +180,25 @@ returns a new strategy for it. So for example:
     >>> json = recursive(none() | booleans() | floats() | text(printable),
     ... lambda children: lists(children) | dictionaries(text(printable), children))
     >>> pprint(json.example())
-    [['P'],
-     [None,
-      True,
-      -inf,
-      5.5477328279826776e+16,
-      True,
-      None,
-      -0.3333333333333333,
-      -1.7093843795721067e-100,
-      False,
-      '94K~{mY>a1yA:#CmDYb',
-      None],
-     [None, 8.628035772152501e-162, None],
-     False]
+    ['dy',
+     [None, True, 6.297399055778002e+16, False],
+     {'a{h\\:694K~{mY>a1yA:#CmDYb': None},
+     '\\kP!4',
+     {'#1J1': '',
+      'cx.': None,
+      "jv'A?qyp_sB\n$62g": [],
+      'qgnP': [False, -inf, 'la)']},
+     [],
+     {}]
     >>> pprint(json.example())
-    {'': [True]}
+    {'': None,
+     '(Rt)': 1.192092896e-07,
+     ',': [],
+     '6': 2.2250738585072014e-308,
+     'HA=/': [],
+     'YU]gy8': inf,
+     'l': None,
+     'nK': False}
     >>> pprint(json.example())
     []
 
@@ -211,7 +214,7 @@ we wanted to only generate really small JSON we could do this as:
     >>> small_lists.example()
     [False]
     >>> small_lists.example()
-    [True, True]
+    True
     >>> small_lists.example()
     []
 

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -180,7 +180,20 @@ returns a new strategy for it. So for example:
     >>> json = recursive(none() | booleans() | floats() | text(printable),
     ... lambda children: lists(children) | dictionaries(text(printable), children))
     >>> pprint(json.example())
-    ['PP']
+    [['P'],
+     [None,
+      True,
+      -inf,
+      5.5477328279826776e+16,
+      True,
+      None,
+      -0.3333333333333333,
+      -1.7093843795721067e-100,
+      False,
+      '94K~{mY>a1yA:#CmDYb',
+      None],
+     [None, 8.628035772152501e-162, None],
+     False]
     >>> pprint(json.example())
     {'': [True]}
     >>> pprint(json.example())
@@ -198,7 +211,7 @@ we wanted to only generate really small JSON we could do this as:
     >>> small_lists.example()
     [False]
     >>> small_lists.example()
-    False
+    [True, True]
     >>> small_lists.example()
     []
 

--- a/docs/reproducing.rst
+++ b/docs/reproducing.rst
@@ -106,7 +106,7 @@ as follows:
     ...     pass
     Falsifying example: test(f=nan)
     <BLANKLINE>
-    You can reproduce this example by temporarily adding @reproduce_failure(..., b'AAD/8AAAAAAAAQA=') as a decorator on your test case
+    You can reproduce this example by temporarily adding @reproduce_failure(..., b'AAAA//AAAAAAAAEA') as a decorator on your test case
 
 Adding the suggested decorator to the test should reproduce the failure (as
 long as everything else is the same - changing the versions of Python or

--- a/src/hypothesis/internal/conjecture/utils.py
+++ b/src/hypothesis/internal/conjecture/utils.py
@@ -319,9 +319,9 @@ class Sampler(object):
         use_alternate = biased_coin(data, alternate_chance)
         data.stop_example()
         if use_alternate:
-            return base
-        else:
             return alternate
+        else:
+            return base
 
 
 class many(object):

--- a/src/hypothesis/internal/conjecture/utils.py
+++ b/src/hypothesis/internal/conjecture/utils.py
@@ -281,23 +281,23 @@ class Sampler(object):
         heapq.heapify(large)
 
         while small and large:
-            s = heapq.heappop(small)
-            l = heapq.heappop(large)
+            lo = heapq.heappop(small)
+            hi = heapq.heappop(large)
 
-            assert s != l
-            assert scaled_probabilities[l] > one
-            assert self.table[s][1] is None
-            self.table[s][1] = l
-            self.table[s][2] = one - scaled_probabilities[s]
-            scaled_probabilities[l] = (
-                scaled_probabilities[l] + scaled_probabilities[s]) - one
+            assert lo != hi
+            assert scaled_probabilities[hi] > one
+            assert self.table[lo][1] is None
+            self.table[lo][1] = hi
+            self.table[lo][2] = one - scaled_probabilities[lo]
+            scaled_probabilities[hi] = (
+                scaled_probabilities[hi] + scaled_probabilities[lo]) - one
 
-            if scaled_probabilities[l] < 1:
-                heapq.heappush(small, l)
-            elif scaled_probabilities[l] == 1:
-                self.table[l][2] = zero
+            if scaled_probabilities[hi] < 1:
+                heapq.heappush(small, hi)
+            elif scaled_probabilities[hi] == 1:
+                self.table[hi][2] = zero
             else:
-                heapq.heappush(large, l)
+                heapq.heappush(large, hi)
         while large:
             self.table[large.pop()][2] = zero
         while small:

--- a/src/hypothesis/searchstrategy/numbers.py
+++ b/src/hypothesis/searchstrategy/numbers.py
@@ -112,8 +112,8 @@ class FloatStrategy(SearchStrategy):
 
         self.nasty_floats = [f for f in NASTY_FLOATS if self.permitted(f)]
         weights = [
-            0.6 * len(self.nasty_floats)
-        ] + [0.4] * len(self.nasty_floats)
+            0.2 * len(self.nasty_floats)
+        ] + [0.8] * len(self.nasty_floats)
         self.sampler = d.Sampler(weights)
 
     def __repr__(self):

--- a/tests/cover/test_conjecture_float_encoding.py
+++ b/tests/cover/test_conjecture_float_encoding.py
@@ -128,18 +128,14 @@ def test_floats_order_worse_than_their_integral_part(n, g):
 
 integral_floats = st.floats(
     allow_infinity=False, allow_nan=False, min_value=0.0
-).map(lambda x: float(int(x)))
+).map(lambda x: abs(float(int(x))))
 
 
 @given(integral_floats, integral_floats)
 def test_integral_floats_order_as_integers(x, y):
     assume(x != y)
     x, y = sorted((x, y))
-    assume(y < 0 or x > 0)
-    if y < 0:
-        assert flt.float_to_lex(y) < flt.float_to_lex(x)
-    else:
-        assert flt.float_to_lex(x) < flt.float_to_lex(y)
+    assert flt.float_to_lex(x) < flt.float_to_lex(y)
 
 
 @given(st.floats(0, 1))

--- a/tests/cover/test_conjecture_utils.py
+++ b/tests/cover/test_conjecture_utils.py
@@ -154,11 +154,6 @@ def test_sampler_distribution(weights):
     sampler = cu.Sampler(weights)
 
     calculated = [Fraction(0)] * n
-    for base, alternate, p_alternate in zip(
-        sampler.base, sampler.alternate, sampler.use_alternate
-    ):
+    for base, alternate, p_alternate in sampler.table:
         calculated[base] += (1 - p_alternate) / n
-        if alternate is not None:
-            calculated[alternate] += p_alternate / n
-
     assert probabilities == calculated

--- a/tests/cover/test_conjecture_utils.py
+++ b/tests/cover/test_conjecture_utils.py
@@ -17,10 +17,14 @@
 
 from __future__ import division, print_function, absolute_import
 
+from fractions import Fraction
 from collections import Counter
 
+import hypothesis.strategies as st
 import hypothesis.internal.conjecture.utils as cu
+from hypothesis import given, assume, example, settings
 from hypothesis.internal.compat import hbytes
+from hypothesis.internal.coverage import IN_COVERAGE_TESTS
 from hypothesis.internal.conjecture.data import ConjectureData
 
 
@@ -118,3 +122,43 @@ def test_drawing_impossible_coin_still_writes():
     assert not data.buffer
     assert not cu.biased_coin(data, 0)
     assert data.buffer
+
+
+@st.composite
+def weights(draw):
+    parts = draw(st.lists(st.integers()))
+    parts.reverse()
+    base = Fraction(1, 1)
+    for p in parts:
+        base = Fraction(1) / (1 + base)
+    return base
+
+
+@example([Fraction(1, 1), Fraction(1, 2)])
+@example([Fraction(1, 2), Fraction(4, 10)])
+@example([Fraction(1, 1), Fraction(3, 5), Fraction(1, 1)])
+@example([Fraction(2, 257), Fraction(2, 5), Fraction(1, 11)])
+@settings(
+    deadline=None, perform_health_check=False,
+    max_examples=0 if IN_COVERAGE_TESTS else settings.default.max_examples,
+)
+@given(st.lists(weights(), min_size=1))
+def test_sampler_distribution(weights):
+    total = sum(weights)
+    n = len(weights)
+
+    assume(total > 0)
+
+    probabilities = [w / total for w in weights]
+
+    sampler = cu.Sampler(weights)
+
+    calculated = [Fraction(0)] * n
+    for base, alternate, p_alternate in zip(
+        sampler.base, sampler.alternate, sampler.use_alternate
+    ):
+        calculated[base] += (1 - p_alternate) / n
+        if alternate is not None:
+            calculated[alternate] += p_alternate / n
+
+    assert probabilities == calculated

--- a/tests/cover/test_conjecture_utils.py
+++ b/tests/cover/test_conjecture_utils.py
@@ -156,4 +156,5 @@ def test_sampler_distribution(weights):
     calculated = [Fraction(0)] * n
     for base, alternate, p_alternate in sampler.table:
         calculated[base] += (1 - p_alternate) / n
+        calculated[alternate] += p_alternate / n
     assert probabilities == calculated

--- a/tests/cover/test_conjecture_utils.py
+++ b/tests/cover/test_conjecture_utils.py
@@ -23,7 +23,7 @@ from collections import Counter
 import hypothesis.strategies as st
 import hypothesis.internal.conjecture.utils as cu
 from hypothesis import given, assume, example, settings
-from hypothesis.internal.compat import hbytes
+from hypothesis.internal.compat import hbytes, hrange
 from hypothesis.internal.coverage import IN_COVERAGE_TESTS
 from hypothesis.internal.conjecture.data import ConjectureData
 
@@ -124,6 +124,14 @@ def test_drawing_impossible_coin_still_writes():
     assert data.buffer
 
 
+def test_drawing_an_exact_fraction_coin():
+    count = 0
+    for i in hrange(8):
+        if cu.biased_coin(ConjectureData.for_buffer([i]), Fraction(3, 8)):
+            count += 1
+    assert count == 3
+
+
 @st.composite
 def weights(draw):
     parts = draw(st.lists(st.integers()))
@@ -134,6 +142,7 @@ def weights(draw):
     return base
 
 
+@example([Fraction(1, 3), Fraction(1, 3), Fraction(1, 3)])
 @example([Fraction(1, 1), Fraction(1, 2)])
 @example([Fraction(1, 2), Fraction(4, 10)])
 @example([Fraction(1, 1), Fraction(3, 5), Fraction(1, 1)])

--- a/tests/nocover/test_conjecture_utils.py
+++ b/tests/nocover/test_conjecture_utils.py
@@ -1,0 +1,50 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2018 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+from fractions import Fraction
+
+import hypothesis.internal.conjecture.utils as cu
+from hypothesis.internal.compat import int_to_bytes
+from hypothesis.internal.conjecture.data import StopTest, ConjectureData
+
+
+def test_gives_the_correct_probabilities():
+    weights = [Fraction(1), Fraction(9)]
+    total = sum(weights)
+    probabilities = [w / total for w in weights]
+
+    sampler = cu.Sampler(probabilities)
+
+    assert cu.Sampler(weights).table == sampler.table
+
+    counts = [0] * len(weights)
+
+    i = 0
+    while i < 2 ** 16:
+        data = ConjectureData.for_buffer(int_to_bytes(i, 2))
+        try:
+            c = sampler.sample(data)
+            counts[c] += 1
+            assert probabilities[c] >= Fraction(counts[c], 2 ** 16)
+        except StopTest:
+            pass
+        if 1 in data.forced_indices:
+            i += 256
+        else:
+            i += 1

--- a/tests/quality/test_shrink_quality.py
+++ b/tests/quality/test_shrink_quality.py
@@ -47,7 +47,7 @@ def test_minimal_fractions_2():
 
 def test_minimal_fractions_3():
     assert minimal(
-        lists(fractions()), lambda s: len(s) >= 20) == [Fraction(0)] * 20
+        lists(fractions()), lambda s: len(s) >= 5) == [Fraction(0)] * 5
 
 
 def test_minimize_string_to_empty():


### PR DESCRIPTION
As part of #1048 I was working on the sampler and discovered that as well as shrinking badly the distribution of our sampler was also significantly wrong!

This PR switches us back to a more standard method of sampling - the alias method, adapted lightly for shrink quality purposes. I don't think the claimed advantages of the weird system we were using instead are borne out in practice given that it appears to shrink badly and be wrong.