### PR TITLE
Make settings.register_profile(...) accept kwargs as for settings(...)

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: minor
+
+:obj:`~hypothesis.settings.register_profile` now accepts keyword arguments
+for specific settings, and the parent settings object is now optional.

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -2,3 +2,5 @@ RELEASE_TYPE: minor
 
 :obj:`~hypothesis.settings.register_profile` now accepts keyword arguments
 for specific settings, and the parent settings object is now optional.
+Using a ``name`` for a registered profile which is not a string was never
+suggested, but it is now also deprecated and will eventually be an error.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -263,13 +263,12 @@ by your conftest you can load one with the command line option ``--hypothesis-pr
 Timeouts
 ~~~~~~~~
 
-The `timeout` functionality of Hypothesis is being deprecated, and will
+The timeout functionality of Hypothesis is being deprecated, and will
 eventually be removed. For the moment, the timeout setting can still be set
 and the old default timeout of one minute remains.
 
 If you want to future proof your code you can get
-the future behaviour by setting it to the value `unlimited`, which you can
-import from the main Hypothesis package:
+the future behaviour by setting it to the value ``hypothesis.unlimited``.
 
 .. code:: python
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -220,7 +220,7 @@ of tests that explicitly change the settings.
 .. doctest::
 
     >>> from hypothesis import settings
-    >>> settings.register_profile("ci", settings(max_examples=1000))
+    >>> settings.register_profile("ci", max_examples=1000)
     >>> settings().max_examples
     100
     >>> settings.load_profile("ci")
@@ -246,9 +246,9 @@ If this variable is not defined the Hypothesis defined defaults will be loaded.
 
     >>> import os
     >>> from hypothesis import settings, Verbosity
-    >>> settings.register_profile("ci", settings(max_examples=1000))
-    >>> settings.register_profile("dev", settings(max_examples=10))
-    >>> settings.register_profile("debug", settings(max_examples=10, verbosity=Verbosity.verbose))
+    >>> settings.register_profile("ci", max_examples=1000)
+    >>> settings.register_profile("dev", max_examples=10)
+    >>> settings.register_profile("debug", max_examples=10, verbosity=Verbosity.verbose)
     >>> settings.load_profile(os.getenv(u'HYPOTHESIS_PROFILE', 'default'))
 
 If you are using the hypothesis pytest plugin and your profiles are registered

--- a/src/hypothesis/_settings.py
+++ b/src/hypothesis/_settings.py
@@ -285,17 +285,32 @@ class settings(settingsMeta('settings', (object,), {})):
         return default_context_manager.__exit__(*args, **kwargs)
 
     @staticmethod
-    def register_profile(name, settings):
+    def register_profile(name, parent=None, **kwargs):
         """Registers a collection of values to be used as a settings profile.
 
         Settings profiles can be loaded by name - for example, you might
         create a 'fast' profile which runs fewer examples, keep the 'default'
         profile, and create a 'ci' profile that increases the number of
         examples and uses a different database to store failures.
+
+        The arguments to this method are exactly as for
+        :class:`~hypothesis.settings`: optional ``parent`` settings, and
+        keyword arguments for each setting that will be set differently to
+        parent (or settings.default, if parent is None).
         """
         if not isinstance(name, (str, text_type)):
             note_deprecation('name=%r must be a string' % (name,))
-        settings._profiles[name] = settings
+        if 'settings' in kwargs:
+            if parent is None:
+                parent = kwargs.pop('settings')
+                note_deprecation('The `settings` argument is deprecated - '
+                                 'use `parent` instead.')
+            else:
+                raise InvalidArgument(
+                    'The `settings` argument is deprecated, and has been '
+                    'replaced by the `parent` argument.  Use `parent` only.'
+                )
+        settings._profiles[name] = settings(parent=parent, **kwargs)
 
     @staticmethod
     def get_profile(name):

--- a/src/hypothesis/_settings.py
+++ b/src/hypothesis/_settings.py
@@ -287,35 +287,26 @@ class settings(settingsMeta('settings', (object,), {})):
     def register_profile(name, settings):
         """Registers a collection of values to be used as a settings profile.
 
-        These settings can be loaded in by name. Enable different
-        defaults for different settings.  ``settings`` must be a
-        settings object.
+        Settings profiles can be loaded by name - for example, you might
+        create a 'fast' profile which runs fewer examples, keep the 'default'
+        profile, and create a 'ci' profile that increases the number of
+        examples and uses a different database to store failures.
         """
         settings._profiles[name] = settings
 
     @staticmethod
     def get_profile(name):
-        """Return the profile with the given name.
-
-        - name is a string representing the name of the profile
-         to load
-        A InvalidArgument exception will be thrown if the
-         profile does not exist
-        """
+        """Return the profile with the given name."""
         try:
             return settings._profiles[name]
         except KeyError:
-            raise InvalidArgument(
-                "Profile '{0}' has not been registered".format(
-                    name
-                )
-            )
+            raise InvalidArgument('Profile %r is not registered' % (name,))
 
     @staticmethod
     def load_profile(name):
-        """Loads in the settings defined in the profile provided If the profile
-        does not exist an InvalidArgument will be thrown.
+        """Loads in the settings defined in the profile provided.
 
+        If the profile does not exist an InvalidArgument will be thrown.
         Any setting not defined in the profile will be the library
         defined default for that setting
         """

--- a/src/hypothesis/_settings.py
+++ b/src/hypothesis/_settings.py
@@ -326,9 +326,9 @@ class settings(settingsMeta('settings', (object,), {})):
     def load_profile(name):
         """Loads in the settings defined in the profile provided.
 
-        If the profile does not exist an InvalidArgument will be thrown.
+        If the profile does not exist, InvalidArgument will be raised.
         Any setting not defined in the profile will be the library
-        defined default for that setting
+        defined default for that setting.
         """
         if not isinstance(name, (str, text_type)):
             note_deprecation('name=%r must be a string' % (name,))

--- a/src/hypothesis/_settings.py
+++ b/src/hypothesis/_settings.py
@@ -33,6 +33,7 @@ import attr
 
 from hypothesis.errors import InvalidArgument, HypothesisDeprecationWarning
 from hypothesis.configuration import hypothesis_home_dir
+from hypothesis.internal.compat import text_type
 from hypothesis.utils.conventions import UniqueIdentifier, not_set
 from hypothesis.internal.validation import try_convert
 from hypothesis.utils.dynamicvariables import DynamicVariable
@@ -292,11 +293,15 @@ class settings(settingsMeta('settings', (object,), {})):
         profile, and create a 'ci' profile that increases the number of
         examples and uses a different database to store failures.
         """
+        if not isinstance(name, (str, text_type)):
+            note_deprecation('name=%r must be a string' % (name,))
         settings._profiles[name] = settings
 
     @staticmethod
     def get_profile(name):
         """Return the profile with the given name."""
+        if not isinstance(name, (str, text_type)):
+            note_deprecation('name=%r must be a string' % (name,))
         try:
             return settings._profiles[name]
         except KeyError:
@@ -310,6 +315,8 @@ class settings(settingsMeta('settings', (object,), {})):
         Any setting not defined in the profile will be the library
         defined default for that setting
         """
+        if not isinstance(name, (str, text_type)):
+            note_deprecation('name=%r must be a string' % (name,))
         settings._current_profile = name
         settings._assign_default_internal(settings.get_profile(name))
 
@@ -707,10 +714,6 @@ more details of this behaviour.
 
 settings.lock_further_definitions()
 
-settings.register_profile('default', settings())
-settings.load_profile('default')
-assert settings.default is not None
-
 
 def note_deprecation(message, s=None):
     if s is None:
@@ -720,3 +723,8 @@ def note_deprecation(message, s=None):
     warning = HypothesisDeprecationWarning(message)
     if verbosity > Verbosity.quiet:
         warnings.warn(warning, stacklevel=3)
+
+
+settings.register_profile('default', settings())
+settings.load_profile('default')
+assert settings.default is not None

--- a/tests/cover/test_settings.py
+++ b/tests/cover/test_settings.py
@@ -95,6 +95,20 @@ def test_cannot_create_settings_with_invalid_options():
         settings(a_setting_with_limited_options=u'spoon')
 
 
+def test_cannot_register_with_parent_and_settings_args():
+    with pytest.raises(InvalidArgument):
+        settings.register_profile(
+            'conflicted', settings.default, settings=settings.default)
+    assert 'conflicted' not in settings._profiles
+
+
+@checks_deprecated_behaviour
+def test_register_profile_kwarg_settings_is_deprecated():
+    settings.register_profile('test', settings=settings(max_examples=10))
+    settings.load_profile('test')
+    assert settings.default.max_examples == 10
+
+
 def test_can_set_verbosity():
     settings(verbosity=Verbosity.quiet)
     settings(verbosity=Verbosity.normal)
@@ -134,14 +148,7 @@ def test_load_profile():
     assert settings.default.max_shrinks == 500
     assert settings.default.min_satisfying_examples == 5
 
-    settings.register_profile(
-        'test',
-        settings(
-            max_examples=10,
-            max_shrinks=5
-        )
-    )
-
+    settings.register_profile('test', settings(max_examples=10), max_shrinks=5)
     settings.load_profile('test')
 
     assert settings.default.max_examples == 10

--- a/tests/cover/test_settings.py
+++ b/tests/cover/test_settings.py
@@ -155,6 +155,13 @@ def test_load_profile():
     assert settings.default.min_satisfying_examples == 5
 
 
+@checks_deprecated_behaviour
+def test_nonstring_profile_names_deprecated():
+    settings.register_profile(5, max_shrinks=5)
+    settings.load_profile(5)
+    assert settings.default.max_shrinks == 5
+
+
 def test_loading_profile_keeps_expected_behaviour():
     settings.register_profile('ci', settings(max_examples=10000))
     settings.load_profile('ci')


### PR DESCRIPTION
This closes #940, replacing and completing it.

As well as simplifying registration of new settings profiles, this patch requires that the name be a native or unicode string (in order to ease file- or envvar-based loading), and does some general tidying up of the formatting and documentation.