### PR TITLE
fix indentation of docstrings produced by renamed_arguments

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This fixes an indentation issue in docstrings for 
+:func:`~hypothesis.strategies.datetimes`, :func:`~hypothesis.strategies.dates`,  
+:func:`~hypothesis.strategies.times`, and 
+:func:`~hypothesis.strategies.timedeltas`.

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,6 +1,6 @@
 RELEASE_TYPE: patch
 
-This fixes an indentation issue in docstrings for 
-:func:`~hypothesis.strategies.datetimes`, :func:`~hypothesis.strategies.dates`,  
-:func:`~hypothesis.strategies.times`, and 
+This fixes an indentation issue in docstrings for
+:func:`~hypothesis.strategies.datetimes`, :func:`~hypothesis.strategies.dates`,
+:func:`~hypothesis.strategies.times`, and
 :func:`~hypothesis.strategies.timedeltas`.

--- a/src/hypothesis/internal/renaming.py
+++ b/src/hypothesis/internal/renaming.py
@@ -17,13 +17,22 @@
 
 from __future__ import division, print_function, absolute_import
 
+from inspect import cleandoc
+
 from hypothesis._settings import note_deprecation
 from hypothesis.internal.reflection import proxies
 
 
 def renamed_arguments(**rename_mapping):
     """Helper function for deprecating arguments that have been renamed to a
-    new form."""
+    new form.
+
+    Note: There are some issues with this function (see
+    https://github.com/HypothesisWorks/hypothesis-python/issues/1111).
+    It's not too bad for current uses, but shouldn't be used in new
+    places without fixing it up.
+
+    """
     assert len(set(rename_mapping.values())) == len(rename_mapping)
 
     def accept(f):
@@ -48,6 +57,10 @@ def renamed_arguments(**rename_mapping):
         # a docstring is a strong indicator that they're running in this mode,
         # so skip adding this message if that's the case.
         if with_name_check.__doc__ is not None:
+            # Appending to the raw docstring gives the new stuff a
+            # different indentation level and so prevents the later clean step
+            # from working properly. So we clean here first.
+            with_name_check.__doc__ = cleandoc(with_name_check.__doc__)
             with_name_check.__doc__ += '\n'.join((
                 '', '',
                 'The following arguments have been renamed:',

--- a/tests/cover/test_renaming.py
+++ b/tests/cover/test_renaming.py
@@ -17,6 +17,8 @@
 
 from __future__ import division, print_function, absolute_import
 
+import inspect
+
 from tests.common.utils import checks_deprecated_behaviour
 from hypothesis.internal.renaming import renamed_arguments
 
@@ -37,3 +39,17 @@ def test_using_old_args():
     old_arg = 'An order of otters on the Ouse'
     assert f(old_arg=old_arg) == old_arg
     assert f.__doc__ is None
+
+
+@renamed_arguments(old_arg='new_arg')
+def g(new_arg=None, old_arg=None):
+    """Hi.
+
+    Bye
+
+    """
+
+
+def test_docstring():
+    """Make sure the docstring's indentation didn't get messed up."""
+    assert inspect.cleandoc(g.__doc__).startswith('Hi.\n\nBye')


### PR DESCRIPTION
Fixes https://github.com/HypothesisWorks/hypothesis-python/issues/1111 (just item 1, not the rest).

Before:

```
In [1]: from hypothesis.strategies import timedeltas

In [2]: ?timedeltas
Signature: timedeltas(min_value=datetime.timedelta(-999999999), max_value=datetime.timedelta(999999999, 86399, 999999), min_delta=None, max_delta=None)
Docstring:
A strategy for timedeltas between ``min_value`` and ``max_value``.

    Examples from this strategy shrink towards zero.



The following arguments have been renamed:

  * min_delta has been renamed to min_value
  * max_delta has been renamed to max_value

Use of the old names has been deprecated and will be removed
in a future version of Hypothesis.
File:      ~/hypothesis-python/src/hypothesis/strategies.py
Type:      function
```

After:

```
In [1]: from hypothesis.strategies import timedeltas

In [2]: ?timedeltas
Signature: timedeltas(min_value=datetime.timedelta(-999999999), max_value=datetime.timedelta(999999999, 86399, 999999), min_delta=None, max_delta=None)
Docstring:
A strategy for timedeltas between ``min_value`` and ``max_value``.

Examples from this strategy shrink towards zero.

The following arguments have been renamed:

  * min_delta has been renamed to min_value
  * max_delta has been renamed to max_value

Use of the old names has been deprecated and will be removed
in a future version of Hypothesis.
File:      ~/hypothesis-python/src/hypothesis/strategies.py
Type:      function
```

The difference is that `Examples from this strategy shrink towards zero.` is now in the right place.

We also have the corresponding improvement in the docs produced by `make documentation`.