### PR TITLE
Fix .gitignore example excluding hypothesis examples database

### DIFF
--- a/docs/database.rst
+++ b/docs/database.rst
@@ -56,7 +56,7 @@ The examples database can be shared simply by checking the directory into
 version control, for example with the following ``.gitignore``::
 
     # Ignore files cached by Hypothesis...
-    .hypothesis/
+    .hypothesis/*
     # except for the examples directory
     !.hypothesis/examples/
 


### PR DESCRIPTION
From `git help gitignore`:

> * An optional prefix "!" which negates the pattern; any matching file excluded by a previous pattern will become included again. It is not possible to re-include a file if a parent directory of that file is excluded.

Therefore, we should exclude `.hypothesis/*`, not `.hypothesis/`.