### PR TITLE
Improve unhappy paths using @given with unittest

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,21 @@
+RELEASE_TYPE: minor
+
+This release improves some "unhappy paths" when using Hypothesis
+with the standard library :mod:`python:unittest` module:
+
+- Applying :func:`@given <hypothesis.given>` to a non-test method which is
+  overridden from :class:`python:unittest.TestCase`, such as ``setUp``,
+  raises :attr:`a new health check <hypothesis.settings.not_a_test_method>`.
+  (:issue:`991`)
+- Using :meth:`~python:unittest.TestCase.subTest` within a test decorated
+  with :func:`@given <hypothesis.given>` would leak intermediate results
+  when tests were run under the :mod:`python:unittest` test runner.
+  Individual reporting of failing subtests is now disabled during a test
+  using :func:`@given <hypothesis.given>`.  (:issue:`1071`)
+- :func:`@given <hypothesis.given>` is still not a class decorator, but the
+  error message if you try using it on a class has been improved.
+
+As a related improvement, using :class:`django:django.test.TestCase` with
+:func:`@given <hypothesis.given>` instead of
+:class:`hypothesis.extra.django.TestCase` raises an explicit error instead
+of running all examples in a single database transaction.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -51,7 +51,7 @@ what arguments are valid, and additional validation logic to raise a
 clear error early (instead of e.g. silently ignoring a bad argument).
 Categories may be specified as the Unicode 'general category'
 (eg ``u'Nd'``), or as the 'major category' (eg ``[u'N', u'Lu']``
-is equivalent to ``[u'Nd', u'Nl', u'No', u'Lu']``.
+is equivalent to ``[u'Nd', u'Nl', u'No', u'Lu']``).
 
 In previous versions, general categories were supported and all other
 input was silently ignored.  Now, major categories are supported in

--- a/docs/healthchecks.rst
+++ b/docs/healthchecks.rst
@@ -17,11 +17,12 @@ If any of these scenarios are detected, Hypothesis will emit a warning about the
 The general goal of these health checks is to warn you about things that you are doing that might
 appear to work but will either cause Hypothesis to not work correctly or to perform badly.
 
-To selectively disable health checks, use the suppress_health_check setting.
+To selectively disable health checks, use the
+:obj:`~hypothesis.settings.suppress_health_check` setting.
 The argument for this parameter is a list with elements drawn from any of
 the class-level attributes of the HealthCheck class.
 
-To disable all health checks, set the perform_health_check settings parameter
+To disable all health checks, set the :obj:`~hypothesis.settings.perform_health_check`
 to False.
 
 .. module:: hypothesis

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -281,7 +281,7 @@ the future behaviour by setting it to the value ``hypothesis.unlimited``.
         ...
 
 This will cause your code to run until it hits the normal Hypothesis example
-limits, regardless of how long it takes. `timeout=unlimited` will remain a
+limits, regardless of how long it takes. ``timeout=unlimited`` will remain a
 valid setting after the timeout functionality has been deprecated (but will
 then have its own deprecation cycle).
 

--- a/docs/supported.rst
+++ b/docs/supported.rst
@@ -52,22 +52,22 @@ test to take this form.
 
 In terms of what's actually *known* to work:
 
-  * Hypothesis integrates as smoothly with py.test and unittest as I can make it,
+  * Hypothesis integrates as smoothly with py.test and unittest as we can make it,
     and this is verified as part of the CI.
-  * py.test fixtures work correctly with Hypothesis based functions, but note that
-    function based fixtures will only run once for the whole function, not once per
-    example.
+    Note however that :func:`@given <hypothesis.given>` should only be used on
+    tests, not :class:`python:unittest.TestCase` setup or teardown methods.
+  * py.test fixtures work in the usual way for tests that have been decorated
+    with :func:`@given <hypothesis.given>` - just avoid passing a strategy for
+    each argument that will be supplied by a fixture.  However, each fixture
+    will run once for the whole function, not once per example.  Decorating a
+    fixture function is meaningless.
   * Nose works fine with hypothesis, and this is tested as part of the CI. yield based
     tests simply won't work.
   * Integration with Django's testing requires use of the :ref:`hypothesis-django` package.
     The issue is that in Django's tests' normal mode of execution it will reset the
     database one per test rather than once per example, which is not what you want.
-
-Coverage works out of the box with Hypothesis (and Hypothesis has 100% branch
-coverage in its own tests). However you should probably not use Coverage, Hypothesis
-and PyPy together. Because Hypothesis does quite a lot of CPU heavy work compared
-to normal tests, it really exacerbates the performance problems the two normally
-have working together.
+  * Coverage works out of the box with Hypothesis - we use it to guide example
+    selection for user code, and Hypothesis has 100% branch coverage in its own tests.
 
 -----------------
 Optional Packages
@@ -82,10 +82,11 @@ Regularly verifying this
 ------------------------
 
 Everything mentioned above as explicitly supported is checked on every commit
-with `Travis <https://travis-ci.org/HypothesisWorks/hypothesis-python>`_ and
-`Appveyor <https://ci.appveyor.com/project/DRMacIver/hypothesis-python/>`_
-and goes green before a release happens, so when I say they're supported I
-really mean it.
+with `Travis <https://travis-ci.org/HypothesisWorks/hypothesis-python>`_,
+`Appveyor <https://ci.appveyor.com/project/DRMacIver/hypothesis-python/>`_, and
+`CircleCI <https://circleci.com/gh/HypothesisWorks/hypothesis-python>`_.
+Our continous delivery pipeline runs all of these checks before publishing
+each release, so when we say they're supported we really mean it.
 
 -------------------
 Hypothesis versions

--- a/src/hypothesis/_settings.py
+++ b/src/hypothesis/_settings.py
@@ -522,6 +522,9 @@ class HealthCheck(Enum):
     large_base_example = 7
     """Checks if the natural example to shrink towards is very large."""
 
+    not_a_test_method = 8
+    """Checks if @given has been applied to a method of unittest.TestCase."""
+
 
 @unique
 class Statistics(IntEnum):

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -31,6 +31,7 @@ import warnings
 import traceback
 import contextlib
 from random import Random
+from unittest import TestCase
 
 import attr
 from coverage import CoverageData
@@ -968,6 +969,11 @@ def given(*given_arguments, **given_kwargs):
             arguments, kwargs, test_runner, search_strategy = processed_args
 
             runner = getattr(search_strategy, 'runner', None)
+            if isinstance(runner, TestCase) and test.__name__ in dir(TestCase):
+                msg = ('You have applied @given to the method %s, which is '
+                       'used by the unittest runner but is not itself a test.'
+                       '  This is not useful in any way.' % test.__name__)
+                fail_health_check(settings, msg, HealthCheck.not_a_test_method)
 
             state = StateForActualGivenExecution(
                 test_runner, search_strategy, test, settings, random,

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -52,8 +52,9 @@ from hypothesis._settings import note_deprecation
 from hypothesis.executors import new_style_executor
 from hypothesis.reporting import report, verbose_report, current_verbosity
 from hypothesis.statistics import note_engine_for_statistics
-from hypothesis.internal.compat import ceil, hbytes, str_to_bytes, \
-    benchmark_time, get_type_hints, getfullargspec, encoded_filepath
+from hypothesis.internal.compat import ceil, hbytes, qualname, \
+    str_to_bytes, benchmark_time, get_type_hints, getfullargspec, \
+    encoded_filepath, bad_django_TestCase
 from hypothesis.internal.coverage import IN_COVERAGE_TESTS
 from hypothesis.utils.conventions import infer, not_set
 from hypothesis.internal.escalation import is_hypothesis_file, \
@@ -974,6 +975,15 @@ def given(*given_arguments, **given_kwargs):
                        'used by the unittest runner but is not itself a test.'
                        '  This is not useful in any way.' % test.__name__)
                 fail_health_check(settings, msg, HealthCheck.not_a_test_method)
+            if bad_django_TestCase(runner):  # pragma: no cover
+                # Covered by the Django tests, but not the pytest coverage task
+                raise InvalidArgument(
+                    'You have applied @given to a method on %s, but this '
+                    'class does not inherit from the supported versions in '
+                    '`hypothesis.extra.django`.  Use the Hypothesis variants '
+                    'to ensure that each example is run in a separate '
+                    'database transaction.' % qualname(type(runner))
+                )
 
             state = StateForActualGivenExecution(
                 test_runner, search_strategy, test, settings, random,

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -26,6 +26,7 @@ import sys
 import time
 import zlib
 import base64
+import inspect
 import traceback
 from random import Random
 
@@ -885,6 +886,11 @@ def given(*given_arguments, **given_kwargs):
     This is the main entry point to Hypothesis.
     """
     def run_test_with_generator(test):
+        if inspect.isclass(test):
+            # Provide a meaningful error to users, instead of exceptions from
+            # internals that assume we're dealing with a function.
+            raise InvalidArgument('@given cannot be applied to a class.')
+
         generator_arguments = tuple(given_arguments)
         generator_kwargs = dict(given_kwargs)
 

--- a/src/hypothesis/errors.py
+++ b/src/hypothesis/errors.py
@@ -154,8 +154,16 @@ class FailedHealthCheck(HypothesisException, Warning):
         self.health_check = check
 
 
-class HypothesisDeprecationWarning(HypothesisException, FutureWarning):
-    pass
+class HypothesisWarning(HypothesisException, Warning):
+    """A generic warning issued by Hypothesis."""
+
+
+class HypothesisDeprecationWarning(HypothesisWarning, FutureWarning):
+    """A deprecation warning issued by Hypothesis.
+
+    Actually inherits from FutureWarning, because DeprecationWarning is
+    hidden by the default warnings filter.
+    """
 
 
 class Frozen(HypothesisException):

--- a/src/hypothesis/internal/compat.py
+++ b/src/hypothesis/internal/compat.py
@@ -517,3 +517,19 @@ if PY2:
         return hbytes(base(s))
 else:
     from base64 import b64decode
+
+
+_cases = []
+
+
+def bad_django_TestCase(runner):
+    if runner is None:
+        return False
+    if not _cases:
+        try:
+            from django.test import TransactionTestCase
+            from hypothesis.extra.django import HypothesisTestCase
+            _cases[:] = TransactionTestCase, HypothesisTestCase
+        except ImportError:
+            _cases[:] = type, type
+    return isinstance(runner, _cases[0]) and not isinstance(runner, _cases[1])

--- a/tests/cover/test_given_error_conditions.py
+++ b/tests/cover/test_given_error_conditions.py
@@ -23,7 +23,7 @@ import pytest
 
 from hypothesis import given, infer, assume, reject, settings
 from hypothesis.errors import Timeout, Unsatisfiable, InvalidArgument
-from tests.common.utils import validate_deprecation
+from tests.common.utils import fails_with, validate_deprecation
 from hypothesis.strategies import booleans, integers
 
 
@@ -89,3 +89,12 @@ def test_given_twice_deprecated():
         pass
     with validate_deprecation():
         inner()
+
+
+@fails_with(InvalidArgument)
+def test_given_is_not_a_class_decorator():
+    @given(integers())
+    class test_given_is_not_a_class_decorator():
+
+        def __init__(self, i):
+            pass

--- a/tests/cover/test_unittest.py
+++ b/tests/cover/test_unittest.py
@@ -24,7 +24,8 @@ import pytest
 
 from hypothesis import given
 from hypothesis import strategies as st
-from hypothesis.errors import HypothesisWarning
+from hypothesis.errors import FailedHealthCheck, HypothesisWarning
+from tests.common.utils import fails_with
 from hypothesis.internal.compat import PY2
 
 
@@ -45,3 +46,15 @@ def test_subTest():
     stream = io.BytesIO() if PY2 else io.StringIO()
     out = unittest.TextTestRunner(stream=stream).run(suite)
     assert len(out.failures) <= out.testsRun, out
+
+
+class test_given_on_setUp_fails_health_check(unittest.TestCase):
+
+    @fails_with(FailedHealthCheck)
+    @given(st.integers())
+    def setUp(self, i):
+        pass
+
+    def test(self):
+        """Provide something to set up for, so the setUp method is called."""
+        pass

--- a/tests/cover/test_unittest.py
+++ b/tests/cover/test_unittest.py
@@ -1,0 +1,47 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2018 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import io
+import unittest
+
+import pytest
+
+from hypothesis import given
+from hypothesis import strategies as st
+from hypothesis.errors import HypothesisWarning
+from hypothesis.internal.compat import PY2
+
+
+class Thing_with_a_subThing(unittest.TestCase):
+    """Example test case using subTest for the actual test below."""
+
+    @given(st.tuples(st.booleans(), st.booleans()))
+    def thing(self, lst):
+        for i, b in enumerate(lst):
+            with pytest.warns(HypothesisWarning):
+                with self.subTest((i, b)):
+                    self.assertTrue(b)
+
+
+def test_subTest():
+    suite = unittest.TestSuite()
+    suite.addTest(Thing_with_a_subThing('thing'))
+    stream = io.BytesIO() if PY2 else io.StringIO()
+    out = unittest.TextTestRunner(stream=stream).run(suite)
+    assert len(out.failures) <= out.testsRun, out

--- a/tests/django/toystore/test_basic_configuration.py
+++ b/tests/django/toystore/test_basic_configuration.py
@@ -19,9 +19,12 @@ from __future__ import division, print_function, absolute_import
 
 from unittest import TestCase as VanillaTestCase
 
+import pytest
 from django.db import IntegrityError
+from django.test import TestCase as DjangoTestCase
 
 from hypothesis import HealthCheck, given, settings
+from hypothesis.errors import InvalidArgument
 from hypothesis.strategies import integers
 from hypothesis.extra.django import TestCase, TransactionTestCase
 from hypothesis.internal.compat import PYPY
@@ -77,3 +80,14 @@ class TestWorkflow(VanillaTestCase):
         except IntegrityError:
             pass
         t.test_normal_test_1()
+
+    def test_given_needs_hypothesis_test_case(self):
+
+        class LocalTest(DjangoTestCase):
+
+            @given(integers())
+            def tst(self, i):
+                assert False, 'InvalidArgument should be raised in @given'
+
+        with pytest.raises(InvalidArgument):
+            LocalTest('tst').tst()


### PR DESCRIPTION
- [x] Closes #991 - applying `@given` to setUp, tearDown, etc will all be detected and issue a deprecation.
- [x] Closes #1071 - using `subTest` with a test decorated with `@given` now works, via some introspective monkeypatching
- [x] Closes #1113 - easy to check when you have access to the class.

This is implemented via a series of terrible hacks, so I've put the whole thing in `core.py` 😜 