### PR TITLE
Deal with another old-typing-module problem

### DIFF
--- a/tests/py3/test_lookup.py
+++ b/tests/py3/test_lookup.py
@@ -396,3 +396,8 @@ def test_resolving_recursive_type():
     except ResolutionFailed:
         assert sys.version_info[:2] == (3, 5)
         pytest.xfail('python 3.5 typing module may not resolve annotations')
+    except TypeError:
+        # TypeError raised if typing.get_type_hints(Tree.__init__) fails; see
+        # https://github.com/HypothesisWorks/hypothesis-python/issues/1074
+        assert sys.version_info[:2] == (3, 5)
+        pytest.skip('Could not find type hints to resolve')


### PR DESCRIPTION
Closes #1074, which was raising `TypeError` because the type hints went missing before `Tree` was passed to `builds()`, which then failed because required arguments were not provided.  If this happens, we now assert that the test is running on Python 3.5.x (which has a very early provisional typing module), and then skip the test.

I still hate debugging things I can't reproduce locally - I even installed the exact version of Python! - but I suppose reading the code is good for me :roll_eyes: 