### PR TITLE
give every Example a label

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This is an internal change to give every ``Example`` object a label. It should
+have very minimal user-visible effects.

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,4 +1,3 @@
 RELEASE_TYPE: patch
 
-This is an internal change to give every ``Example`` object a label. It should
-have very minimal user-visible effects.
+This patch may improve example shrinking slightly for some strategies.

--- a/src/hypothesis/internal/conjecture/data.py
+++ b/src/hypothesis/internal/conjecture/data.py
@@ -27,6 +27,7 @@ from hypothesis.internal.compat import hbytes, hrange, text_type, \
     bit_length, benchmark_time, int_from_bytes, unicode_safe_repr
 from hypothesis.internal.coverage import IN_COVERAGE_TESTS
 from hypothesis.internal.escalation import mark_for_escalation
+from hypothesis.internal.conjecture.utils import calc_label_from_name
 
 
 class Status(IntEnum):
@@ -111,7 +112,7 @@ class ConjectureData(object):
         self.example_stack = []
         self.has_discards = False
 
-        self.start_example()
+        self.start_example(calc_label_from_name('top'))
 
     def __assert_not_frozen(self, name):
         if self.frozen:
@@ -182,7 +183,7 @@ class ConjectureData(object):
             if not self.frozen:
                 self.stop_example()
 
-    def start_example(self, label=None):
+    def start_example(self, label):
         self.__assert_not_frozen('start_example')
         self.level += 1
         i = len(self.examples)
@@ -229,8 +230,7 @@ class ConjectureData(object):
                 if ex.discarded:
                     discards.append((ex.start, ex.end))
                     continue
-                if ex.label is not None:
-                    self.tags.add(structural_tag(ex.label))
+                self.tags.add(structural_tag(ex.label))
 
         self.buffer = hbytes(self.buffer)
         self.events = frozenset(self.events)
@@ -286,7 +286,8 @@ class ConjectureData(object):
         if n == 0:
             return hbytes(b'')
         self.__check_capacity(n)
-        self.start_example()
+        self.start_example(calc_label_from_name(
+            'draw_bytes() in ConjectureData'))
         result = self._draw_bytes(self, n)
         assert len(result) == n
         self.__write(result)

--- a/src/hypothesis/internal/conjecture/data.py
+++ b/src/hypothesis/internal/conjecture/data.py
@@ -29,6 +29,9 @@ from hypothesis.internal.coverage import IN_COVERAGE_TESTS
 from hypothesis.internal.escalation import mark_for_escalation
 from hypothesis.internal.conjecture.utils import calc_label_from_name
 
+TOP_LABEL = calc_label_from_name('top')
+DRAW_BYTES_LABEL = calc_label_from_name('draw_bytes() in ConjectureData')
+
 
 class Status(IntEnum):
     OVERRUN = 0
@@ -112,7 +115,7 @@ class ConjectureData(object):
         self.example_stack = []
         self.has_discards = False
 
-        self.start_example(calc_label_from_name('top'))
+        self.start_example(TOP_LABEL)
 
     def __assert_not_frozen(self, name):
         if self.frozen:
@@ -286,8 +289,7 @@ class ConjectureData(object):
         if n == 0:
             return hbytes(b'')
         self.__check_capacity(n)
-        self.start_example(calc_label_from_name(
-            'draw_bytes() in ConjectureData'))
+        self.start_example(DRAW_BYTES_LABEL)
         result = self._draw_bytes(self, n)
         assert len(result) == n
         self.__write(result)

--- a/src/hypothesis/internal/conjecture/floats.py
+++ b/src/hypothesis/internal/conjecture/floats.py
@@ -21,6 +21,7 @@ from array import array
 
 from hypothesis.internal.compat import hbytes, hrange, int_to_bytes
 from hypothesis.internal.floats import float_to_int, int_to_float
+from hypothesis.internal.conjecture.utils import calc_label_from_name
 
 """
 This module implements support for arbitrary floating point numbers in
@@ -231,7 +232,7 @@ def is_simple(f):
 
 def draw_float(data):
     try:
-        data.start_example()
+        data.start_example(calc_label_from_name('drawing a float'))
         f = lex_to_float(data.draw_bits(64))
         if data.draw_bits(1):
             f = -f

--- a/src/hypothesis/internal/conjecture/floats.py
+++ b/src/hypothesis/internal/conjecture/floats.py
@@ -91,6 +91,8 @@ SPECIAL_EXPONENTS = (0, MAX_EXPONENT)
 BIAS = 1023
 MAX_POSITIVE_EXPONENT = (MAX_EXPONENT - 1 - BIAS)
 
+DRAW_FLOAT_LABEL = calc_label_from_name('drawing a float')
+
 
 def exponent_key(e):
     if e == MAX_EXPONENT:
@@ -232,7 +234,7 @@ def is_simple(f):
 
 def draw_float(data):
     try:
-        data.start_example(calc_label_from_name('drawing a float'))
+        data.start_example(DRAW_FLOAT_LABEL)
         f = lex_to_float(data.draw_bits(64))
         if data.draw_bits(1):
             f = -f

--- a/src/hypothesis/internal/conjecture/utils.py
+++ b/src/hypothesis/internal/conjecture/utils.py
@@ -49,6 +49,14 @@ def combine_labels(*labels):
     return label
 
 
+INTEGER_RANGE_DRAW_LABEL = calc_label_from_name(
+    'another draw in integer_range()')
+GEOMETRIC_LABEL = calc_label_from_name('geometric()')
+BIASED_COIN_LABEL = calc_label_from_name('biased_coin()')
+SAMPLE_IN_SAMPLER_LABLE = calc_label_from_name('a sample() in Sampler')
+ONE_FROM_MANY_LABEL = calc_label_from_name('one more from many()')
+
+
 def integer_range(data, lower, upper, center=None):
     assert lower <= upper
     if lower == upper:
@@ -76,8 +84,7 @@ def integer_range(data, lower, upper, center=None):
     probe = gap + 1
 
     while probe > gap:
-        data.start_example(calc_label_from_name(
-            'another draw in integer_range()'))
+        data.start_example(INTEGER_RANGE_DRAW_LABEL)
         probe = data.draw_bits(bits)
         data.stop_example(discard=probe > gap)
 
@@ -152,8 +159,7 @@ def fractional_float(data):
 
 def geometric(data, p):
     denom = math.log1p(-p)
-
-    data.start_example(calc_label_from_name('geometric()'))
+    data.start_example(GEOMETRIC_LABEL)
     while True:
         probe = fractional_float(data)
         if probe < 1.0:
@@ -170,7 +176,7 @@ def boolean(data):
 def biased_coin(data, p):
     """Return False with probability p (assuming a uniform generator),
     shrinking towards False."""
-    data.start_example(calc_label_from_name('biased_coin()'))
+    data.start_example(BIASED_COIN_LABEL)
     while True:
         # The logic here is a bit complicated and special cased to make it
         # play better with the shrinker.
@@ -334,7 +340,7 @@ class Sampler(object):
         self.table.sort()
 
     def sample(self, data):
-        data.start_example(calc_label_from_name('a sample() in Sampler'))
+        data.start_example(SAMPLE_IN_SAMPLER_LABLE)
         i = integer_range(data, 0, len(self.table) - 1)
         base, alternate, alternate_chance = self.table[i]
         use_alternate = biased_coin(data, alternate_chance)
@@ -391,8 +397,7 @@ class many(object):
             should_continue = biased_coin(self.data, p_continue)
 
         if should_continue:
-            self.data.start_example(calc_label_from_name(
-                'one more from many()'))
+            self.data.start_example(ONE_FROM_MANY_LABEL)
             self.count += 1
             return True
         else:

--- a/src/hypothesis/searchstrategy/collections.py
+++ b/src/hypothesis/searchstrategy/collections.py
@@ -20,8 +20,9 @@ from __future__ import division, print_function, absolute_import
 import hypothesis.internal.conjecture.utils as cu
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.compat import OrderedDict, hbytes
+from hypothesis.internal.conjecture.utils import combine_labels
 from hypothesis.searchstrategy.strategies import SearchStrategy, \
-    MappedSearchStrategy, combine_labels, one_of_strategies
+    MappedSearchStrategy, one_of_strategies
 
 
 class TupleStrategy(SearchStrategy):

--- a/src/hypothesis/searchstrategy/numbers.py
+++ b/src/hypothesis/searchstrategy/numbers.py
@@ -99,6 +99,9 @@ NASTY_FLOATS = sorted([
 NASTY_FLOATS = list(map(float, NASTY_FLOATS))
 NASTY_FLOATS.extend([-x for x in NASTY_FLOATS])
 
+FLOAT_STRATEGY_DO_DRAW_LABEL = calc_label_from_name(
+    'getting another float in FloatStrategy')
+
 
 class FloatStrategy(SearchStrategy):
     """Generic superclass for strategies which produce floats."""
@@ -129,8 +132,7 @@ class FloatStrategy(SearchStrategy):
 
     def do_draw(self, data):
         while True:
-            data.start_example(calc_label_from_name(
-                'getting another float in FloatStrategy'))
+            data.start_example(FLOAT_STRATEGY_DO_DRAW_LABEL)
             i = self.sampler.sample(data)
             if i == 0:
                 result = flt.draw_float(data)

--- a/src/hypothesis/searchstrategy/numbers.py
+++ b/src/hypothesis/searchstrategy/numbers.py
@@ -23,6 +23,7 @@ import hypothesis.internal.conjecture.utils as d
 import hypothesis.internal.conjecture.floats as flt
 from hypothesis.control import assume
 from hypothesis.internal.floats import sign
+from hypothesis.internal.conjecture.utils import calc_label_from_name
 from hypothesis.searchstrategy.strategies import SearchStrategy, \
     MappedSearchStrategy
 
@@ -128,7 +129,8 @@ class FloatStrategy(SearchStrategy):
 
     def do_draw(self, data):
         while True:
-            data.start_example()
+            data.start_example(calc_label_from_name(
+                'getting another float in FloatStrategy'))
             i = self.sampler.sample(data)
             if i == 0:
                 result = flt.draw_float(data)

--- a/src/hypothesis/searchstrategy/strategies.py
+++ b/src/hypothesis/searchstrategy/strategies.py
@@ -33,6 +33,9 @@ from hypothesis.internal.conjecture.utils import LABEL_MASK, \
 
 calculating = UniqueIdentifier('calculating')
 
+MAPPED_SEARCH_STRATEGY_DO_DRAW_LABEL = calc_label_from_name(
+    'another attempted draw in MappedSearchStrategy')
+
 
 def one_of_strategies(xs):
     """Helper function for unioning multiple strategies."""
@@ -547,8 +550,7 @@ class MappedSearchStrategy(SearchStrategy):
         for _ in range(3):
             i = data.index
             try:
-                data.start_example(calc_label_from_name(
-                    'another attempted draw in MappedSearchStrategy'))
+                data.start_example(MAPPED_SEARCH_STRATEGY_DO_DRAW_LABEL)
                 result = self.pack(data.draw(self.mapped_strategy))
                 data.stop_example()
                 return result

--- a/src/hypothesis/stateful.py
+++ b/src/hypothesis/stateful.py
@@ -52,6 +52,8 @@ from hypothesis.searchstrategy.strategies import SearchStrategy
 from hypothesis.searchstrategy.collections import TupleStrategy, \
     FixedKeysDictStrategy
 
+STATE_MACHINE_RUN_LABEL = calc_label_from_name('another state machine step')
+
 
 class TestCaseProperty(object):  # pragma: no cover
 
@@ -235,8 +237,7 @@ class StateMachineRunner(object):
             while True:
                 if steps >= self.n_steps:
                     stopping_value = 0
-                self.data.start_example(calc_label_from_name(
-                    'another state machine step'))
+                self.data.start_example(STATE_MACHINE_RUN_LABEL)
                 if not cu.biased_coin(self.data, stopping_value):
                     self.data.stop_example()
                     break

--- a/src/hypothesis/stateful.py
+++ b/src/hypothesis/stateful.py
@@ -46,7 +46,8 @@ from hypothesis.strategies import just, lists, builds, one_of, runner, \
 from hypothesis.vendor.pretty import CUnicodeIO, RepresentationPrinter
 from hypothesis.internal.reflection import proxies, nicerepr
 from hypothesis.internal.conjecture.data import StopTest
-from hypothesis.internal.conjecture.utils import integer_range
+from hypothesis.internal.conjecture.utils import integer_range, \
+    calc_label_from_name
 from hypothesis.searchstrategy.strategies import SearchStrategy
 from hypothesis.searchstrategy.collections import TupleStrategy, \
     FixedKeysDictStrategy
@@ -234,7 +235,8 @@ class StateMachineRunner(object):
             while True:
                 if steps >= self.n_steps:
                     stopping_value = 0
-                self.data.start_example()
+                self.data.start_example(calc_label_from_name(
+                    'another state machine step'))
                 if not cu.biased_coin(self.data, stopping_value):
                     self.data.stop_example()
                     break

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -1531,7 +1531,7 @@ def composite(f):
     """
 
     from hypothesis.internal.reflection import define_function_signature
-    from hypothesis.searchstrategy.strategies import calc_label
+    from hypothesis.internal.conjecture.utils import calc_label_from_cls
     argspec = getfullargspec(f)
 
     if (
@@ -1550,7 +1550,7 @@ def composite(f):
               if k in (argspec.args + argspec.kwonlyargs + ['return'])}
     new_argspec = argspec._replace(args=argspec.args[1:], annotations=annots)
 
-    label = calc_label(f)
+    label = calc_label_from_cls(f)
 
     @defines_strategy
     @define_function_signature(f.__name__, f.__doc__, new_argspec)

--- a/tests/cover/test_conjecture_engine.py
+++ b/tests/cover/test_conjecture_engine.py
@@ -755,8 +755,8 @@ def test_clears_out_its_database_on_shrinking(
 
 
 def test_saves_negated_examples_in_covering():
-    """Check that every tag that's a key in examples_by_tags is either the
-    universal tag or a Negated of some other tag that is also in the dict?"""
+    """Check that every key in examples_by_tags is either the universal tag or
+    a Negated of some other key in the dict."""
     def f(data):
         if data.draw_bits(8) & 1:
             data.add_tag('hi')

--- a/tests/cover/test_conjecture_engine.py
+++ b/tests/cover/test_conjecture_engine.py
@@ -763,11 +763,11 @@ def test_saves_negated_examples_in_covering():
 
     runner = ConjectureRunner(f)
     runner.run()
-
     tags = set(runner.target_selector.examples_by_tags)
     negated_tags = {t for t in tags if isinstance(t, Negated)}
     not_universal_or_negated = tags - negated_tags - {universal}
-    assert {t.tag for t in negated_tags} == not_universal_or_negated > set()
+    assert not_universal_or_negated > set()
+    assert {t.tag for t in negated_tags} == not_universal_or_negated
 
 
 def test_can_delete_intervals(monkeypatch):

--- a/tests/cover/test_conjecture_engine.py
+++ b/tests/cover/test_conjecture_engine.py
@@ -32,10 +32,12 @@ from tests.common.strategies import SLOW, HardToShrink
 from hypothesis.internal.compat import hbytes, hrange, int_from_bytes
 from hypothesis.internal.conjecture.data import MAX_DEPTH, Status, \
     ConjectureData
+from hypothesis.internal.conjecture.utils import calc_label_from_name
 from hypothesis.internal.conjecture.engine import Shrinker, \
     RunIsComplete, ConjectureRunner
 
 MAX_SHRINKS = 1000
+SOME_LABEL = calc_label_from_name('some label')
 
 
 def run_to_buffer(f):
@@ -165,7 +167,7 @@ def test_variadic_draw():
     def draw_list(data):
         result = []
         while True:
-            data.start_example()
+            data.start_example(SOME_LABEL)
             d = data.draw_bytes(1)[0] & 7
             if d:
                 result.append(data.draw_bytes(d))
@@ -759,7 +761,7 @@ def test_saves_negated_examples_in_covering():
 
     runner = ConjectureRunner(f)
     runner.run()
-    assert len(runner.target_selector.examples_by_tags) == 3
+    assert len(runner.target_selector.examples_by_tags) == 7
 
 
 def test_can_delete_intervals(monkeypatch):
@@ -888,7 +890,7 @@ def test_discarding(monkeypatch):
     def x(data):
         count = 0
         while count < 10:
-            data.start_example()
+            data.start_example(SOME_LABEL)
             b = data.draw_bits(1)
             if b:
                 count += 1
@@ -918,7 +920,7 @@ def test_discarding_runs_automatically(monkeypatch):
     @run_to_buffer
     def x(data):
         while True:
-            data.start_example()
+            data.start_example(SOME_LABEL)
             b = data.draw_bits(8)
             data.stop_example(discard=(b == 0))
             if b == 11:
@@ -951,7 +953,7 @@ def test_automatic_discarding_is_turned_off_if_it_does_not_work(monkeypatch):
     def x(data):
         count = 0
         while True:
-            data.start_example()
+            data.start_example(SOME_LABEL)
             b = data.draw_bits(8)
             if not b:
                 count += 1
@@ -1027,7 +1029,7 @@ def test_depth_bounds_in_generation():
     def tree(data, n):
         depth[0] = max(depth[0], n)
         if data.draw_bits(8):
-            data.start_example()
+            data.start_example(SOME_LABEL)
             tree(data, n + 1)
             tree(data, n + 1)
             data.stop_example()
@@ -1067,9 +1069,9 @@ def test_handles_nesting_of_discard_correctly(monkeypatch):
     @run_to_buffer
     def x(data):
         while True:
-            data.start_example()
+            data.start_example(SOME_LABEL)
             succeeded = data.draw_bits(1)
-            data.start_example()
+            data.start_example(SOME_LABEL)
             data.draw_bits(1)
             data.stop_example(discard=not succeeded)
             data.stop_example(discard=not succeeded)
@@ -1091,7 +1093,7 @@ def test_can_zero_subintervals(monkeypatch):
     @run_to_buffer
     def x(data):
         for _ in hrange(10):
-            data.start_example()
+            data.start_example(SOME_LABEL)
             n = data.draw_bits(8)
             data.draw_bytes(n)
             data.stop_example()
@@ -1267,9 +1269,9 @@ def test_handle_empty_draws(monkeypatch):
     @run_to_buffer
     def x(data):
         while True:
-            data.start_example()
+            data.start_example(SOME_LABEL)
             n = data.draw_bits(1)
-            data.start_example()
+            data.start_example(SOME_LABEL)
             data.stop_example()
             data.stop_example(discard=n > 0)
             if not n:

--- a/tests/nocover/test_labels.py
+++ b/tests/nocover/test_labels.py
@@ -99,7 +99,8 @@ def test_discarded_intervals_are_not_in_labels():
         data.draw_bits(1)
         data.stop_example()
 
-    assert x == frozenset({2})
+    assert 3 not in x
+    assert 2 in x
 
 
 def test_nested_discarded_intervals_are_not_in_labels():
@@ -115,7 +116,9 @@ def test_nested_discarded_intervals_are_not_in_labels():
         data.draw_bits(1)
         data.stop_example()
 
-    assert x == frozenset({2})
+    assert 2 in x
+    assert 3 not in x
+    assert 4 not in x
 
 
 def test_label_of_deferred_strategy_is_well_defined():


### PR DESCRIPTION
This gives every `Example` a non-`None` label, as a prerequisite for (and as discussed in) https://github.com/HypothesisWorks/hypothesis-python/issues/1098.

I think previously most labels were sensitive to the substructure below them in the example tree (e.g. strategies like `ListStrategy` using `combine_labels` to combine their labels with those of the element strategies). That wasn't really available to me here (at least without bigger changes), so hopefully it's not a problem.

This will change the behavior of `TargetSelector` at least a little, since the `Example`s that previously had labels `None` are included in `TargetSelector.examples_by_tags` when they weren't before.