### PR TITLE
rename target arg so we can use targets requiring an argument 'target'

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -171,6 +171,7 @@ their individual contributions.
 * `Cory Benfield <https://www.github.com/Lukasa>`_
 * `Cristi Cobzarenco <https://github.com/cristicbz>`_ (cristi@reinfer.io)
 * `David Bonner <https://github.com/rascalking>`_ (dbonner@gmail.com)
+* `David Chudzicki <https://github.com/dchudz>`_ (dchudz@gmail.com)
 * `Derek Gustafson <https://www.github.com/degustaf>`_
 * `Dion Misic <https://www.github.com/kingdion>`_ (dion.misic@gmail.com)
 * `Florian Bruhin <https://www.github.com/The-Compiler>`_

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,6 +1,6 @@
 RELEASE_TYPE: patch
 
-This release fixes :func:`~hypothesis.strategies.builds` so that ``target`` 
+This release fixes :func:`~hypothesis.strategies.builds` so that ``target``
 can be used as a keyword argument for passing values to the target. The target
 itself can still be specified as a keyword argument, but that behavior is now
 deprecated. The target should be provided as the first positional argument.

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,4 +1,4 @@
-RELEASE_TYPE: patch
+RELEASE_TYPE: minor
 
 This release fixes :func:`~hypothesis.strategies.builds` so that ``target``
 can be used as a keyword argument for passing values to the target. The target

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This release fixes :func:`builds(callable) <hypothesis.strategies.builds>` so that ``target`` can be used as a keyword argument for passing values to the target. The target itself can still be specified as a keyword argument, but that behavior is now deprecated. The target should be provided as the first positional argument.

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,3 +1,6 @@
 RELEASE_TYPE: patch
 
-This release fixes :func:`builds(callable) <hypothesis.strategies.builds>` so that ``target`` can be used as a keyword argument for passing values to the target. The target itself can still be specified as a keyword argument, but that behavior is now deprecated. The target should be provided as the first positional argument.
+This release fixes :func:`~hypothesis.strategies.builds` so that ``target`` 
+can be used as a keyword argument for passing values to the target. The target
+itself can still be specified as a keyword argument, but that behavior is now
+deprecated. The target should be provided as the first positional argument.

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -955,24 +955,24 @@ def builds(*target_and_args, **kwargs):
     if target_and_args:
         target, args = target_and_args
         if not callable(target):
-            raise InvalidArgument('The first positional argument to `builds()` must be a callable'
+            raise InvalidArgument('The first positional argument to builds() must be a callable'
                                   'target to construct.')
     elif 'target' in kwargs:
         args = []
-        note_deprecation('Specifying the target as a keyword argument to `builds()` is deprecated. '
+        note_deprecation('Specifying the target as a keyword argument to builds() is deprecated. '
                          'Provide it as the first positional argument instead.')
         target = kwargs.pop('target')
     else:
-       raise InvalidArgument('No target was provided to `builds()`.'
+       raise InvalidArgument('No target was provided to builds().'
                              'Specify it as the first positional argument.')
 
     if target is None:
         try:
             target = kwargs.pop('target')
         except KeyError:
-            raise TypeError('`builds()` must receive an argument for the target we are '
-                            'building, either as the `hypothesis_internal_target` argument or'
-                            ' (deprecated) the `target` keyword argument')
+            raise TypeError('builds() must receive an argument for the target we are '
+                            'building, either as the hypothesis_internal_target argument or'
+                            ' (deprecated) the target keyword argument')
 
     if infer in args:
         # Avoid an implementation nightmare juggling tuples and worse things

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -966,14 +966,6 @@ def builds(*target_and_args, **kwargs):
        raise InvalidArgument('No target was provided to builds().'
                              'Specify it as the first positional argument.')
 
-    if target is None:
-        try:
-            target = kwargs.pop('target')
-        except KeyError:
-            raise TypeError('builds() must receive an argument for the target we are '
-                            'building, either as the the first positional argument or'
-                            ' (deprecated) the target keyword argument')
-
     if infer in args:
         # Avoid an implementation nightmare juggling tuples and worse things
         raise InvalidArgument('infer was passed as a positional argument to '

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -953,7 +953,7 @@ def builds(*target_and_args, **kwargs):
 
     """
     if target_and_args:
-        target, *args = target_and_args
+        target, args = target_and_args
         if not callable(target):
             raise InvalidArgument('The first positional argument to `builds()` must be a callable'
                                   'target to construct.')

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -117,13 +117,16 @@ def cacheable(fn):
 
 
 def base_defines_strategy(force_reusable):
-    """Returns a decorator for strategy functions. If force_reusable is True, the generated
-    values are assumed to be reusable, i.e. immutable and safe to cache, across multiple test
+    """Returns a decorator for strategy functions.
+
+    If force_reusable is True, the generated values are assumed to be
+    reusable, i.e. immutable and safe to cache, across multiple test
     invocations.
 
     """
     def decorator(strategy_definition):
-        """A decorator that registers the function as a strategy and makes it lazily evaluated."""
+        """A decorator that registers the function as a strategy and makes it
+        lazily evaluated."""
         from hypothesis.searchstrategy.lazy import LazyStrategy
         _strategies.add(strategy_definition.__name__)
 
@@ -963,8 +966,8 @@ def builds(*target_and_args, **kwargs):
                          'Provide it as the first positional argument instead.')
         target = kwargs.pop('target')
     else:
-       raise InvalidArgument('No target was provided to builds().'
-                             'Specify it as the first positional argument.')
+        raise InvalidArgument('No target was provided to builds().'
+                              'Specify it as the first positional argument.')
 
     if infer in args:
         # Avoid an implementation nightmare juggling tuples and worse things

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -936,8 +936,8 @@ def random_module():
 @defines_strategy
 def builds(*target_and_args, **kwargs):
     """Generates values by drawing from ``args`` and ``kwargs`` and passing
-    them to ``hypothesis_internal_target`` in the appropriate argument
-    position.
+    them to the target (provided as the first positional argument) in the
+    appropriate argument position.
 
     e.g. ``builds(target, integers(), flag=booleans())`` would draw an
     integer ``i`` and a boolean ``b`` and call ``target(i, flag=b)``.
@@ -971,7 +971,7 @@ def builds(*target_and_args, **kwargs):
             target = kwargs.pop('target')
         except KeyError:
             raise TypeError('builds() must receive an argument for the target we are '
-                            'building, either as the hypothesis_internal_target argument or'
+                            'building, either as the the first positional argument or'
                             ' (deprecated) the target keyword argument')
 
     if infer in args:

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -970,7 +970,7 @@ def builds(*callable_and_args, **kwargs):
     else:
         raise InvalidArgument(
             'builds() must be passed a callable as the first positional '
-            'argument, but no positional argument was given.')
+            'argument, but no positional arguments were given.')
 
     if infer in args:
         # Avoid an implementation nightmare juggling tuples and worse things

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -953,7 +953,7 @@ def builds(*target_and_args, **kwargs):
 
     """
     if target_and_args:
-        target, args = target_and_args
+        target, args = target_and_args[0], target_and_args[1:]
         if not callable(target):
             raise InvalidArgument('The first positional argument to builds() must be a callable'
                                   'target to construct.')

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -117,7 +117,13 @@ def cacheable(fn):
 
 
 def base_defines_strategy(force_reusable):
+    """Returns a decorator for strategy functions. If force_reusable is True, the generated
+    values are assumed to be reusable, i.e. immutable and safe to cache, across multiple test
+    invocations.
+
+    """
     def decorator(strategy_definition):
+        """A decorator that registers the function as a strategy and makes it lazily evaluated."""
         from hypothesis.searchstrategy.lazy import LazyStrategy
         _strategies.add(strategy_definition.__name__)
 
@@ -192,7 +198,7 @@ def just(value):
     return JustStrategy(value)
 
 
-@defines_strategy
+@defines_strategy_with_reusable_values
 def none():
     """Return a strategy which only generates None.
 

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -937,7 +937,7 @@ def random_module():
 
 @cacheable
 @defines_strategy
-def builds(*target_and_args, **kwargs):
+def builds(*callable_and_args, **kwargs):
     """Generates values by drawing from ``args`` and ``kwargs`` and passing
     them to the callable (provided as the first positional argument) in the
     appropriate argument position.
@@ -955,8 +955,8 @@ def builds(*target_and_args, **kwargs):
     the callable.
 
     """
-    if target_and_args:
-        target, args = target_and_args[0], target_and_args[1:]
+    if callable_and_args:
+        target, args = callable_and_args[0], callable_and_args[1:]
         if not callable(target):
             raise InvalidArgument(
                 'The first positional argument to builds() must be a callable '

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -939,42 +939,44 @@ def random_module():
 @defines_strategy
 def builds(*target_and_args, **kwargs):
     """Generates values by drawing from ``args`` and ``kwargs`` and passing
-    them to the target (provided as the first positional argument) in the
+    them to the callable (provided as the first positional argument) in the
     appropriate argument position.
 
     e.g. ``builds(target, integers(), flag=booleans())`` would draw an
     integer ``i`` and a boolean ``b`` and call ``target(i, flag=b)``.
 
-    If ``target`` has type annotations, they will be used to infer a strategy
+    If the callable has type annotations, they will be used to infer a strategy
     for required arguments that were not passed to builds.  You can also tell
     builds to infer a strategy for an optional argument by passing the special
     value :const:`hypothesis.infer` as a keyword argument to
-    builds, instead of a strategy for that argument to ``target``.
+    builds, instead of a strategy for that argument to the callable.
 
     Examples from this strategy shrink by shrinking the argument values to
-    the target.
+    the callable.
 
     """
     if target_and_args:
         target, args = target_and_args[0], target_and_args[1:]
         if not callable(target):
-            raise InvalidArgument('The first positional argument to builds() must be a callable'
-                                  'target to construct.')
-    elif 'target' in kwargs:
+            raise InvalidArgument(
+                'The first positional argument to builds() must be a callable '
+                'target to construct.')
+    elif 'target' in kwargs and callable(kwargs['target']):
         args = []
-        note_deprecation('Specifying the target as a keyword argument to builds() is deprecated. '
-                         'Provide it as the first positional argument instead.')
+        note_deprecation(
+            'Specifying the target as a keyword argument to builds() is '
+            'deprecated. Provide it as the first positional argument instead.')
         target = kwargs.pop('target')
     else:
-        raise InvalidArgument('No target was provided to builds().'
-                              'Specify it as the first positional argument.')
+        raise InvalidArgument(
+            'builds() must be passed a callable as the first positional '
+            'argument, but no positional argument was given.')
 
     if infer in args:
         # Avoid an implementation nightmare juggling tuples and worse things
         raise InvalidArgument('infer was passed as a positional argument to '
                               'builds(), but is only allowed as a keyword arg')
-    hints = get_type_hints(target.__init__
-                           if isclass(target) else target)
+    hints = get_type_hints(target.__init__ if isclass(target) else target)
     for kw in [k for k, v in kwargs.items() if v is infer]:
         if kw not in hints:
             raise InvalidArgument(

--- a/tests/cover/test_direct_strategies.py
+++ b/tests/cover/test_direct_strategies.py
@@ -20,6 +20,7 @@ from __future__ import division, print_function, absolute_import
 import math
 import decimal
 import fractions
+import collections
 from datetime import date, time, datetime, timedelta
 
 import pytest
@@ -27,6 +28,7 @@ import pytest
 import hypothesis.strategies as ds
 from hypothesis import find, given, settings
 from hypothesis.errors import InvalidArgument
+from tests.common.utils import checks_deprecated_behaviour
 from hypothesis.internal.reflection import nicerepr
 
 
@@ -223,6 +225,29 @@ def test_validates_args(fn, args):
 )
 def test_produces_valid_examples_from_args(fn, args):
     fn(*args).example()
+
+
+def test_build_class_with_target_kwarg():
+    NamedTupleWithTargetField = collections.namedtuple('Something', ['target'])
+    ds.builds(NamedTupleWithTargetField, target=ds.integers())
+
+
+@checks_deprecated_behaviour
+def test_builds_can_specify_target_with_target_kwarg():
+    # wish deprecation warning were issued here:
+    strategy = ds.builds(target=lambda x: x, x=ds.integers())
+
+    # instead we only get the warning here:
+    strategy.example()
+
+
+def test_builds_raises_with_no_target():
+    with pytest.raises(TypeError):
+        # wish TypeError were raised here
+        strategy = ds.builds()
+
+        # instead we only get the ValueError here:
+        strategy.example()
 
 
 def test_tuples_raise_error_on_bad_kwargs():

--- a/tests/cover/test_direct_strategies.py
+++ b/tests/cover/test_direct_strategies.py
@@ -234,20 +234,20 @@ def test_build_class_with_target_kwarg():
 
 @checks_deprecated_behaviour
 def test_builds_can_specify_target_with_target_kwarg():
-    # wish deprecation warning were issued here:
-    strategy = ds.builds(target=lambda x: x, x=ds.integers())
-
-    # instead we only get the warning here:
-    strategy.example()
+    ds.builds(x=ds.integers(), target=lambda x: x).example()
 
 
 def test_builds_raises_with_no_target():
-    with pytest.raises(TypeError):
-        # wish TypeError were raised here
-        strategy = ds.builds()
+    with pytest.raises(InvalidArgument):
+        ds.builds().example()
 
-        # instead we only get the ValueError here:
-        strategy.example()
+
+@pytest.mark.parametrize('non_callable', [1, 'abc', ds.integers()])
+def test_builds_raises_if_passed_search_strategy_as_first_arg(non_callable):
+    # If there are any positional arguments, then the target (which must be callable) must be
+    # specified as the first one.
+    with pytest.raises(InvalidArgument):
+        ds.builds(non_callable, target=lambda x: x).example()
 
 
 def test_tuples_raise_error_on_bad_kwargs():

--- a/tests/cover/test_direct_strategies.py
+++ b/tests/cover/test_direct_strategies.py
@@ -229,7 +229,7 @@ def test_produces_valid_examples_from_args(fn, args):
 
 def test_build_class_with_target_kwarg():
     NamedTupleWithTargetField = collections.namedtuple('Something', ['target'])
-    ds.builds(NamedTupleWithTargetField, target=ds.integers())
+    ds.builds(NamedTupleWithTargetField, target=ds.integers()).example()
 
 
 @checks_deprecated_behaviour
@@ -243,9 +243,15 @@ def test_builds_raises_with_no_target():
 
 
 @pytest.mark.parametrize('non_callable', [1, 'abc', ds.integers()])
-def test_builds_raises_if_passed_search_strategy_as_first_arg(non_callable):
-    # If there are any positional arguments, then the target (which must be callable) must be
-    # specified as the first one.
+def test_builds_raises_if_non_callable_as_target_kwarg(non_callable):
+    with pytest.raises(InvalidArgument):
+        ds.builds(target=non_callable).example()
+
+
+@pytest.mark.parametrize('non_callable', [1, 'abc', ds.integers()])
+def test_builds_raises_if_non_callable_as_first_arg(non_callable):
+    # If there are any positional arguments, then the target (which must be
+    # callable) must be specified as the first one.
     with pytest.raises(InvalidArgument):
         ds.builds(non_callable, target=lambda x: x).example()
 


### PR DESCRIPTION
This is my attempt to address https://github.com/HypothesisWorks/hypothesis-python/issues/1104, following the suggestion in the comment from @DRMacIver on that issue.

But I don't think it's good:

- calling `builds()` with no argument for the target no longer raises `TypeError` (`builds().example()` does), since the new code here isn't actually run when you call `builds()`
- for the same reason, the deprecation warning doesn't show when you first call `builds()`

I'm not thinking of any ways to fix this without adding a bunch of complication (I'd have to mess with `proxies()` and/or `base_defines_strategy()`?).

I'm completely new here, but it seems to me that merging this would make life worse for users and developers.

I figured I'd post it anyway, since (a) maybe I'm wrong about that or (b) I'd love to be pointed in a better direction if anyone has time to set me right.

Or if not, we can just close this and add to the issue: "Don't fix it THAT way!"
