### PR TITLE
Fix build on 2.7.14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,8 +145,9 @@ check-pytest30: $(TOX)
 check-pytest28: $(TOX)
 	$(TOX) --recreate -e pytest28
 
-check-quality: $(TOX)
+check-quality: $(TOX) $(PY27)
 	$(TOX) --recreate -e quality
+	$(TOX) --recreate -e quality2
 
 check-ancient-pip: $(PY273)
 	scripts/check-ancient-pip.sh $(PY273)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -86,7 +86,7 @@ install () {
 for var in "$@"; do
   case "${var}" in
     2.7)
-      install 2.7.11 python2.7
+      install 2.7.14 python2.7
       ;;
     2.7.3)
       install 2.7.3 python2.7.3

--- a/tests/quality/test_zig_zagging.py
+++ b/tests/quality/test_zig_zagging.py
@@ -47,6 +47,8 @@ def problem(draw):
 @given(problem())
 def test_avoids_zig_zag_trap(p):
     b, marker, lower_bound = p
+    b = hbytes(b)
+    marker = hbytes(marker)
 
     n_bits = 8 * (len(b) + 1)
 

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,14 @@ deps=
 commands=
     python -m pytest tests/quality/
 
+
+[testenv:quality]
+basepython=python2.7
+deps=
+    -rrequirements/test.txt
+commands=
+    python -m pytest tests/quality/
+
 [testenv:oldpy27]
 basepython=python2.7.3
 deps=

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ commands=
     python -m pytest tests/quality/
 
 
-[testenv:quality]
+[testenv:quality2]
 basepython=python2.7
 deps=
     -rrequirements/test.txt


### PR DESCRIPTION
Fixes #1087. It turns out the reason why our build didn't catch this is we only run the quality tests on Python 3!

This also:

*  updates the build to run quality tests on Python 2 so this doesn't happen again (As part of the same build job given how much of our tests are Travis startup time).
* Updates our testing version of Python to 2.7.14, though this turned out not to matter.