### PR TITLE
Add flake8-docstrings as an additional style lint.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ format: $(PYFORMAT) $(ISORT)
 	$(FILES_TO_FORMAT) | xargs $(PYFORMAT) -i
 
 lint: $(FLAKE8)
-	$(FLAKE8) src tests --exclude=compat.py,test_reflection.py,test_imports.py,tests/py2,test_lambda_formatting.py
+	$(FLAKE8) src tests
 
 
 check-pyup-yml: $(TOOL_VIRTUALENV)

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This release makes our docstring style more consistent, thanks to
+:pypi:`flake8-docstrings`.  There are no user-visible changes.

--- a/requirements/tools.in
+++ b/requirements/tools.in
@@ -1,4 +1,5 @@
 flake8
+flake8-docstrings
 isort
 pip-tools
 pyformat

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -17,6 +17,8 @@ docformatter==0.8         # via pyformat
 docutils==0.14            # via restructuredtext-lint, sphinx
 dparse==0.2.1             # via pyupio, safety
 first==2.0.1              # via pip-tools
+flake8-docstrings==1.3.0
+flake8-polyfill==1.0.2    # via flake8-docstrings
 flake8==3.5.0
 hashin-pyup==0.7.2        # via pyupio
 idna==2.6                 # via requests
@@ -31,6 +33,7 @@ pkginfo==1.4.1            # via twine
 pluggy==0.6.0             # via pytest, tox
 py==1.5.2                 # via pytest, tox
 pycodestyle==2.3.1        # via autopep8, flake8
+pydocstyle==2.1.1         # via flake8-docstrings
 pyflakes==1.6.0           # via autoflake, flake8
 pyformat==0.7
 pygithub==1.36            # via pyupio
@@ -46,8 +49,8 @@ requests-toolbelt==0.8.0  # via twine
 requests==2.18.4          # via python-gitlab, pyupio, requests-toolbelt, safety, sphinx, twine
 restructuredtext-lint==1.1.2
 safety==1.7.0             # via pyupio
-six==1.11.0               # via dparse, packaging, pip-tools, pytest, python-gitlab, pyupio, sphinx, tox
-snowballstemmer==1.2.1    # via sphinx
+six==1.11.0               # via dparse, packaging, pip-tools, pydocstyle, pytest, python-gitlab, pyupio, sphinx, tox
+snowballstemmer==1.2.1    # via pydocstyle, sphinx
 sphinx-rtd-theme==0.2.4
 sphinx==1.7.0
 sphinxcontrib-websupport==1.0.1  # via sphinx

--- a/src/hypothesis/_settings.py
+++ b/src/hypothesis/_settings.py
@@ -110,7 +110,6 @@ class settingsMeta(type):
 
 
 class settings(settingsMeta('settings', (object,), {})):
-
     """A settings object controls a variety of parameters that are used in
     falsification. These may control both the falsification strategy and the
     details of the data that is generated.
@@ -290,11 +289,11 @@ class settings(settingsMeta('settings', (object,), {})):
 
     @staticmethod
     def register_profile(name, settings):
-        """registers a collection of values to be used as a settings profile.
-        These settings can be loaded in by name. Enable different defaults for
-        different settings.
+        """Registers a collection of values to be used as a settings profile.
 
-        - settings is a settings object
+        These settings can be loaded in by name. Enable different
+        defaults for different settings.  ``settings`` must be a
+        settings object.
 
         """
         settings._profiles[name] = settings

--- a/src/hypothesis/control.py
+++ b/src/hypothesis/control.py
@@ -30,8 +30,8 @@ def reject():
 
 
 def assume(condition):
-    """``assume()`` is like an :ref:`assert <python:assert>` that marks the
-    example as bad, rather than failing the test.
+    """Calling ``assume`` is like an :ref:`assert <python:assert>` that marks
+    the example as bad, rather than failing the test.
 
     This allows you to specify properties that you *assume* will be
     true, and let Hypothesis try to avoid similar examples in future.
@@ -123,7 +123,6 @@ def event(value):
     Events should be strings or convertible to them.
 
     """
-
     context = _current_build_context.value
     if context is None:
         raise InvalidArgument(

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -114,7 +114,6 @@ def seed(seed):
     derandomize setting if it is present.
 
     """
-
     def accept(test):
         test._hypothesis_internal_use_seed = seed
         return test

--- a/src/hypothesis/database.py
+++ b/src/hypothesis/database.py
@@ -64,7 +64,7 @@ class ExampleDatabase(EDMeta('ExampleDatabase', (object,), {})):
     """
 
     def save(self, key, value):
-        """save this value under this key.
+        """Save ``value`` under ``key``.
 
         If this value is already present for this key, silently do
         nothing

--- a/src/hypothesis/errors.py
+++ b/src/hypothesis/errors.py
@@ -19,17 +19,14 @@ from __future__ import division, print_function, absolute_import
 
 
 class HypothesisException(Exception):
-
     """Generic parent class for exceptions thrown by Hypothesis."""
 
 
 class CleanupFailed(HypothesisException):
-
     """At least one cleanup task failed and no other exception was raised."""
 
 
 class UnsatisfiedAssumption(HypothesisException):
-
     """An internal error raised by assume.
 
     If you're seeing this error something has gone wrong.
@@ -38,7 +35,6 @@ class UnsatisfiedAssumption(HypothesisException):
 
 
 class BadTemplateDraw(HypothesisException):
-
     """An internal error raised when something unfortunate happened during
     template generation and you should restart the draw, preferably with a new
     parameter.
@@ -50,7 +46,6 @@ class BadTemplateDraw(HypothesisException):
 
 
 class NoSuchExample(HypothesisException):
-
     """The condition we have been asked to satisfy appears to be always false.
 
     This does not guarantee that no example exists, only that we were
@@ -76,14 +71,12 @@ class DefinitelyNoSuchExample(NoSuchExample):  # pragma: no cover
 
 
 class NoExamples(HypothesisException):
-
     """Raised when example() is called on a strategy but we cannot find any
     examples after enough tries that we really should have been able to if this
     was ever going to work."""
 
 
 class Unsatisfiable(HypothesisException):
-
     """We ran out of time or examples before we could find enough examples
     which satisfy the assumptions of this hypothesis.
 
@@ -98,7 +91,6 @@ class Unsatisfiable(HypothesisException):
 
 
 class Flaky(HypothesisException):
-
     """This function appears to fail non-deterministically: We have seen it
     fail when passed this example at least once, but a subsequent invocation
     did not fail.
@@ -117,31 +109,26 @@ class Flaky(HypothesisException):
 
 
 class Timeout(Unsatisfiable):
-
     """We were unable to find enough examples that satisfied the preconditions
     of this hypothesis in the amount of time allotted to us."""
 
 
 class WrongFormat(HypothesisException, ValueError):
-
     """An exception indicating you have attempted to serialize a value that
     does not match the type described by this format."""
 
 
 class BadData(HypothesisException, ValueError):
-
     """The data that we got out of the database does not seem to match the data
     we could have put into the database given this schema."""
 
 
 class InvalidArgument(HypothesisException, TypeError):
-
     """Used to indicate that the arguments to a Hypothesis function were in
     some manner incorrect."""
 
 
 class ResolutionFailed(InvalidArgument):
-
     """Hypothesis had to resolve a type to a strategy, but this failed.
 
     Type inference is best-effort, so this only happens when an
@@ -152,18 +139,15 @@ class ResolutionFailed(InvalidArgument):
 
 
 class InvalidState(HypothesisException):
-
     """The system is not in a state where you were allowed to do that."""
 
 
 class InvalidDefinition(HypothesisException, TypeError):
-
     """Used to indicate that a class definition was not well put together and
     has something wrong with it."""
 
 
 class AbnormalExit(HypothesisException):
-
     """Raised when a test running in a child process exits without returning or
     raising an exception."""
 
@@ -182,7 +166,6 @@ class HypothesisDeprecationWarning(HypothesisException, FutureWarning):
 
 
 class Frozen(HypothesisException):
-
     """Raised when a mutation method has been called on a ConjectureData object
     after freeze() has been called."""
 

--- a/src/hypothesis/extra/django/models.py
+++ b/src/hypothesis/extra/django/models.py
@@ -92,7 +92,6 @@ default_value = UniqueIdentifier(u'default_value')
 def validator_to_filter(f):
     """Converts the field run_validators method to something suitable for use
     in filter."""
-
     def validate(value):
         try:
             f.run_validators(value)

--- a/src/hypothesis/extra/pandas/impl.py
+++ b/src/hypothesis/extra/pandas/impl.py
@@ -433,7 +433,6 @@ def data_frames(
       InvalidArgument being raised.
 
     """
-
     if index is None:
         index = range_indexes()
     else:

--- a/src/hypothesis/internal/cache.py
+++ b/src/hypothesis/internal/cache.py
@@ -49,6 +49,7 @@ class GenericCache(object):
     on_access and on_evict to implement a specific scoring strategy.
 
     """
+
     __slots__ = ('keys_to_indices', 'data', 'max_size')
 
     def __init__(self, max_size):
@@ -141,7 +142,6 @@ class GenericCache(object):
         is working correctly this should be an expensive no-op.
 
         """
-
         for i, e in enumerate(self.data):
             assert self.keys_to_indices[e.key] == i
             for j in [i * 2 + 1, i * 2 + 2]:
@@ -160,7 +160,6 @@ class GenericCache(object):
         the heap property has been violated locally around i but previously
         held for all other indexes (and no other values have been modified),
         this fixes the heap so that the heap property holds everywhere."""
-
         while i > 0:
             parent = (i - 1) // 2
             if self.__out_of_order(parent, i):
@@ -189,7 +188,6 @@ class GenericCache(object):
         i must be the parent of j.
 
         """
-
         assert i == (j - 1) // 2
         return self.data[j].score < self.data[i].score
 
@@ -209,6 +207,7 @@ class LRUReusedCache(GenericCache):
     entries in preference for the new ones.
 
     """
+
     __slots__ = ('__tick',)
 
     def __init__(self, max_size, ):

--- a/src/hypothesis/internal/conjecture/engine.py
+++ b/src/hypothesis/internal/conjecture/engine.py
@@ -973,6 +973,7 @@ class SampleSet(object):
     the index for efficient lookup to add and remove values.
 
     """
+
     __slots__ = ('__values', '__index')
 
     def __init__(self):
@@ -1290,7 +1291,6 @@ class Shrinker(object):
         it twice will have exactly the same effect as calling it once.
 
         """
-
         run_expensive_shrinks = False
 
         prev = None
@@ -1663,7 +1663,6 @@ class Shrinker(object):
         block to be lowered.
 
         """
-
         initial_attempt = bytearray(self.shrink_target.buffer)
         for i in blocks:
             if i >= len(self.blocks):
@@ -1867,7 +1866,6 @@ class Shrinker(object):
         more values at once.
 
         """
-
         self.debug('Simultaneous shrinking of duplicated blocks')
 
         def canon(b):
@@ -2012,7 +2010,6 @@ class Shrinker(object):
         been.
 
         """
-
         self.debug('Lowering blocks while deleting intervals')
         i = 0
         while i < len(self.intervals):
@@ -2118,7 +2115,6 @@ class Shrinker(object):
         out of order pairs before we get to that stage.
 
         """
-
         free_bytes = []
 
         for i, (u, v) in enumerate(self.blocks):

--- a/src/hypothesis/internal/conjecture/minimizer.py
+++ b/src/hypothesis/internal/conjecture/minimizer.py
@@ -151,7 +151,6 @@ class Minimizer(object):
         of floating at low cost in runtime and only moderate cost in elegance.
 
         """
-
         # If the block is of the wrong size then we're certainly not using the
         # float encoding.
         if self.size != 8:

--- a/src/hypothesis/internal/conjecture/utils.py
+++ b/src/hypothesis/internal/conjecture/utils.py
@@ -378,7 +378,7 @@ class many(object):
 
     def reject(self):
         """Reject the last example (i.e. don't count it towards our budget of
-        elements because it's not going to go in the final collection)"""
+        elements because it's not going to go in the final collection)."""
         assert self.count > 0
         self.count -= 1
         self.rejections += 1

--- a/src/hypothesis/internal/reflection.py
+++ b/src/hypothesis/internal/reflection.py
@@ -38,7 +38,7 @@ from hypothesis.internal.compat import ARG_NAME_ATTRIBUTE, hrange, \
 
 
 def fully_qualified_name(f):
-    """Returns a unique identifier for f pointing to the module it was define
+    """Returns a unique identifier for f pointing to the module it was defined
     on, and an containing functions."""
     if f.__module__ is not None:
         return f.__module__ + '.' + qualname(f)

--- a/src/hypothesis/searchstrategy/collections.py
+++ b/src/hypothesis/searchstrategy/collections.py
@@ -25,7 +25,6 @@ from hypothesis.searchstrategy.strategies import SearchStrategy, \
 
 
 class TupleStrategy(SearchStrategy):
-
     """A strategy responsible for fixed length tuples based on heterogenous
     strategies for each of their elements."""
 
@@ -72,7 +71,6 @@ TERMINATOR = hbytes(b'\0')
 
 
 class ListStrategy(SearchStrategy):
-
     """A strategy for lists which takes an intended average length and a
     strategy for each of its element types and generates lists containing any
     of those element types.
@@ -192,12 +190,11 @@ class UniqueListStrategy(SearchStrategy):
 
 
 class FixedKeysDictStrategy(MappedSearchStrategy):
-
     """A strategy which produces dicts with a fixed set of keys, given a
     strategy for each of their equivalent values.
 
-    e.g. {'foo' : some_int_strategy} would
-    generate dicts with the single key 'foo' mapping to some integer.
+    e.g. {'foo' : some_int_strategy} would generate dicts with the single
+    key 'foo' mapping to some integer.
 
     """
 

--- a/src/hypothesis/searchstrategy/deferred.py
+++ b/src/hypothesis/searchstrategy/deferred.py
@@ -25,7 +25,6 @@ from hypothesis.searchstrategy.strategies import SearchStrategy
 
 
 class DeferredStrategy(SearchStrategy):
-
     """A strategy which may be used before it is fully defined."""
 
     def __init__(self, definition):
@@ -66,7 +65,7 @@ class DeferredStrategy(SearchStrategy):
         return self.wrapped_strategy.supports_find
 
     def calc_label(self):
-        """deferred strategies don't have a calculated label, because we would
+        """Deferred strategies don't have a calculated label, because we would
         end up having to calculate the fixed point of some hash function in
         order to calculate it when they recursively refer to themself!
 
@@ -74,7 +73,6 @@ class DeferredStrategy(SearchStrategy):
         will be passed to draw.
 
         """
-
         # This is actually the same as the parent class implementation, but we
         # include it explicitly here in order to document that this is a
         # deliberate decision.

--- a/src/hypothesis/searchstrategy/lazy.py
+++ b/src/hypothesis/searchstrategy/lazy.py
@@ -64,7 +64,6 @@ def unwrap_strategies(s):
 
 
 class LazyStrategy(SearchStrategy):
-
     """A strategy which is defined purely by conversion to and from another
     strategy.
 

--- a/src/hypothesis/searchstrategy/misc.py
+++ b/src/hypothesis/searchstrategy/misc.py
@@ -24,7 +24,6 @@ from hypothesis.searchstrategy.strategies import SearchStrategy, \
 
 
 class BoolStrategy(SearchStrategy):
-
     """A strategy that produces Booleans with a Bernoulli conditional
     distribution."""
 
@@ -47,9 +46,7 @@ def is_simple_data(value):
 
 
 class JustStrategy(SearchStrategy):
-
-    """A strategy which simply returns a single fixed value with probability
-    1."""
+    """A strategy which always returns a single fixed value."""
 
     def __init__(self, value):
         SearchStrategy.__init__(self)
@@ -69,7 +66,6 @@ class JustStrategy(SearchStrategy):
 
 
 class RandomStrategy(MappedSearchStrategy):
-
     """A strategy which produces Random objects.
 
     The conditional distribution is simply a RandomWithSeed seeded with
@@ -82,7 +78,6 @@ class RandomStrategy(MappedSearchStrategy):
 
 
 class SampledFromStrategy(SearchStrategy):
-
     """A strategy which samples from a set of elements. This is essentially
     equivalent to using a OneOfStrategy over Just strategies but may be more
     efficient and convenient.

--- a/src/hypothesis/searchstrategy/numbers.py
+++ b/src/hypothesis/searchstrategy/numbers.py
@@ -28,7 +28,6 @@ from hypothesis.searchstrategy.strategies import SearchStrategy, \
 
 
 class IntStrategy(SearchStrategy):
-
     """A generic strategy for integer types that provides the basic methods
     other than produce.
 
@@ -74,7 +73,6 @@ class WideRangeIntStrategy(IntStrategy):
 
 
 class BoundedIntStrategy(SearchStrategy):
-
     """A strategy for providing integers in some interval with inclusive
     endpoints."""
 
@@ -102,7 +100,6 @@ NASTY_FLOATS.extend([-x for x in NASTY_FLOATS])
 
 
 class FloatStrategy(SearchStrategy):
-
     """Generic superclass for strategies which produce floats."""
 
     def __init__(self, allow_infinity, allow_nan):
@@ -148,7 +145,6 @@ def float_order_key(k):
 
 
 class FixedBoundedFloatStrategy(SearchStrategy):
-
     """A strategy for floats distributed between two endpoints.
 
     The conditional distribution tries to produce values clustered
@@ -189,7 +185,6 @@ class FixedBoundedFloatStrategy(SearchStrategy):
 
 
 class ComplexStrategy(MappedSearchStrategy):
-
     """A strategy over complex numbers, with real and imaginary values
     distributed according to some provided strategy for floating point
     numbers."""

--- a/src/hypothesis/searchstrategy/strategies.py
+++ b/src/hypothesis/searchstrategy/strategies.py
@@ -60,7 +60,6 @@ def one_of_strategies(xs):
 
 
 class SearchStrategy(object):
-
     """A SearchStrategy is an object that knows how to explore data of a given
     type.
 
@@ -421,7 +420,6 @@ class SearchStrategy(object):
 
 
 class OneOfStrategy(SearchStrategy):
-
     """Implements a union of strategies. Given a number of strategies this
     generates values which could have come from any of them.
 
@@ -526,7 +524,6 @@ class OneOfStrategy(SearchStrategy):
 
 
 class MappedSearchStrategy(SearchStrategy):
-
     """A strategy which is defined purely by conversion to and from another
     strategy.
 

--- a/src/hypothesis/searchstrategy/strings.py
+++ b/src/hypothesis/searchstrategy/strings.py
@@ -27,8 +27,8 @@ from hypothesis.searchstrategy.strategies import SearchStrategy, \
 
 
 class OneCharStringStrategy(SearchStrategy):
-
     """A strategy which generates single character strings of text type."""
+
     specifier = text_type
     zero_point = ord('0')
 
@@ -67,7 +67,6 @@ class OneCharStringStrategy(SearchStrategy):
 
 
 class StringStrategy(MappedSearchStrategy):
-
     """A strategy for text strings, defined in terms of a strategy for lists of
     single character text strings."""
 
@@ -84,7 +83,6 @@ class StringStrategy(MappedSearchStrategy):
 
 
 class BinaryStringStrategy(MappedSearchStrategy):
-
     """A strategy for strings of bytes, defined in terms of a strategy for
     lists of bytes."""
 

--- a/src/hypothesis/stateful.py
+++ b/src/hypothesis/stateful.py
@@ -116,7 +116,6 @@ def run_state_machine_as_test(state_machine_factory, settings=None):
 
 
 class GenericStateMachine(object):
-
     """A GenericStateMachine is the basic entry point into Hypothesis's
     approach to stateful testing.
 
@@ -211,7 +210,6 @@ GenericStateMachine.find_breaking_runner = classmethod(find_breaking_runner)
 
 
 class StateMachineRunner(object):
-
     """A StateMachineRunner is a description of how to run a state machine.
 
     It contains values that it will use to shape the examples.
@@ -430,7 +428,6 @@ class ShuffleBundle(object):
 
 
 class RuleBasedStateMachine(GenericStateMachine):
-
     """A RuleBasedStateMachine gives you a more structured way to define state
     machines.
 
@@ -441,6 +438,7 @@ class RuleBasedStateMachine(GenericStateMachine):
     executed.
 
     """
+
     _rules_per_class = {}
     _invariants_per_class = {}
     _base_rules_per_class = {}

--- a/src/hypothesis/types.py
+++ b/src/hypothesis/types.py
@@ -25,7 +25,6 @@ from hypothesis.errors import InvalidArgument
 
 
 class RandomWithSeed(Random):
-
     """A subclass of Random designed to expose the seed it was initially
     provided with.
 
@@ -51,7 +50,6 @@ class RandomWithSeed(Random):
 
 
 class Stream(object):
-
     """A stream is a possibly infinite list. You can index into it, and you can
     iterate over it, but you can't ask its length and iterating over it will
     not necessarily terminate.

--- a/tests/cover/test_conjecture_engine.py
+++ b/tests/cover/test_conjecture_engine.py
@@ -1150,7 +1150,6 @@ def test_can_handle_size_changing_in_reordering_with_unsortable_bits(
 ):
     """Forces the reordering to pass to run its quadratic comparison of every
     pair and changes the size during that pass."""
-
     monkeypatch.setattr(
         Shrinker, 'shrink', Shrinker.reorder_bytes)
     monkeypatch.setattr(

--- a/tests/cover/test_skipping.py
+++ b/tests/cover/test_skipping.py
@@ -32,7 +32,6 @@ def test_no_falsifying_example_if_unittest_skip(skip_exception):
     """If a ``SkipTest`` exception is raised during a test, Hypothesis should
     not continue running the test and shrink process, nor should it print
     anything about falsifying examples."""
-
     class DemoTest(unittest.TestCase):
 
         @given(xs=integers())

--- a/tests/pandas/helpers.py
+++ b/tests/pandas/helpers.py
@@ -28,7 +28,6 @@ PANDAS_TIME_DTYPES = tuple(map(np.dtype, [
 def supported_by_pandas(dtype):
     """Checks whether the dtype is one that can be correctly handled by
     Pandas."""
-
     # Pandas only supports a limited range of timedelta and datetime dtypes
     # compared to the full range that numpy supports and will convert
     # everything to those types (possibly increasing precision in the course of

--- a/tox.ini
+++ b/tox.ini
@@ -200,7 +200,9 @@ addopts=--strict --tb=native -p pytester --runpytest=subprocess --durations=20 -
 [flake8]
 exclude =
     compat.py,
+    src/hypothesis/vendor/,
     test_reflection.py,
     test_imports.py,
     tests/py2,
     test_lambda_formatting.py
+ignore = D1,D205,D209,D213,D400,D401,D999

--- a/tox.ini
+++ b/tox.ini
@@ -196,3 +196,11 @@ commands=
 
 [pytest]
 addopts=--strict --tb=native -p pytester --runpytest=subprocess --durations=20 -n 2
+
+[flake8]
+exclude =
+    compat.py,
+    test_reflection.py,
+    test_imports.py,
+    tests/py2,
+    test_lambda_formatting.py


### PR DESCRIPTION
You can see the list of possible errors [here](http://www.pydocstyle.org/en/stable/error_codes.html); but in short this ensures that we have consistent indentation, use and placement of newlines, and capitalization.

Checks also exist (but have been disabled) for presence of a docstring on all public classes and functions, single-line summaries, and trailing quotes on a new line - these might be nice, but I'm not going to add it all in this pull.

Closes #1088.