### PR TITLE
don't show diff in make check-release-file

### DIFF
--- a/scripts/hypothesistooling.py
+++ b/scripts/hypothesistooling.py
@@ -120,7 +120,8 @@ def has_source_changes(version=None):
     point_of_divergence = merge_base('HEAD', version)
 
     return subprocess.call([
-        'git', 'diff', '--exit-code', point_of_divergence, 'HEAD', '--', SRC,
+        'git', 'diff', '-s', '--exit-code', point_of_divergence, 'HEAD', '--',
+        SRC,
     ]) != 0
 
 

--- a/scripts/hypothesistooling.py
+++ b/scripts/hypothesistooling.py
@@ -120,8 +120,8 @@ def has_source_changes(version=None):
     point_of_divergence = merge_base('HEAD', version)
 
     return subprocess.call([
-        'git', 'diff', '-s', '--exit-code', point_of_divergence, 'HEAD', '--',
-        SRC,
+        'git', 'diff', '--no-patch', '--exit-code', point_of_divergence,
+        'HEAD', '--', SRC,
     ]) != 0
 
 


### PR DESCRIPTION
I've been slightly annoyed that when I run `make check-release-file` spits out the whole diff, so this suppresses that. (This is often much more output than other `make ...` commands.)

I'm not too attached to this, so if anyone else prefers the status quo, I'm happy to stick to that instead.

(I confirmed that `make check-release-file` still complains if there are source changes and no RELEASE.rst.)