### PR TITLE
Generate prefixes that guarantee novelty rather than trying to rewrite on the fly

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,10 @@
+RELEASE_TYPE: patch
+
+This is a change to some internals around how Hypothesis handles avoiding
+generating duplicate examples and seeking out novel regions of the search
+space.
+
+You are unlikely to see much difference as a result of it, but it fixes
+a bug where an internal assertion could theoretically be triggered and has some
+minor effects on the distribution of examples so could potentially find bugs
+that have previously been missed.

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -68,7 +68,7 @@ e.g.:
 .. doctest::
 
     >>> lists(integers()).map(sorted).example()
-    [-158104205405429173199472404790070005365, -131418136966037518992825706738877085689, -49279168042092131242764306881569217089, 2564476464308589627769617001898573635]
+    [-78884847206213906511836787254166687782, -76909635420830485682582721877759211823, -44559228081689387929401032510890553563, -32036761006342126710872700040664763427, -29721490749413656301400860492587986444, -19875460741278405972821070710713254908, 1738337815718610679283633570264779410, 22460900724744407855333819913302342200, 98446321754182121638067231096055783484, 125772708953927921071741597382378939575, 161581895130900991894656088964032281884]
 
 Note that many things that you might use mapping for can also be done with
 :func:`~hypothesis.strategies.builds`.
@@ -85,9 +85,9 @@ example of ``s`` such that ``f(example)`` is truthy.
 .. doctest::
 
     >>> integers().filter(lambda x: x > 11).example()
-    87034457550488036879331335314643907276
+    168598116374314904934044029275251725493
     >>> integers().filter(lambda x: x > 11).example()
-    145321388071838806577381808280858991039
+    103020536062639114490162140392832233565
 
 It's important to note that ``filter`` isn't magic and if your condition is too
 hard to satisfy then this can fail:
@@ -110,7 +110,7 @@ you wanted pairs of integers (x,y) such that x < y you could do the following:
 .. doctest::
 
     >>> tuples(integers(), integers()).map(sorted).filter(lambda x: x[0] < x[1]).example()
-    [-145066798798423346485767563193971626126, -19139012562996970506504843426153630262]
+    [-106979217440879777144016292455448447532, -98347272262279521424856712916204968291]
 
 .. _flatmap:
 
@@ -180,30 +180,11 @@ returns a new strategy for it. So for example:
     >>> json = recursive(none() | booleans() | floats() | text(printable),
     ... lambda children: lists(children) | dictionaries(text(printable), children))
     >>> pprint(json.example())
-    {'': 'wkP!4',
-     '\nLdy': None,
-     '"uHuds:8a{h\\:694K~{mY>a1yA:#CmDYb': {},
-     '#1J1': [')gnP',
-              inf,
-              ['6', 11881275561.716116, "v'A?qyp_sB\n$62g", ''],
-              -1e-05,
-              'aF\rl',
-              [-2.599459969184803e+250, True, True, None],
-              [True,
-               '9qP\x0bnUJH5',
-               3.0741121405774857e-131,
-               None,
-               '',
-               -inf,
-               'L&',
-               1.5,
-               False,
-               None]],
-     'cx.': None}
+    ['PP']
     >>> pprint(json.example())
-    [5.321430774293539e+16, [], 1.1045114769709281e-125]
+    {'': [True]}
     >>> pprint(json.example())
-    {'a': []}
+    []
 
 That is, we start with our leaf data and then we augment it by allowing lists and dictionaries of anything we can generate as JSON data.
 
@@ -215,11 +196,11 @@ we wanted to only generate really small JSON we could do this as:
 
     >>> small_lists = recursive(booleans(), lists, max_leaves=5)
     >>> small_lists.example()
-    True
+    [False]
     >>> small_lists.example()
-    [False, False, True, True, True]
+    False
     >>> small_lists.example()
-    True
+    []
 
 .. _composite-strategies:
 
@@ -253,7 +234,7 @@ accept all the others in the expected order. Defaults are preserved.
     >>> list_and_index()
     list_and_index()
     >>> list_and_index().example()
-    ([-57328788235238539257894870261848707608], 0)
+    ([-152878008174320402947441705721992520443, -113186425854604234871894120415088031020, -96921918763257938910439520463617861053, -105558953921933489774350201121230998748, 142532841698616540202879075992631272422, -92884554287929966590888981977733955366, 58985296493310657692270943917968787600, 97379273098575556095766461165741918726, 60328833624325181011165460989194888725, -29348109911189983741103124324039487609, -134212176354682208167522355387844513741, -62659847478174732559422739267774880206, -33294213942482611904289029199093844676, 137205879894109311837996144643445403798, -61105391525705275506417777419814026363, 80214748440107597488669535240903445548], 1)
 
     >>> list_and_index(booleans())
     list_and_index(elements=booleans())

--- a/docs/details.rst
+++ b/docs/details.rst
@@ -36,8 +36,8 @@ intermediate steps of your test. That's where the ``note`` function comes in:
     ...     test_shuffle_is_noop()
     ... except AssertionError:
     ...     print('ls != ls2')
-    Falsifying example: test_shuffle_is_noop(ls=[0, 0, 1], r=RandomWithSeed(0))
-    Shuffle: [0, 1, 0]
+    Falsifying example: test_shuffle_is_noop(ls=[0, 1], r=RandomWithSeed(1))
+    Shuffle: [1, 0]
     ls != ls2
 
 The note is printed in the final run of the test in order to include any
@@ -283,7 +283,7 @@ If you want to see exactly what a strategy produces you can ask for an example:
 .. doctest::
 
     >>> integers(min_value=0, max_value=10).example()
-    9
+    1
 
 Many strategies are built out of other strategies. For example, if you want
 to define a tuple you need to say what goes in each element:
@@ -292,7 +292,7 @@ to define a tuple you need to say what goes in each element:
 
     >>> from hypothesis.strategies import tuples
     >>> tuples(integers(), integers()).example()
-    (-85296636193678268231691518597782489127, 68871684356256783618296489618877951982)
+    (134332809039453074360454593782613510772, 130496674427438803384263463511313040000)
 
 Further details are :doc:`available in a separate document <data>`.
 
@@ -509,7 +509,7 @@ argument, to force this inference for arguments with a default value.
     >>> def func(a: int, b: str):
     ...     return [a, b]
     >>> builds(func).example()
-    [72627971792323936471739212691379790782, '']
+    [-42720342683730728910509591013777481668, '\t']
 
 :func:`@given <hypothesis.given>` does not perform any implicit inference
 for required arguments, as this would break compatibility with pytest fixtures.

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -213,6 +213,8 @@ class ConjectureRunner(object):
                 break
             self.block_sizes[indices[u]] = v - u
 
+        self.dead.update(indices[self.cap:])
+
         if data.status != Status.OVERRUN and node_index not in self.dead:
             self.dead.add(node_index)
             self.tree[node_index] = data
@@ -266,6 +268,10 @@ class ConjectureRunner(object):
             self.exit_with(ExitReason.finished)
 
         self.record_for_health_check(data)
+
+    @property
+    def cap(self):
+        return self.settings.buffer_size // 2
 
     def record_for_health_check(self, data):
         # Once we've actually found a bug, there's no point in trying to run

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -430,11 +430,10 @@ class ConjectureRunner(object):
             return _draw_successor(self.random, existing)
 
         def reuse_existing(data, n):
-            choices = data.block_starts.get(n, []) or \
-                target_data[0].block_starts.get(n, [])
+            choices = data.block_starts.get(n, [])
             if choices:
                 i = self.random.choice(choices)
-                return target_data[0].buffer[i:i + n]
+                return data.buffer[i:i + n]
             else:
                 result = uniform(self.random, n)
                 assert isinstance(result, hbytes)

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -269,6 +269,40 @@ class ConjectureRunner(object):
 
         self.record_for_health_check(data)
 
+    def generate_novel_prefix(self):
+        prefix = bytearray()
+        node = 0
+        while True:
+            assert len(prefix) < self.cap
+            assert node not in self.dead
+            upper_bound = self.capped.get(node, 255) + 1
+            try:
+                c = self.forced[node]
+                prefix.append(c)
+                node = self.tree[node][c]
+                continue
+            except KeyError:
+                pass
+            c = self.random.randrange(0, upper_bound)
+            try:
+                next_node = self.tree[node][c]
+                if next_node in self.dead:
+                    choices = [
+                        c for c in hrange(upper_bound)
+                        if self.tree[node].get(c) not in self.dead
+                    ]
+                    assert choices
+                    c = self.random.choice(choices)
+                    node = self.tree[node][c]
+                else:
+                    node = next_node
+                prefix.append(c)
+            except KeyError:
+                prefix.append(c)
+                break
+        assert node not in self.dead
+        return hbytes(prefix)
+
     @property
     def cap(self):
         return self.settings.buffer_size // 2
@@ -433,7 +467,7 @@ class ConjectureRunner(object):
             choices = data.block_starts.get(n, [])
             if choices:
                 i = self.random.choice(choices)
-                return data.buffer[i:i + n]
+                return hbytes(data.buffer[i:i + n])
             else:
                 result = uniform(self.random, n)
                 assert isinstance(result, hbytes)
@@ -477,8 +511,11 @@ class ConjectureRunner(object):
             self.random.choice(options) for _ in hrange(3)
         ]
 
+        prefix = [None]
+
         def mutate_from(origin):
             target_data[0] = origin
+            prefix[0] = self.generate_novel_prefix()
             return draw_mutated
 
         def draw_mutated(data, n):
@@ -486,16 +523,16 @@ class ConjectureRunner(object):
                 result = uniform(self.random, n)
             else:
                 result = self.random.choice(bits)(data, n)
-
-            return self.__rewrite_for_novelty(
-                data, self.__zero_bound(data, result))
+            p = prefix[0]
+            if data.index < len(p):
+                start = p[data.index:data.index + n]
+                result = start + result[len(start):]
+            return self.__zero_bound(data, result)
 
         return mutate_from
 
     def __rewrite(self, data, result):
-        return self.__rewrite_for_novelty(
-            data, self.__zero_bound(data, result)
-        )
+        return self.__zero_bound(data, result)
 
     def __zero_bound(self, data, result):
         """This tries to get the size of the generated data under control by
@@ -506,88 +543,23 @@ class ConjectureRunner(object):
         the size of the generated data.
 
         """
+        initial = len(result)
         if (
             data.depth * 2 >= MAX_DEPTH or
-            (data.index + len(result)) * 2 >= self.settings.buffer_size
+            data.index >= self.cap
         ):
-            if any(result):
-                data.hit_zero_bound = True
-            return hbytes(len(result))
-        else:
-            return result
-
-    def __rewrite_for_novelty(self, data, result):
-        """Take a block that is about to be added to data as the result of a
-        draw_bytes call and rewrite it a small amount to ensure that the result
-        will be novel: that is, not hit a part of the tree that we have fully
-        explored.
-
-        This is mostly useful for test functions which draw a small
-        number of blocks.
-
-        """
-        assert isinstance(result, hbytes)
-        try:
-            node_index = data.__current_node_index
-        except AttributeError:
-            node_index = 0
-            data.__current_node_index = node_index
-            data.__hit_novelty = False
-            data.__evaluated_to = 0
-
-        if data.__hit_novelty:
-            return result
-
-        node = self.tree[node_index]
-
-        for i in hrange(data.__evaluated_to, len(data.buffer)):
-            node = self.tree[node_index]
-            try:
-                node_index = node[data.buffer[i]]
-                assert node_index not in self.dead
-                node = self.tree[node_index]
-            except KeyError:  # pragma: no cover
-                assert False, (
-                    'This should be impossible. If you see this error, please '
-                    'report it as a bug (ideally with a reproducible test '
-                    'case).'
-                )
-
-        for i, b in enumerate(result):
-            assert isinstance(b, int)
-            try:
-                new_node_index = node[b]
-            except KeyError:
-                data.__hit_novelty = True
-                return result
-
-            new_node = self.tree[new_node_index]
-
-            if new_node_index in self.dead:
-                if isinstance(result, hbytes):
-                    result = bytearray(result)
-                for c in range(256):
-                    if c not in node:
-                        assert c <= self.capped.get(node_index, c)
-                        result[i] = c
-                        data.__hit_novelty = True
-                        return hbytes(result)
-                    else:
-                        new_node_index = node[c]
-                        new_node = self.tree[new_node_index]
-                        if new_node_index not in self.dead:
-                            result[i] = c
-                            break
-                else:  # pragma: no cover
-                    assert False, (
-                        'Found a tree node which is live despite all its '
-                        'children being dead.')
-            node_index = new_node_index
-            node = new_node
-        assert node_index not in self.dead
-        data.__current_node_index = node_index
-        data.__evaluated_to = data.index + len(result)
-        return hbytes(result)
+            data.forced_indices.update(
+                hrange(data.index, data.index + initial))
+            data.hit_zero_bound = True
+            result = hbytes(initial)
+        elif data.index + initial >= self.cap:
+            data.hit_zero_bound = True
+            n = self.cap - data.index
+            data.forced_indices.update(
+                hrange(self.cap, data.index + initial))
+            result = result[:n] + hbytes(initial - n)
+        assert len(result) == initial
+        return result
 
     @property
     def database(self):
@@ -697,10 +669,16 @@ class ConjectureRunner(object):
         while not self.interesting_examples and (
             count < 10 or self.health_check_state is not None
         ):
+            prefix = self.generate_novel_prefix()
+
             def draw_bytes(data, n):
-                return self.__rewrite_for_novelty(
-                    data, self.__zero_bound(data, uniform(self.random, n))
-                )
+                if data.index < len(prefix):
+                    result = prefix[data.index:data.index + n]
+                    if len(result) < n:
+                        result += uniform(self.random, n - len(result))
+                else:
+                    result = uniform(self.random, n)
+                return self.__zero_bound(data, result)
 
             targets_found = len(self.covering_examples)
 

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -288,8 +288,8 @@ class ConjectureRunner(object):
                 next_node = self.tree[node][c]
                 if next_node in self.dead:
                     choices = [
-                        c for c in hrange(upper_bound)
-                        if self.tree[node].get(c) not in self.dead
+                        b for b in hrange(upper_bound)
+                        if self.tree[node].get(b) not in self.dead
                     ]
                     assert choices
                     c = self.random.choice(choices)
@@ -544,10 +544,7 @@ class ConjectureRunner(object):
 
         """
         initial = len(result)
-        if (
-            data.depth * 2 >= MAX_DEPTH or
-            data.index >= self.cap
-        ):
+        if data.depth * 2 >= MAX_DEPTH or data.index >= self.cap:
             data.forced_indices.update(
                 hrange(data.index, data.index + initial))
             data.hit_zero_bound = True

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -1800,16 +1800,16 @@ def deferred(definition):
     >>> x.example()
     (((False, (True, True)), (False, True)), (True, True))
     >>> x.example()
-    (True, True)
+    True
 
     Mutual recursion also works fine:
 
     >>> a = st.deferred(lambda: st.booleans() | b)
     >>> b = st.deferred(lambda: st.tuples(a, a))
     >>> a.example()
-    (True, (True, False))
+    True
     >>> b.example()
-    (False, True)
+    (False, (False, ((False, True), False)))
 
     Examples from this strategy shrink as they normally would from the strategy
     returned by the definition.

--- a/tests/cover/test_conjecture_engine.py
+++ b/tests/cover/test_conjecture_engine.py
@@ -699,7 +699,7 @@ def test_can_increase_number_of_bytes_drawn_in_tail():
         x = data.draw_bytes(5)
         n = x.count(0)
         b = data.draw_bytes(n + 1)
-        assert not any(b[:-1])
+        assert not any(b)
 
     runner = ConjectureRunner(
         f, settings=settings(buffer_size=11, perform_health_check=False))

--- a/tests/cover/test_deferred_strategies.py
+++ b/tests/cover/test_deferred_strategies.py
@@ -33,23 +33,9 @@ def test_binary_tree():
     assert minimal(tree, lambda x: isinstance(x, tuple)) == (0, 0)
 
 
-def test_bad_binary_tree():
-    tree = st.deferred(lambda: st.tuples(tree, tree) | st.integers())
-
-    assert minimal(tree) == 0
-    assert minimal(tree, lambda x: isinstance(x, tuple)) == (0, 0)
-
-
 def test_large_branching_tree():
     tree = st.deferred(
         lambda: st.integers() | st.tuples(tree, tree, tree, tree, tree))
-    assert minimal(tree) == 0
-    assert minimal(tree, lambda x: isinstance(x, tuple)) == (0,) * 5
-
-
-def test_bad_branching_tree():
-    tree = st.deferred(
-        lambda: st.tuples(tree, tree, tree, tree, tree) | st.integers())
     assert minimal(tree) == 0
     assert minimal(tree, lambda x: isinstance(x, tuple)) == (0,) * 5
 


### PR DESCRIPTION
~~Update: Please review #1054 first~~.

Previously in Hypothesis development...

1. I opened a pull request (#1048) to make our default integer size smaller
2. This revealed some problems with our internal sampler implementation, so I opened a pull request (#1049) that replaced it with a more normal sampler implementation.
3. This revealed a bug in `__rewrite_for_novelty` where the change to the sampler triggered an internal assertion.
4. This pull request ended up breaking the pandas tests because one of them was more or less only working by coincidence - the test for shrinking based on two columns only worked if you got the right initial example. Previously we were, now we're not. #1054 fixed this.

 `__rewrite_for_novelty` has been on my hit list for a while, so this is a pull request to kill it rather than figure out that bug.

To extend the yak stack one step further, this pull request is dependent on #1051, so review that first.

The goal of  `__rewrite_for_novelty`  was to use the tree to make sure that data we draw avoids examples we've already generated (I'm sortof on the fence as to how useful this actually is, but that's a separate consideration). It does this by checking whether you're about to enter a region of the tree that is marked "dead" and rewriting the result just before you would. This was messy and required a lot of careful book-keeping.

The approach in this PR starts from the other end: Instead of trying to rewrite on the fly, we begin the process by generating a prefix at random until we hit one that guarantees we'll enter a novel region of the tree. We then start the examples we try from that prefix, guaranteeing they are not duplicates of anything we've seen previously.

This changes the distribution of examples a bit - we'll now see a bunch more diversity early in the example rather than late - but this probably won't be very noticeable.
  