### PR TITLE
Improve validation of numeric bounds

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,25 @@
+RELEASE_TYPE: minor
+
+This release improves validation of numeric bounds for some strategies.
+
+- :func:`~hypothesis.strategies.integers` and :func:`~hypothesis.strategies.floats`
+  now raise ``InvalidArgument`` if passed a ``min_value`` or ``max_value``
+  which is not an instance of :class:`~python:numbers.Real`, instead of
+  various internal errors.
+- :func:`~hypothesis.strategies.floats` now converts its bounding values to
+  the nearest float above or below the min or max bound respectively, instead
+  of just casting to float.  The old behaviour was incorrect in that you could
+  generate ``float(min_value)``, even when this was less than ``min_value``
+  itself (possible with eg. fractions).
+- When both bounds are provided to :func:`~hypothesis.strategies.floats` but
+  there are no floats in the interval, such as ``[(2**54)+1 .. (2**55)-1]``,
+  InvalidArgument is raised.
+- :func:`~hypothesis.strategies.decimals` gives a more useful error message
+  if passed a string that cannot be converted to :class:`~python:decimal.Decimal`
+  in a context where this error is not trapped.
+
+Code that previously **seemed** to work may be explicitly broken if there
+were no floats between ``min_value`` and ``max_value`` (only possible with
+non-float bounds), or if a bound was not a :class:`~python:numbers.Real`
+number but still allowed in :obj:`python:math.isnan` (some custom classes
+with a ``__float__`` method).

--- a/src/hypothesis/_settings.py
+++ b/src/hypothesis/_settings.py
@@ -35,7 +35,6 @@ from hypothesis.errors import InvalidArgument, HypothesisDeprecationWarning
 from hypothesis.configuration import hypothesis_home_dir
 from hypothesis.internal.compat import text_type
 from hypothesis.utils.conventions import UniqueIdentifier, not_set
-from hypothesis.internal.validation import try_convert
 from hypothesis.utils.dynamicvariables import DynamicVariable
 
 __all__ = [
@@ -636,6 +635,7 @@ attempting to actually execute your test.
 
 
 def validate_health_check_suppressions(suppressions):
+    from hypothesis.internal.validation import try_convert
     suppressions = try_convert(list, suppressions, 'suppress_health_check')
     for s in suppressions:
         if not isinstance(s, HealthCheck):

--- a/src/hypothesis/internal/floats.py
+++ b/src/hypothesis/internal/floats.py
@@ -48,12 +48,31 @@ def count_between_floats(x, y):
 
 
 def float_to_int(value):
-    return (
-        struct_unpack(b'!Q', struct_pack(b'!d', value))[0]
-    )
+    return struct_unpack(b'!Q', struct_pack(b'!d', value))[0]
 
 
 def int_to_float(value):
-    return (
-        struct_unpack(b'!d', struct_pack(b'!Q', value))[0]
-    )
+    return struct_unpack(b'!d', struct_pack(b'!Q', value))[0]
+
+
+def next_up(value):
+    """Return the first float larger than finite `val` - IEEE 754's `nextUp`.
+
+    From https://stackoverflow.com/a/10426033, with thanks to Mark Dickinson.
+    """
+    assert isinstance(value, float)
+    if math.isnan(value) or (math.isinf(value) and value > 0):
+        return value
+    if value == 0.0:
+        value = 0.0
+    # Note: n is signed; float_to_int returns unsigned
+    n = struct_unpack(b'q', struct_pack(b'd', value))[0]
+    if n >= 0:
+        n += 1
+    else:
+        n -= 1
+    return struct_unpack(b'd', struct_pack(b'q', n))[0]
+
+
+def next_down(value):
+    return -next_up(-value)

--- a/src/hypothesis/internal/validation.py
+++ b/src/hypothesis/internal/validation.py
@@ -85,7 +85,7 @@ def try_convert(typ, value, name):
                 name, value, type(value).__name__, typ.__name__
             )
         )
-    except (OverflowError, ValueError):
+    except (OverflowError, ValueError, ArithmeticError):
         raise InvalidArgument(
             'Cannot convert %s=%r to type %s' % (
                 name, value, typ.__name__

--- a/src/hypothesis/internal/validation.py
+++ b/src/hypothesis/internal/validation.py
@@ -18,7 +18,8 @@
 from __future__ import division, print_function, absolute_import
 
 import math
-from numbers import Rational
+import decimal
+from numbers import Real, Rational
 
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.compat import integer_types
@@ -64,6 +65,8 @@ def check_valid_bound(value, name):
     """
     if value is None or isinstance(value, integer_types + (Rational,)):
         return
+    if not isinstance(value, (Real, decimal.Decimal)):
+        raise InvalidArgument('%s=%r must be a real number.' % (name, value))
     if math.isnan(value):
         raise InvalidArgument(u'Invalid end point %s=%r' % (name, value))
 

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -334,11 +334,14 @@ def floats(
                     allow_nan
                 ))
 
-    min_value = try_convert(float, min_value, 'min_value')
-    max_value = try_convert(float, max_value, 'max_value')
-
     check_valid_bound(min_value, 'min_value')
     check_valid_bound(max_value, 'max_value')
+
+    if min_value is not None:
+        min_value = float(min_value)
+    if max_value is not None:
+        max_value = float(max_value)
+
     check_valid_interval(min_value, max_value, 'min_value', 'max_value')
     if min_value == float(u'-inf'):
         min_value = None

--- a/tests/cover/test_direct_strategies.py
+++ b/tests/cover/test_direct_strategies.py
@@ -119,6 +119,8 @@ def fn_ktest(*fnkwargs):
     (ds.binary, {'min_size': 10, 'max_size': 9}),
     (ds.binary, {'max_size': 10, 'average_size': 20}),
     (ds.floats, {'min_value': float('nan')}),
+    (ds.floats, {'min_value': '0'}),
+    (ds.floats, {'max_value': '0'}),
     (ds.floats, {'max_value': 0.0, 'min_value': 1.0}),
     (ds.floats, {'min_value': 0.0, 'allow_nan': True}),
     (ds.floats, {'max_value': 0.0, 'allow_nan': True}),

--- a/tests/cover/test_float_nastiness.py
+++ b/tests/cover/test_float_nastiness.py
@@ -19,15 +19,18 @@ from __future__ import division, print_function, absolute_import
 
 import sys
 import math
+from decimal import Decimal
 
 import pytest
 from flaky import flaky
 
 import hypothesis.strategies as st
-from hypothesis import find, given, settings
+from hypothesis import find, given, assume, settings
+from hypothesis.errors import InvalidArgument
 from tests.common.debug import minimal, find_any
 from hypothesis.internal.compat import WINDOWS
-from hypothesis.internal.floats import float_to_int, int_to_float
+from hypothesis.internal.floats import next_up, next_down, float_to_int, \
+    int_to_float
 
 
 @pytest.mark.parametrize(('lower', 'upper'), [
@@ -150,3 +153,41 @@ def test_very_narrow_interval():
     def test(f):
         assert lower_bound <= f <= upper_bound
     test()
+
+
+@given(st.floats())
+def test_up_means_greater(x):
+    hi = next_up(x)
+    if not x < hi:
+        assert (math.isnan(x) and math.isnan(hi)) or (x > 0 and math.isinf(x))
+
+
+@given(st.floats())
+def test_down_means_lesser(x):
+    lo = next_down(x)
+    if not x > lo:
+        assert (math.isnan(x) and math.isnan(lo)) or (x < 0 and math.isinf(x))
+
+
+@given(st.floats(allow_nan=False, allow_infinity=False))
+def test_updown_roundtrip(val):
+    assert val == next_up(next_down(val))
+    assert val == next_down(next_up(val))
+
+
+@given(st.data(), st.floats(allow_nan=False, allow_infinity=False))
+def test_floats_in_tiny_interval_within_bounds(data, center):
+    assume(not (math.isinf(next_down(center)) or math.isinf(next_up(center))))
+    lo = Decimal.from_float(next_down(center)).next_plus()
+    hi = Decimal.from_float(next_up(center)).next_minus()
+    assert float(lo) < lo < center < hi < float(hi)
+    val = data.draw(st.floats(lo, hi))
+    assert lo < val < hi
+
+
+def test_float_free_interval_is_invalid():
+    lo = (2 ** 54) + 1
+    hi = lo + 2
+    assert float(lo) < lo < hi < float(hi), 'There are no floats in [lo .. hi]'
+    with pytest.raises(InvalidArgument):
+        st.floats(lo, hi).example()

--- a/tests/cover/test_numerics.py
+++ b/tests/cover/test_numerics.py
@@ -122,3 +122,13 @@ def test_issue_725_regression(x):
 @given(decimals(min_value='0.1', max_value='0.3'))
 def test_issue_739_regression(x):
     pass
+
+
+def test_consistent_decimal_error():
+    bad = 'invalid argument to Decimal'
+    with pytest.raises(InvalidArgument) as excinfo:
+        decimals(bad).example()
+    with pytest.raises(InvalidArgument) as excinfo2:
+        with decimal.localcontext(decimal.Context(traps=[])):
+            decimals(bad).example()
+    assert str(excinfo.value) == str(excinfo2.value)


### PR DESCRIPTION
Closes #814 - see issue or release notes for details.

Notably, passing non-`Real` bounds to `integers` and `floats` has been converted to an error without any deprecation period, because this was a `TypeError` in `math.isnan` immediately below.  Otherwise, it's as planned in the issue.