### PR TITLE
Add purely structural tags to ConjectureData

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,13 @@
+RELEASE_TYPE: patch
+
+This change adds some additional structural information that Hypothesis will
+use to guide its search.
+
+You mostly shouldn't see much difference from this. The two most likely effects
+you would notice are:
+
+1. Hypothesis stores slightly more examples in its database for passing tests.
+2. Hypothesis *may* find new bugs that it was previously missing, but it
+   probably won't (this is a basic implementation of the feature that is
+   intended to support future work. Although it is useful on its own, it's not
+   *very* useful on its own).

--- a/src/hypothesis/internal/compat.py
+++ b/src/hypothesis/internal/compat.py
@@ -23,6 +23,7 @@ import re
 import sys
 import math
 import time
+import array
 import codecs
 import platform
 import importlib
@@ -117,11 +118,13 @@ else:
             return struct.unpack(fmt, str(string))
 
     def int_from_bytes(data):
-        assert isinstance(data, bytearray)
         if CAN_UNPACK_BYTE_ARRAY:
             unpackable_data = data
-        else:
+        elif isinstance(data, bytearray):
             unpackable_data = bytes(data)
+        else:
+            unpackable_data = data
+        assert isinstance(data, (bytes, bytearray))
         result = 0
         i = 0
         while i + 4 <= len(data):

--- a/src/hypothesis/searchstrategy/collections.py
+++ b/src/hypothesis/searchstrategy/collections.py
@@ -21,7 +21,7 @@ import hypothesis.internal.conjecture.utils as cu
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.compat import OrderedDict, hbytes
 from hypothesis.searchstrategy.strategies import SearchStrategy, \
-    MappedSearchStrategy, one_of_strategies
+    MappedSearchStrategy, combine_labels, one_of_strategies
 
 
 class TupleStrategy(SearchStrategy):
@@ -38,6 +38,10 @@ class TupleStrategy(SearchStrategy):
     def do_validate(self):
         for s in self.element_strategies:
             s.validate()
+
+    def calc_label(self):
+        return combine_labels(
+            self.class_label, *[s.label for s in self.element_strategies])
 
     def __repr__(self):
         if len(self.element_strategies) == 1:
@@ -91,6 +95,9 @@ class ListStrategy(SearchStrategy):
         self.min_size = min_size or 0
         self.max_size = max_size or float('inf')
         self.element_strategy = one_of_strategies(strategies)
+
+    def calc_label(self):
+        return combine_labels(self.class_label, self.element_strategy.label)
 
     def do_validate(self):
         self.element_strategy.validate()

--- a/src/hypothesis/searchstrategy/deferred.py
+++ b/src/hypothesis/searchstrategy/deferred.py
@@ -65,6 +65,21 @@ class DeferredStrategy(SearchStrategy):
     def supports_find(self):
         return self.wrapped_strategy.supports_find
 
+    def calc_label(self):
+        """deferred strategies don't have a calculated label, because we would
+        end up having to calculate the fixed point of some hash function in
+        order to calculate it when they recursively refer to themself!
+
+        The label for the wrapped strategy will still appear because it
+        will be passed to draw.
+
+        """
+
+        # This is actually the same as the parent class implementation, but we
+        # include it explicitly here in order to document that this is a
+        # deliberate decision.
+        return self.class_label
+
     def calc_is_empty(self, recur):
         return recur(self.wrapped_strategy)
 

--- a/src/hypothesis/searchstrategy/lazy.py
+++ b/src/hypothesis/searchstrategy/lazy.py
@@ -156,3 +156,7 @@ class LazyStrategy(SearchStrategy):
 
     def do_draw(self, data):
         return data.draw(self.wrapped_strategy)
+
+    @property
+    def label(self):
+        return self.wrapped_strategy.label

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -1504,6 +1504,7 @@ def composite(f):
     """
 
     from hypothesis.internal.reflection import define_function_signature
+    from hypothesis.searchstrategy.strategies import calc_label
     argspec = getfullargspec(f)
 
     if (
@@ -1522,6 +1523,8 @@ def composite(f):
               if k in (argspec.args + argspec.kwonlyargs + ['return'])}
     new_argspec = argspec._replace(args=argspec.args[1:], annotations=annots)
 
+    label = calc_label(f)
+
     @defines_strategy
     @define_function_signature(f.__name__, f.__doc__, new_argspec)
     def accept(*args, **kwargs):
@@ -1535,6 +1538,10 @@ def composite(f):
                     return data.draw(strategy)
 
                 return f(draw, *args, **kwargs)
+
+            @property
+            def label(self):
+                return label
         return CompositeStrategy()
     accept.__module__ = f.__module__
     return accept

--- a/tests/cover/test_conjecture_engine.py
+++ b/tests/cover/test_conjecture_engine.py
@@ -142,12 +142,8 @@ def test_terminates_shrinks(n, monkeypatch):
     last_data, = runner.interesting_examples.values()
     assert last_data.status == Status.INTERESTING
     assert runner.shrinks == n
-    in_db = set(
-        v
-        for vs in db.data.values()
-        for v in vs
-    )
-    assert len(in_db) == n + 1
+    in_db = set(db.data[runner.secondary_key])
+    assert len(in_db) == n
 
 
 def test_detects_flakiness():

--- a/tests/cover/test_database_usage.py
+++ b/tests/cover/test_database_usage.py
@@ -58,15 +58,15 @@ def test_clears_out_database_as_things_get_boring():
         except NoSuchExample:
             pass
     stuff()
-    assert len(all_values(database)) > 1
+    assert len(non_covering_examples(database)) > 1
     do_we_care = False
     stuff()
-    initial = len(all_values(database))
+    initial = len(non_covering_examples(database))
     assert initial > 0
 
     for _ in range(initial):
         stuff()
-        keys = len(all_values(database))
+        keys = len(non_covering_examples(database))
         if not keys:
             break
     else:

--- a/tests/cover/test_simple_numbers.py
+++ b/tests/cover/test_simple_numbers.py
@@ -22,10 +22,9 @@ import math
 
 import pytest
 
-from hypothesis import given, settings
+from hypothesis import given
 from tests.common.debug import minimal
-from hypothesis.strategies import lists, floats, randoms, integers, \
-    complex_numbers
+from hypothesis.strategies import lists, floats, integers, complex_numbers
 
 
 def test_minimize_negative_int():
@@ -169,11 +168,8 @@ def test_list_of_fractional_float():
     )
 
 
-@settings(deadline=None)
-@given(randoms())
-def test_minimal_fractional_float(rnd):
-    assert minimal(
-        floats(), lambda x: x >= 1.5, random=rnd) in (1.5, 2.0)
+def test_minimal_fractional_float():
+    assert minimal(floats(), lambda x: x >= 1.5) in (1.5, 2.0)
 
 
 def test_minimizes_lists_of_negative_ints_up_to_boundary():

--- a/tests/cover/test_stateful.py
+++ b/tests/cover/test_stateful.py
@@ -511,7 +511,7 @@ def test_saves_failing_example_in_database():
     with raises(AssertionError):
         run_state_machine_as_test(
             SetStateMachine, Settings(database=db))
-    assert len(list(db.data.keys())) == 2
+    assert any(list(db.data.values()))
 
 
 def test_can_run_with_no_db():

--- a/tests/nocover/test_labels.py
+++ b/tests/nocover/test_labels.py
@@ -1,0 +1,123 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2018 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import hypothesis.strategies as st
+from hypothesis.internal.compat import hbytes
+from hypothesis.internal.conjecture.data import Status, StructuralTag, \
+    ConjectureData
+
+
+def test_labels_are_cached():
+    x = st.integers()
+    assert x.label is x.label
+
+
+def test_labels_are_distinct():
+    assert st.integers().label != st.text().label
+
+
+@st.composite
+def foo(draw):
+    pass
+
+
+@st.composite
+def bar(draw):
+    pass
+
+
+def test_different_composites_have_different_labels():
+    assert foo().label != bar().label
+
+
+def test_one_of_label_is_distinct():
+    a = st.integers()
+    b = st.booleans()
+    assert st.one_of(a, b).label != st.one_of(b, a).label
+
+
+def test_lists_label_by_element():
+    assert st.lists(st.integers()).label != st.lists(st.booleans()).label
+
+
+def get_tags(strat, buf):
+    d = ConjectureData.for_buffer(buf)
+    d.draw(strat)
+    d.freeze()
+    assert d.status == Status.VALID
+    return d.tags
+
+
+def test_labels_get_used_for_tagging():
+    assert get_tags(st.integers(), hbytes(8)) != get_tags(st.text(), hbytes(8))
+
+
+def test_labels_get_used_for_tagging_branches():
+    strat = st.one_of(
+        st.booleans().map(lambda x: not x),
+        st.booleans().map(lambda x: x),
+    )
+
+    assert get_tags(strat, hbytes(2)) != get_tags(strat, hbytes([1, 0]))
+
+
+def run_for_labels(buffer):
+    buffer = hbytes(buffer)
+
+    def accept(f):
+        data = ConjectureData.for_buffer(buffer)
+        f(data)
+        data.freeze()
+        return frozenset(
+            t.label for t in data.tags if isinstance(t, StructuralTag))
+    return accept
+
+
+def test_discarded_intervals_are_not_in_labels():
+    @run_for_labels([0, 0])
+    def x(data):
+        data.start_example(3)
+        data.draw_bits(1)
+        data.stop_example(discard=True)
+        data.start_example(2)
+        data.draw_bits(1)
+        data.stop_example()
+
+    assert x == frozenset({2})
+
+
+def test_nested_discarded_intervals_are_not_in_labels():
+    @run_for_labels([0, 0, 0])
+    def x(data):
+        data.start_example(3)
+        data.draw_bits(1)
+        data.start_example(4)
+        data.draw_bits(1)
+        data.stop_example()
+        data.stop_example(discard=True)
+        data.start_example(2)
+        data.draw_bits(1)
+        data.stop_example()
+
+    assert x == frozenset({2})
+
+
+def test_label_of_deferred_strategy_is_well_defined():
+    recursive = st.deferred(lambda: st.lists(recursive))
+    recursive.label


### PR DESCRIPTION
There are currently two tensions in moving forward some planned Hypothesis development:

1. I want to take better advantage of coverage information.
2. I want to keep things working without coverage information

One option is basically to just fall back to something 100% naive in the latter case, but that seems a shame. We're basically just using coverage to partition the space, so perhaps we can figure out a (necessarily coarser) partition without coverage?

This PR is a first pass at doing that: The idea is to using hashing to indicate some basic structural information about the shape of the data - for example, to distinguish an empty list from a list containing an integer from a list containing a string. The tags in question are then used exactly like coverage targets, but apply whether or not we are running with coverage on.

~~In addition, this information can be helpful for test case reduction because it lets us simultaneously minimize all values corresponding to a strategy - e.g. replace all strings with the empty string, or all integers with 0, so this also adds another shrink pass (it doesn't seem to be *that* helpful, but it's reasonably cheap and seemed worth a try)~~ This interacts poorly with trying to avoid duplicates. I'm unconvinced trying to avoid duplicates actually matters that much here, but it's of arguable enough benefit that I decided to just pull this bit and revisit this question later.