### PR TITLE
Actually skip bump-commits in Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,11 @@ environment:
       PYTHON_VERSION: "3.6.1"
       PYTHON_ARCH: "64"
 
+# Appveyor "helpfully" ignores skip directives in the commit message body
+# https://www.appveyor.com/docs/how-to/filtering-commits/#commit-message
+skip_commits:
+  message: /^Bump version to \d+\.\d+\.\d+ and update changelog/
+
 # This matches both branches and tags (no, I don't know why either).
 # We need a match both for pushes to master, and our release tags which
 # trigger wheel builds.

--- a/docs/reproducing.rst
+++ b/docs/reproducing.rst
@@ -6,7 +6,7 @@ One of the things that is often concerning for people using randomized testing
 like Hypothesis is the question of how to reproduce failing test cases.
 
 Fortunately Hypothesis has a number of features in support of this. The one you
-will use most commonly when developing locally is `the example database <database>`,
+will use most commonly when developing locally is :doc:`the example database <database>`,
 which means that you shouldn't have to think about the problem at all for local
 use - test failures will just automatically reproduce without you having to do
 anything.


### PR DESCRIPTION
> [NOTE: AppVeyor searches for skip commit string in the commit message title only (text before first empty line) only.](https://www.appveyor.com/docs/how-to/filtering-commits/#commit-message)

Appveyor "helpfully" supports standard skip messages in a non-standard way.  Instead of making our regular message ugly, I've just told Appveyor to skip that message too.

This should avoid spurious reporting of failures in the commit list; and likewise against the repo title via [refined github](https://github.com/sindresorhus/refined-github).  (which is great, as is [issue link status](https://github.com/bfred-it/github-issue-link-status))