### PR TITLE
Make test output non-verbose by default

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -195,4 +195,4 @@ commands=
     python -m pytest examples
 
 [pytest]
-addopts=--strict --tb=native -vv -p pytester --runpytest=subprocess --durations=20 -n 2
+addopts=--strict --tb=native -p pytester --runpytest=subprocess --durations=20 -n 2


### PR DESCRIPTION
This turns off verbose test reporting in pytest, so instead of seeing each test name we'll mostly see ...F... and then the failing tests printed at the end.

@Zac-HD suggested this a little while back, and I've become convinced it's a good idea, mostly because I'm incredibly annoyed by how badly Travis et al handle large test output (yes, lets take the simple text output and run it through incredibly slow javascript that locks up people's browsers, what a good idea).