### PR TITLE
Improve dependency version constraints for enum34, django extra

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,9 @@
+RELEASE_TYPE: patch
+
+This release fixes dependency information when installing Hypothesis
+from a binary "wheel" distribution.
+
+- The ``install_requires`` for :pypi:`enum34` is resolved at install
+  time, rather than at build time (with potentially different results).
+- Django has fixed their ``python_requires`` for versions 2.0.0 onward,
+  simplifying Python2-compatible constraints for downstream projects.


### PR DESCRIPTION
In #1008, we had to add some maximum version constraints to Django - at the time, it had not set the `python_requires` tag and `pip install django` therefore failed on Python 2.  Since django/django#9413 has been released and the PyPI admins have fixed this on earlier versions, we can ditch the upper version constraint as for all our other dependencies.

While fixing this, I found [this article on conditional dependencies](https://hynek.me/articles/conditional-python-dependencies/), which pointed out that our handling of `enum34` was broken for binary wheels.  I therefore fixed this too - you now need a newish (~8 months old) version of setuptools to build a Hypothesis dist without emitting the new warning, but can install it with very old pips.