### PR TITLE
Move interval calculations into Shrinker and track precise example locations

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This is a small refactoring release that changes how Hypothesis tracks some
+information about the boundary of examples in its internal representation.
+
+You are unlikely to see much difference in behaviour, but memory usage and
+run time may both go down slightly.

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -4,4 +4,5 @@ This is a small refactoring release that changes how Hypothesis tracks some
 information about the boundary of examples in its internal representation.
 
 You are unlikely to see much difference in behaviour, but memory usage and
-run time may both go down slightly.
+run time may both go down slightly during normal test execution, and when
+failing Hypothesis might print its failing example slightly sooner.

--- a/src/hypothesis/internal/conjecture/data.py
+++ b/src/hypothesis/internal/conjecture/data.py
@@ -43,6 +43,10 @@ class Example(object):
     end = attr.ib(default=None)
     discarded = attr.ib(default=None)
 
+    @property
+    def length(self):
+        return self.end - self.start
+
 
 global_test_counter = 0
 

--- a/src/hypothesis/internal/conjecture/data.py
+++ b/src/hypothesis/internal/conjecture/data.py
@@ -20,6 +20,8 @@ from __future__ import division, print_function, absolute_import
 import sys
 from enum import IntEnum
 
+import attr
+
 from hypothesis.errors import Frozen, StopTest, InvalidArgument
 from hypothesis.internal.compat import hbytes, hrange, text_type, \
     bit_length, benchmark_time, int_from_bytes, unicode_safe_repr
@@ -32,6 +34,14 @@ class Status(IntEnum):
     INVALID = 1
     VALID = 2
     INTERESTING = 3
+
+
+@attr.s(slots=True)
+class Example():
+    depth = attr.ib()
+    start = attr.ib()
+    end = attr.ib(default=None)
+    discarded = attr.ib(default=None)
 
 
 global_test_counter = 0
@@ -63,8 +73,6 @@ class ConjectureData(object):
         self.output = u''
         self.status = Status.VALID
         self.frozen = False
-        self.intervals_by_level = []
-        self.interval_stack = []
         global global_test_counter
         self.testcounter = global_test_counter
         global_test_counter += 1
@@ -76,7 +84,10 @@ class ConjectureData(object):
         self.tags = set()
         self.draw_times = []
         self.__intervals = None
-        self.discarded = []
+
+        self.examples = []
+        self.example_stack = []
+        self.has_discards = False
 
     def __assert_not_frozen(self, name):
         if self.frozen:
@@ -89,7 +100,7 @@ class ConjectureData(object):
 
     @property
     def depth(self):
-        return len(self.interval_stack)
+        return self.level
 
     @property
     def index(self):
@@ -145,58 +156,26 @@ class ConjectureData(object):
 
     def start_example(self):
         self.__assert_not_frozen('start_example')
-        self.interval_stack.append(self.index)
         self.level += 1
+        i = len(self.examples)
+        self.examples.append(Example(self.level, self.index))
+        self.example_stack.append(i)
 
     def stop_example(self, discard=False):
         if self.frozen:
             return
         self.level -= 1
-        while self.level >= len(self.intervals_by_level):
-            self.intervals_by_level.append([])
-        k = self.interval_stack.pop()
-        if k != self.index:
-            t = (k, self.index)
-            self.intervals_by_level[self.level].append(t)
-            if discard:
-                while self.discarded:
-                    u, v = t
-                    r, s = self.discarded[-1]
-                    if u <= r <= s <= v:
-                        self.discarded.pop()
-                    else:
-                        assert s <= u
-                        break
-                self.discarded.append(t)
+
+        k = self.example_stack.pop()
+        ex = self.examples[k]
+        ex.end = self.index
+        ex.discarded = discard
+
+        if discard:
+            self.has_discards = True
 
     def note_event(self, event):
         self.events.add(event)
-
-    @property
-    def intervals(self):
-        assert self.frozen
-        if self.__intervals is None:
-            intervals = set(self.blocks)
-            if self.index > 0:
-                intervals.add((0, self.index))
-            for l in self.intervals_by_level:
-                intervals.update(l)
-                for i in hrange(len(l) - 1):
-                    if (
-                        l[i] not in self.discarded and
-                        l[i + 1] not in self.discarded and
-                        l[i][1] == l[i + 1][0]
-                    ):
-                        intervals.add((l[i][0], l[i + 1][1]))
-            for i in hrange(len(self.blocks) - 1):
-                intervals.add((self.blocks[i][0], self.blocks[i + 1][1]))
-            # Intervals are sorted as longest first, then by interval start.
-            self.__intervals = tuple(sorted(
-                set(intervals),
-                key=lambda se: (se[0] - se[1], se[0])
-            ))
-            del self.intervals_by_level
-        return self.__intervals
 
     def freeze(self):
         if self.frozen:

--- a/src/hypothesis/internal/conjecture/data.py
+++ b/src/hypothesis/internal/conjecture/data.py
@@ -189,14 +189,14 @@ class ConjectureData(object):
         if self.frozen:
             assert isinstance(self.buffer, hbytes)
             return
+        while (self.example_stack):
+            self.stop_example()
         self.frozen = True
         self.finish_time = benchmark_time()
 
         self.buffer = hbytes(self.buffer)
         self.events = frozenset(self.events)
         del self._draw_bytes
-        while self.example_stack:
-            self.examples[self.example_stack.pop()].end = self.index
 
     def draw_bits(self, n):
         self.__assert_not_frozen('draw_bits')

--- a/src/hypothesis/internal/conjecture/data.py
+++ b/src/hypothesis/internal/conjecture/data.py
@@ -93,6 +93,8 @@ class ConjectureData(object):
         self.example_stack = []
         self.has_discards = False
 
+        self.start_example()
+
     def __assert_not_frozen(self, name):
         if self.frozen:
             raise Frozen(
@@ -104,7 +106,9 @@ class ConjectureData(object):
 
     @property
     def depth(self):
-        return self.level
+        # We always have a single example wrapping everything. We want to treat
+        # that as depth 0 rather than depth 1.
+        return self.level - 1
 
     @property
     def index(self):
@@ -244,9 +248,11 @@ class ConjectureData(object):
         if n == 0:
             return hbytes(b'')
         self.__check_capacity(n)
+        self.start_example()
         result = self._draw_bytes(self, n)
         assert len(result) == n
         self.__write(result)
+        self.stop_example()
         return hbytes(result)
 
     def mark_interesting(self, interesting_origin=None):

--- a/src/hypothesis/internal/conjecture/data.py
+++ b/src/hypothesis/internal/conjecture/data.py
@@ -37,7 +37,7 @@ class Status(IntEnum):
 
 
 @attr.s(slots=True)
-class Example():
+class Example(object):
     depth = attr.ib()
     start = attr.ib()
     end = attr.ib(default=None)

--- a/src/hypothesis/internal/conjecture/data.py
+++ b/src/hypothesis/internal/conjecture/data.py
@@ -187,6 +187,8 @@ class ConjectureData(object):
         self.buffer = hbytes(self.buffer)
         self.events = frozenset(self.events)
         del self._draw_bytes
+        while self.example_stack:
+            self.examples[self.example_stack.pop()].end = self.index
 
     def draw_bits(self, n):
         self.__assert_not_frozen('draw_bits')

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -1345,8 +1345,7 @@ class Shrinker(object):
         if self.__intervals is None:
             target = self.shrink_target
             intervals = set(target.blocks)
-            if target.index > 0:
-                intervals.add((0, target.index))
+            intervals.add((0, target.index))
             intervals.update(
                 (ex.start, ex.end) for ex in target.examples
                 if ex.start < ex.end

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -1442,16 +1442,23 @@ class Shrinker(object):
 
         """
         i = 0
-        while i < len(self.intervals):
-            u, v = self.intervals[i]
-            for r, s in reversed(self.intervals):
-                if u <= r <= s <= v and s - r < v - u:
+        while i < len(self.shrink_target.examples):
+            ex = self.shrink_target.examples[i]
+            changed = False
+
+            for j in hrange(i + 1, len(self.shrink_target.examples)):
+                child = self.shrink_target.examples[j]
+                if child.start >= ex.end:
+                    break
+                if child.length < ex.length:
                     buf = self.shrink_target.buffer
                     if self.incorporate_new_buffer(
-                        buf[:u] + buf[r:s] + buf[v:]
+                        buf[:ex.start] + buf[child.start:child.end] +
+                        buf[ex.end:]
                     ):
+                        changed = True
                         break
-            else:
+            if not changed:
                 i += 1
 
     def is_shrinking_block(self, i):

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -1406,18 +1406,19 @@ class Shrinker(object):
         i = 0
         while i < len(self.shrink_target.examples):
             ex = self.shrink_target.examples[i]
-            u = ex.start
-            v = ex.end
             buf = self.shrink_target.buffer
-            if any(buf[u:v]):
+            if any(buf[ex.start:ex.end]):
+                prefix = buf[:ex.start]
+                suffix = buf[ex.end:]
                 attempt = self.cached_test_function(
-                    buf[:u] + hbytes(v - u) + buf[v:]
+                    prefix + hbytes(ex.length) + suffix
                 )
                 if attempt.status == Status.VALID:
-                    v2 = attempt.examples[i].end
-                    if v2 < v:
+                    replacement = attempt.examples[i]
+                    assert replacement.start == ex.start
+                    if replacement.length < ex.length:
                         self.incorporate_new_buffer(
-                            buf[:u] + hbytes(v2 - u) + buf[v:]
+                            prefix + hbytes(replacement.length) + suffix
                         )
             i += 1
 

--- a/tests/cover/test_conjecture_engine.py
+++ b/tests/cover/test_conjecture_engine.py
@@ -1090,13 +1090,15 @@ def test_can_zero_subintervals(monkeypatch):
             hbytes([3, 0, 0, 0, 1]) * 10
         ))
 
-    monkeypatch.setattr(Shrinker, 'shrink', fixate(Shrinker.zero_intervals))
+    monkeypatch.setattr(Shrinker, 'shrink', fixate(Shrinker.zero_draws))
 
     @run_to_buffer
     def x(data):
         for _ in hrange(10):
+            data.start_example()
             n = data.draw_bits(8)
             data.draw_bytes(n)
+            data.stop_example()
             if data.draw_bits(8) != 1:
                 return
         data.mark_interesting()

--- a/tests/cover/test_conjecture_test_data.py
+++ b/tests/cover/test_conjecture_test_data.py
@@ -103,7 +103,7 @@ def test_closes_interval_on_error_in_strategy():
     with pytest.raises(ValueError):
         x.draw(BoomStrategy())
     x.freeze()
-    assert len(x.examples) == 1
+    assert not any(eg.end is None for eg in x.examples)
 
 
 class BigStrategy(SearchStrategy):
@@ -117,4 +117,4 @@ def test_does_not_double_freeze_in_interval_close():
     with pytest.raises(StopTest):
         x.draw(BigStrategy())
     assert x.frozen
-    assert len(x.examples) == 1
+    assert not any(eg.end is None for eg in x.examples)

--- a/tests/cover/test_conjecture_test_data.py
+++ b/tests/cover/test_conjecture_test_data.py
@@ -103,7 +103,7 @@ def test_closes_interval_on_error_in_strategy():
     with pytest.raises(ValueError):
         x.draw(BoomStrategy())
     x.freeze()
-    assert len(x.intervals) == 1
+    assert len(x.examples) == 1
 
 
 class BigStrategy(SearchStrategy):
@@ -117,4 +117,4 @@ def test_does_not_double_freeze_in_interval_close():
     with pytest.raises(StopTest):
         x.draw(BigStrategy())
     assert x.frozen
-    assert len(x.intervals) == 0
+    assert len(x.examples) == 1


### PR DESCRIPTION
(In which David takes a break from his wild Friday night of paper editing to implement something the paper made him realise he could do)

The way we store intervals on `ConjectureData` is kinda bad. It's relatively expensive and puts logic that should be in the shrinker in the wrong place.

This changes how we handle that code to instead track a precise list of `start_example/stop_example` boundaries, in order of when `start_example` was called. We can then calculate everything we need off that list in the shrinker as and when we need it.

This has the feature (and also necessity because of how it used intervals) that we can now be more precise in what was previously called `zero_intervals` and is now called `zero_draws` - previously we had a problem caused by the fact that we couldn't tell when an example in the shrunk version was the same as the current one, so we had to try every interval starting at that point. Now we can line up which `start_example` in the replaced version corresponds to the current `start_example` and so instead can just try one extra call.

This follows on from #1077, because some of the machinery I added for that is useful here too.