### PR TITLE
Add :members: directive to autoclass for PrintSettings

### DIFF
--- a/docs/reproducing.rst
+++ b/docs/reproducing.rst
@@ -118,3 +118,4 @@ When to do this is controlled by the :attr:`~hypothesis.settings.print_blob`
 setting, which may be one of the following values:
 
 .. autoclass:: hypothesis.PrintSettings
+  :members:


### PR DESCRIPTION
[The docs for PrintSettings](https://hypothesis.readthedocs.io/en/latest/reproducing.html#hypothesis.PrintSettings) are currently singularly useless because they don't actually document the options! This fixes that.