### PR TITLE
Make build failures tidier

### DIFF
--- a/scripts/run_travis_make_task.py
+++ b/scripts/run_travis_make_task.py
@@ -20,6 +20,7 @@
 from __future__ import division, print_function, absolute_import
 
 import os
+import sys
 import subprocess
 
 from hypothesistooling import should_run_ci_task
@@ -29,4 +30,4 @@ if __name__ == '__main__':
     task = os.environ['TASK']
 
     if should_run_ci_task(task=task, is_pull_request=is_pull_request):
-        subprocess.check_call(['make', task])
+        sys.exit(subprocess.call(['make', task]))


### PR DESCRIPTION
I've been finding the `CalledSubprocessError` stack traces on our build failures annoyingly distracting. This replaces them with code that just exits with the right code instead.