### PR TITLE
Add guard against exponential time pathology

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This release improves shrinking in a class of pathological examples that you
+are probably never hitting in practice. If you *are* hitting them in practice
+this should be a significant speed up in shrinking. If you are not, you are
+very unlikely to notice any difference. You might see a slight slow down and/or
+slightly better falsifying examples.

--- a/tests/quality/test_zig_zagging.py
+++ b/tests/quality/test_zig_zagging.py
@@ -1,0 +1,94 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis, which may be found at
+# https://github.com/HypothesisWorks/hypothesis-python
+#
+# Most of this work is copyright (C) 2013-2018 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# CONTRIBUTING.rst for a full list of people who may hold copyright, and
+# consult the git log if you need to determine who owns an individual
+# contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import hypothesis.strategies as st
+from hypothesis import Verbosity, note, given, assume, example, settings
+from hypothesis.internal.compat import hbytes, int_from_bytes
+from hypothesis.internal.conjecture.data import Status, ConjectureData
+from hypothesis.internal.conjecture.engine import ConjectureRunner
+
+
+@st.composite
+def problem(draw):
+    b = hbytes(draw(st.binary(min_size=1, max_size=8)))
+    m = int_from_bytes(b) * 256
+    assume(m > 0)
+    marker = draw(st.binary(max_size=8))
+    bound = draw(st.integers(0, m - 1))
+    return (b, marker, bound)
+
+
+@example((b'\x01\x00', b'', 20048))
+@example((b'\x02', b'', 258))
+@example((b'\x08', b'', 1792))
+@example((b'\x0c', b'', 0))
+@example((b'\x01', b'', 1))
+@example((b'\x01', b'', 0))
+@settings(
+    deadline=None, perform_health_check=False, max_examples=10,
+    max_shrinks=100
+)
+@given(problem())
+def test_avoids_zig_zag_trap(p):
+    b, marker, lower_bound = p
+
+    n_bits = 8 * (len(b) + 1)
+
+    def test_function(data):
+        m = data.draw_bits(n_bits)
+        if m < lower_bound:
+            data.mark_invalid()
+        n = data.draw_bits(n_bits)
+        if data.draw_bytes(len(marker)) != marker:
+            data.mark_invalid()
+        if abs(m - n) == 1:
+            data.mark_interesting()
+
+    runner = ConjectureRunner(
+        test_function, database_key=None, settings=settings(
+            database=None, max_shrinks=100, verbosity=Verbosity.debug
+        )
+    )
+
+    runner.debug = note
+    original_debug_data = runner.debug_data
+
+    def debug_interesting(data):
+        if data.status == Status.INTERESTING:
+            original_debug_data(data)
+    runner.debug_data = debug_interesting
+
+    runner.test_function(ConjectureData.for_buffer(
+        b + hbytes([0]) + b + hbytes([1]) + marker))
+
+    assert runner.interesting_examples
+
+    runner.run()
+
+    v, = runner.interesting_examples.values()
+
+    data = ConjectureData.for_buffer(v.buffer)
+
+    m = data.draw_bits(n_bits)
+    n = data.draw_bits(n_bits)
+    assert m == lower_bound
+    if m == 0:
+        assert n == 1
+    else:
+        assert n == m - 1


### PR DESCRIPTION
Bad news: Hypothesis's shrinking is sometimes `O(16^n)`.
Good news: Here's a fix for that!
Bad news: This problem is intrinsic to the problem of test-case reduction and there's no escape. All is lost. We are doomed to live in exponential land forever.

(This isn't really a problem in practice because `max_shrinks` saves us, but I thought I'd spend some time figuring out how to deal with the common case and it turns out that the common case is easy to deal with).

Anyway, we can detect and fix some of the common cases as follows:

* we keep track of which bytes have changed since we last managed to reduce the size of the byte stream and as the last stage of the shrink process we try to lexically minimize them all together.
* we beef up the way the lexical minimizer makes changes to multiple bytes at a time so it doesn't just get stuck in the same pickle.

Important note: The lexical minimizer now has quadatic complexity in the size of its input. This mostly doesn't matter because the two cases where it gets used:

* n=16 is unusually big
* we're in this case where we're trying to avoid an exponential slow down, so in comparison quadratic is super fast.

I do want to emphasise though that we are *intrinsically doomed* here. There is no non-exponential shrink algorithm that also produces good results. Something like the [adversarially slow shrinker example we have in our test suite](https://github.com/HypothesisWorks/hypothesis-python/blob/master/tests/common/strategies.py#L36) will for all intents and purposes always allow us force exponential slow downs.

So given that this PR is of somewhat questionable validity. My main arguments in favour of it are:

1. This category of examples isn't a totally unreasonable one to optimise for and the changes that required probably help in other circumstances too (e.g. if you have size constraints among some objects)
2. The strategy of "Oops we're failing to shrink the size, lets make this the lexicographic minimizer's problem!" is a fully general approach that allows us to tweak the lexicographic minimizer independently of the main shrinker, which I think is probably the correct thing to do for this sort of issue.