### PR TITLE
Temporarily disable caching the .runtimes directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ branches:
 cache:
     apt: true
     directories:
-        - $HOME/.runtimes
         - $HOME/.venv
         - $HOME/.cache/pip
         - $HOME/wheelhouse


### PR DESCRIPTION
An attempt to improve the flaky Travis builds.