### PR TITLE
Change how we track whether a block is shrinking

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This is a small refactoring release that changes how Hypothesis detects when
+the structure of data generation depends on earlier values generated (e.g. when
+using :ref:`flatmap <flatmap>` or :func:`~hypothesis.strategies.composite`).
+It should not have any observable effect on behaviour.

--- a/src/hypothesis/internal/conjecture/data.py
+++ b/src/hypothesis/internal/conjecture/data.py
@@ -76,7 +76,6 @@ class ConjectureData(object):
         self.tags = set()
         self.draw_times = []
         self.__intervals = None
-        self.shrinking_blocks = set()
         self.discarded = []
 
     def __assert_not_frozen(self, name):

--- a/tests/cover/test_conjecture_engine.py
+++ b/tests/cover/test_conjecture_engine.py
@@ -585,15 +585,17 @@ def test_can_shrink_variable_draws_with_just_deletion(n, monkeypatch):
     monkeypatch.setattr(
         Shrinker, 'shrink', Shrinker.interval_deletion_with_block_lowering
     )
+    # Would normally be added by minimize_individual_blocks, but we skip
+    # that phase in this test.
+    monkeypatch.setattr(
+        Shrinker, 'is_shrinking_block', lambda self, i: i == 0
+    )
 
     def gen(self):
         data = ConjectureData.for_buffer(
             [n] + [0] * (n - 1) + [1]
         )
         self.test_function(data)
-        # Would normally be added by minimize_individual_blocks, but we skip
-        # that phase in this test.
-        data.shrinking_blocks.add(0)
 
     monkeypatch.setattr(ConjectureRunner, 'generate_new_examples', gen)
 
@@ -610,13 +612,15 @@ def test_deletion_and_lowering_fails_to_shrink(monkeypatch):
     monkeypatch.setattr(
         Shrinker, 'shrink', Shrinker.interval_deletion_with_block_lowering
     )
+    # Would normally be added by minimize_individual_blocks, but we skip
+    # that phase in this test.
+    monkeypatch.setattr(
+        Shrinker, 'is_shrinking_block', lambda self, i: i == 0
+    )
 
     def gen(self):
         data = ConjectureData.for_buffer(hbytes(10))
         self.test_function(data)
-        # Would normally be added by minimize_individual_blocks, but we skip
-        # that phase in this test.
-        data.shrinking_blocks.add(0)
 
     monkeypatch.setattr(ConjectureRunner, 'generate_new_examples', gen)
 


### PR DESCRIPTION
In the Shrinker we have a notion of whether or not a block is "shrinking": The idea is that if we ever see lowering the block reducing the amount of data drawn next, the block is shrinking. If not, it's not.

So for example if we have:

```python
x = integers(0, 255)

t = tuples(x, x)
l = x.flatmap(lambda n: lists(booleans(), min_size=n, max_size=n))
```

Then no block in drawing t is shrinking (the data size is fixed), but the first block in drawing l is shrinking because it determines how many values are drawn afterwards.

The problem we must face is where we store this information: If we've previously determined that a block is shrinking, and then we change the shrink target, is the block at that position still shrinking? Possibly not.

Previously we stored information about which blocks were shrinking on the `ConjectureData` object and tried to propagate some of the information around when we made changes. This is, to put it politely, an ad hoc hack.

This pull request tries to put this approach on a more principled footing. The idea is this: If we have *ever* seen a shrink target that agrees with this one up to the start of this block and for which this block is marked as shrinking, we want to consider the block to be shrinking.

So what we do is that when we mark a block as shrinking, we record the prefix up to that point, and then when checking if a block is shrinking we check the prefix up to that point.

As an added optimisation we cache the decisions about which blocks are shrinking for the current shrink target. This means that iterating over the block indexes checking whether they're shrinking is only O(n^2) the *first* time. This still isn't ideal but in practice eh it doesn't seem to be too bad it's not like it's the only O(n^2) thing we're doing and this happens after we've pruned the worst of the data.

This pull request shouldn't have any observable effect unless the previous ad hoc implementation was wrong in some way (which it probably was).