### PR TITLE
Improve support for shrinking recursive data structures

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,12 @@
+RELEASE_TYPE: patch
+
+This release improves test case reduction for recursive data structures.
+Hypothesis now guarantees that whenever a strategy calls itself recursively
+(usually this will happen because you are using :func:`~hypothesis.strategies.deferred`),
+any recursive call may replace the top level value. e.g. given a tree structure,
+Hypothesis will always try replacing it with a subtree.
+
+Additionally this introduces a new heuristic that may in some circumstances
+significantly speed up test case reduction - Hypothesis should be better at
+immediately replacing elements drawn inside another strategy with their minimal
+possible value.

--- a/docs/details.rst
+++ b/docs/details.rst
@@ -465,7 +465,7 @@ experimenting with conditions for filtering data.
     >>> find(lists(integers()), lambda x: sum(x) >= 10 and len(x) >= 3)
     [0, 0, 10]
     >>> find(sets(integers()), lambda x: sum(x) >= 10 and len(x) >= 3)
-    {0, 9, 1}
+    {0, 1, 9}
 
 The first argument to :func:`~hypothesis.find` describes data in the usual way for an argument to
 :func:`~hypothesis.given`, and supports :doc:`all the same data types <data>`. The second is a

--- a/src/hypothesis/internal/conjecture/data.py
+++ b/src/hypothesis/internal/conjecture/data.py
@@ -178,7 +178,8 @@ class ConjectureData(object):
         assert self.frozen
         if self.__intervals is None:
             intervals = set(self.blocks)
-            intervals.add((0, self.index))
+            if self.index > 0:
+                intervals.add((0, self.index))
             for l in self.intervals_by_level:
                 intervals.update(l)
                 for i in hrange(len(l) - 1):

--- a/src/hypothesis/internal/conjecture/data.py
+++ b/src/hypothesis/internal/conjecture/data.py
@@ -178,6 +178,7 @@ class ConjectureData(object):
         assert self.frozen
         if self.__intervals is None:
             intervals = set(self.blocks)
+            intervals.add((0, self.index))
             for l in self.intervals_by_level:
                 intervals.update(l)
                 for i in hrange(len(l) - 1):

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -1300,11 +1300,11 @@ class Shrinker(object):
         while prev is not self.shrink_target:
             prev = self.shrink_target
             self.remove_discarded()
-            self.greedy_interval_deletion()
             self.zero_intervals()
             self.minimize_duplicated_blocks()
             self.minimize_individual_blocks()
             self.reorder_blocks()
+            self.greedy_interval_deletion()
             self.interval_deletion_with_block_lowering()
             self.pass_to_interval()
 

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -1294,7 +1294,6 @@ class Shrinker(object):
                 ):
                     ends = [s for r, s in attempt.intervals if r == u]
                     ends.reverse()
-                    print(u, v, ends)
                     for s in ends:
                         if s < v and self.incorporate_new_buffer(
                             buf[:u] + hbytes(s - u) + buf[v:]

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -1253,6 +1253,12 @@ class Shrinker(object):
         self.__engine.debug(msg)
 
     def shrink(self):
+        """Run the full set of shrinks and update shrink_target.
+
+        This method is "mostly idempotent" - calling it wice is unlikely to
+        have any effect, though it has a non-zero probability of doing so.
+
+        """
         # We assume that if an all-zero block of bytes is an interesting
         # example then we're not going to do better than that.
         # This might not technically be true: e.g. for integers() | booleans()
@@ -1271,6 +1277,14 @@ class Shrinker(object):
         self.escape_local_minimum()
 
     def greedy_shrink(self):
+        """Run a full set of greedy shrinks (that is, ones that will only ever
+        move to a better target) and update shrink_target appropriately.
+
+        This method iterates to a fixed point and so is idempontent - calling
+        it twice will have exactly the same effect as calling it once.
+
+        """
+
         # This will automatically be run during the normal loop, but it's worth
         # running once before the coarse passes so they don't spend time on
         # useless data.

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -1231,10 +1231,7 @@ class Shrinker(object):
         assert sort_key(buffer) <= sort_key(self.shrink_target.buffer)
         data = ConjectureData.for_buffer(buffer)
         self.__engine.test_function(data)
-        result = self.incorporate_test_data(data)
-        if result and not self.__discarding_failed:
-            self.remove_discarded()
-        return result
+        return self.incorporate_test_data(data)
 
     def incorporate_test_data(self, data):
         if (
@@ -1242,6 +1239,8 @@ class Shrinker(object):
             sort_key(data.buffer) < sort_key(self.shrink_target.buffer)
         ):
             self.shrink_target = data
+            if data.discarded and not self.__discarding_failed:
+                self.remove_discarded()
             return True
         return False
 

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -1578,7 +1578,7 @@ class Shrinker(object):
         """Attempt to delete every interval in the example, but be more
         aggressive about it than we are in greedy_interval_deletion.
 
-        The idea here is that if we have a long list of, say, tends or
+        The idea here is that if we have a long list of, say, tens or
         hundreds of elements, we *could* try deleting each element of the list
         individually, but if only a handful of elements of the list matter then
         this is a bit of a waste of time. Wouldn't it be better if we deleted
@@ -1620,7 +1620,7 @@ class Shrinker(object):
         This is the main point at which we try to lower the size of the data.
         e.g. if we have two successive draw calls, this will attempt to delete
         the first and replace it with the second. This also works for pairs of
-        draw calls (as we create a merged interval for adjacent drawss at the
+        draw calls (as we create a merged interval for adjacent draws at the
         same level). So, for example, if we have something like:
 
         while many.more(data):
@@ -1777,12 +1777,12 @@ class Shrinker(object):
     def interval_deletion_with_block_lowering(self):
         """This pass tries to delete each interval (as per
         greedy_interval_deletion) while replacing a block that precedes that
-        interval with its immediate two lexicographical predecessors. We only.
+        interval with its immediate two lexicographical predecessors.
 
-        do this for blocks that appear in the shrinking_blocks - that is, when
-        we tried lowering them it resulted in a smaller example. This makes it
-        important that this runs after minimize_individual_blocks (which
-        populates those blocks).
+        We only do this for blocks that appear in the shrinking_blocks - that
+        is, when we tried lowering them it resulted in a smaller example.
+        This makes it important that this runs after minimize_individual_blocks
+        (which populates those blocks).
 
         The reason for this pass is that it guarantees that we can delete
         elements of ls in the following scenario:

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -165,8 +165,7 @@ class ConjectureRunner(object):
 
         self.target_selector.add(data)
 
-        if self.settings.verbosity >= Verbosity.debug:
-            self.debug_data(data)
+        self.debug_data(data)
 
         tags = frozenset(data.tags)
         data.tags = self.tag_intern_table.setdefault(tags, tags)
@@ -407,6 +406,8 @@ class ConjectureRunner(object):
             debug_report(message)
 
     def debug_data(self, data):
+        if self.settings.verbosity < Verbosity.debug:
+            return
         buffer_parts = [u"["]
         for i, (u, v) in enumerate(data.blocks):
             if i > 0:
@@ -434,12 +435,11 @@ class ConjectureRunner(object):
                 self._run()
             except RunIsComplete:
                 pass
-            if self.settings.verbosity >= Verbosity.debug:
-                for v in self.interesting_examples.values():
-                    self.debug_data(v)
-                self.debug(
-                    u'Run complete after %d examples (%d valid) and %d shrinks'
-                    % (self.call_count, self.valid_examples, self.shrinks))
+            for v in self.interesting_examples.values():
+                self.debug_data(v)
+            self.debug(
+                u'Run complete after %d examples (%d valid) and %d shrinks'
+                % (self.call_count, self.valid_examples, self.shrinks))
 
     def _new_mutator(self):
         target_data = [None]

--- a/tests/cover/test_conjecture_engine.py
+++ b/tests/cover/test_conjecture_engine.py
@@ -908,7 +908,7 @@ def fixate(f):
 
 def test_discarding_runs_automatically(monkeypatch):
     monkeypatch.setattr(
-        Shrinker, 'shrink', fixate(Shrinker.coarse_block_replacement))
+        Shrinker, 'shrink', fixate(Shrinker.minimize_individual_blocks))
     monkeypatch.setattr(
         ConjectureRunner, 'generate_new_examples',
         lambda runner: runner.test_function(
@@ -929,7 +929,7 @@ def test_discarding_runs_automatically(monkeypatch):
 
 def test_automatic_discarding_is_turned_off_if_it_does_not_work(monkeypatch):
     monkeypatch.setattr(
-        Shrinker, 'shrink', fixate(Shrinker.coarse_block_replacement))
+        Shrinker, 'shrink', fixate(Shrinker.minimize_individual_blocks))
     target = hbytes([0, 1]) * 5 + hbytes([11])
     monkeypatch.setattr(
         ConjectureRunner, 'generate_new_examples',

--- a/tests/quality/test_poisoned_trees.py
+++ b/tests/quality/test_poisoned_trees.py
@@ -1,0 +1,139 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2018 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+from random import Random
+
+import pytest
+
+import hypothesis.internal.conjecture.utils as cu
+from hypothesis import settings, unlimited
+from hypothesis.searchstrategy import SearchStrategy
+from hypothesis.internal.compat import hbytes, hrange
+from hypothesis.internal.conjecture.engine import ConjectureData, \
+    ConjectureRunner, uniform
+
+POISON = 'POISON'
+
+MAX_INT = 2 ** 32 - 1
+
+
+class PoisonedTree(SearchStrategy):
+    """Generates variable sized tuples with an implicit tree structure.
+
+    The actual result is flattened out, but the hierarchy is implicit in
+    the data.
+
+    """
+
+    def __init__(self, p):
+        SearchStrategy.__init__(self)
+        self.__p = p
+
+    def do_draw(self, data):
+        if cu.biased_coin(data, self.__p):
+            return data.draw(self) + data.draw(self)
+        else:
+            # We draw n as two separate calls so that it doesn't show up as a
+            # single block. If it did, the heuristics that allow us to move
+            # blocks around would fire and it would move right, which would
+            # then allow us to shrink it more easily.
+            n = (data.draw_bits(16) << 16) | data.draw_bits(16)
+            if n == MAX_INT:
+                return (POISON,)
+            else:
+                return (None,)
+
+
+LOTS = 10 ** 6
+
+
+TEST_SETTINGS = settings(
+    database=None, perform_health_check=False, max_examples=LOTS,
+    deadline=None, timeout=unlimited, max_shrinks=LOTS
+)
+
+
+@pytest.mark.parametrize('size', [2, 5, 10])
+@pytest.mark.parametrize('seed', [0, 15993493061449915028])
+def test_can_reduce_poison_from_any_subtree(size, seed):
+    """This test validates that we can minimize to any leaf node of a binary
+    tree, regardless of where in the tree the leaf is."""
+    random = Random(seed)
+
+    # Initially we create the minimal tree of size n, regardless of whether it
+    # is poisoned (which it won't be - the poison event essentially never
+    # happens when drawing uniformly at random).
+
+    # Choose p so that the expected size of the tree is equal to the desired
+    # size.
+    p = 1.0 / (2.0 - 1.0 / size)
+    strat = PoisonedTree(p)
+
+    def test_function(data):
+        v = data.draw(strat)
+        if len(v) >= size:
+            data.mark_interesting()
+
+    runner = ConjectureRunner(
+        test_function, random=random, settings=TEST_SETTINGS
+    )
+
+    while not runner.interesting_examples:
+        runner.test_function(ConjectureData(
+            draw_bytes=lambda data, n: uniform(random, n),
+            max_length=LOTS))
+
+    runner.shrink_interesting_examples()
+
+    data, = runner.interesting_examples.values()
+
+    assert len(ConjectureData.for_buffer(data.buffer).draw(strat)) == size
+
+    starts = data.block_starts[2]
+    assert len(starts) % 2 == 0
+
+    for i in hrange(0, len(starts), 2):
+        # Now for each leaf position in the tree we try inserting a poison
+        # value artificially. Additionally, we add a marker to the end that
+        # must be preserved. The marker means that we are not allow to rely on
+        # discarding the end of the buffer to get the desired shrink.
+        u = starts[i]
+        marker = hbytes([1, 2, 3, 4])
+
+        poisoned_data = ConjectureData.for_buffer(
+            data.buffer[:u] + hbytes([255]) * 4 + data.buffer[u + 4:] +
+            marker
+        )
+
+        def test_function(data):
+            v = data.draw(strat)
+            m = data.draw_bytes(len(marker))
+            if POISON in v and m == marker:
+                data.mark_interesting()
+        runner = ConjectureRunner(
+            test_function, random=random, settings=TEST_SETTINGS)
+
+        runner.test_function(poisoned_data)
+        assert runner.interesting_examples
+        runner.shrink_interesting_examples()
+
+        shrunk, = runner.interesting_examples.values()
+
+        assert ConjectureData.for_buffer(
+            shrunk.buffer).draw(strat) == (POISON,)

--- a/tests/quality/test_shrink_quality.py
+++ b/tests/quality/test_shrink_quality.py
@@ -236,3 +236,13 @@ def test_duplicate_containment():
         lambda s: s[0].count(s[1]) > 1, timeout_after=100)
     assert ls == [0, 0]
     assert i == 0
+
+
+@pytest.mark.parametrize('seed', [11, 28, 37])
+def test_reordering_bytes(seed):
+    ls = minimal(
+        lists(integers()), lambda x: sum(x) >= 10 and len(x) >= 3,
+        random=Random(seed),
+    )
+
+    assert ls == sorted(ls)

--- a/tests/quality/test_shrink_quality.py
+++ b/tests/quality/test_shrink_quality.py
@@ -202,16 +202,18 @@ def test_minimize_long():
 
 
 def test_find_large_union_list():
+    size = 10
+
     def large_mostly_non_overlapping(xs):
         union = reduce(set.union, xs)
-        return len(union) >= 30
+        return len(union) >= size
 
     result = minimal(
         lists(sets(integers(), min_size=1), min_size=1),
         large_mostly_non_overlapping, timeout_after=120)
     assert len(result) == 1
     union = reduce(set.union, result)
-    assert len(union) == 30
+    assert len(union) == size
     assert max(union) == min(union) + len(union) - 1
 
 


### PR DESCRIPTION
More work that emerged from evaluations done while writing my paper on the shrinker: I noticed that if we have a binary tree that we're generating as leaf | branch, we actually can only "properly" shrink it to the right hand subtree. We can shrink to the left subtree only if this is the last element drawn (because then we can silently discard the bytes at the end).

This change provides a significant upgrade to how Hypothesis handles recursive data in the form of two extra passes:

* `zero_intervals` tries replacing every draw call with its natural minimum element (the one you get from an infinite series of zeroes): It first tried replacing the interval with a zero interval of the same length. If that works, great. If not but it produces a valid example, we can read off the set of possible lengths for what we should have put there and try each of them. As well as recursive examples this also means that e.g. we can automatically replace unimportant lists with empty-lists.
* `pass_to_subinterval` tries replacing each interval with each interval contained in it. This is potentially fairly expensive, so we do it right at the end. However having run `zero_intervals` first helps greatly in reducing its cost by having killed most sub-examples that we might pass to incorrectly.