### PR TITLE
 Deprecate elements=None in collection strategies

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,9 @@
+RELEASE_TYPE: minor
+
+This release deprecates passing ``elements=None`` to collection strategies,
+such as :func:`~hypothesis.strategies.lists`.
+
+Requiring ``lists(nothing())`` or ``builds(list)`` instead of ``lists()``
+means slightly more typing, but also improves the consistency and
+discoverability of our API - as well as showing how to compose or
+construct strategies in ways that still work in more complex situations.

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -7,3 +7,7 @@ Requiring ``lists(nothing())`` or ``builds(list)`` instead of ``lists()``
 means slightly more typing, but also improves the consistency and
 discoverability of our API - as well as showing how to compose or
 construct strategies in ways that still work in more complex situations.
+
+Passing a nonzero max_size to a collection strategy where the elements
+strategy contains no values is now deprecated, and will be an error in a
+future version.  The equivalent with ``elements=None`` is already an error.

--- a/src/hypothesis/searchstrategy/collections.py
+++ b/src/hypothesis/searchstrategy/collections.py
@@ -104,6 +104,13 @@ class ListStrategy(SearchStrategy):
                 'Cannot create non-empty lists with elements drawn from '
                 'strategy %r because it has no values.') % (
                 self.element_strategy,))
+        if self.element_strategy.is_empty and 0 < self.max_size < float('inf'):
+            from hypothesis._settings import note_deprecation
+            note_deprecation(
+                'Cannot create a collection of max_size=%r, because no '
+                'elements can be drawn from the element strategy %r'
+                % (self.max_size, self.element_strategy)
+            )
 
     def calc_is_empty(self, recur):
         if self.min_size == 0:

--- a/src/hypothesis/searchstrategy/collections.py
+++ b/src/hypothesis/searchstrategy/collections.py
@@ -22,7 +22,7 @@ from hypothesis.errors import InvalidArgument
 from hypothesis.internal.compat import OrderedDict, hbytes
 from hypothesis.internal.conjecture.utils import combine_labels
 from hypothesis.searchstrategy.strategies import SearchStrategy, \
-    MappedSearchStrategy, one_of_strategies
+    MappedSearchStrategy
 
 
 class TupleStrategy(SearchStrategy):
@@ -83,16 +83,14 @@ class ListStrategy(SearchStrategy):
 
     def __init__(
         self,
-        strategies, average_length=50.0, min_size=0, max_size=float('inf')
+        elements, average_size=50.0, min_size=0, max_size=float('inf')
     ):
         SearchStrategy.__init__(self)
-
-        assert average_length > 0
-        self.average_length = average_length
-        strategies = tuple(strategies)
+        self.average_size = average_size
         self.min_size = min_size or 0
         self.max_size = max_size or float('inf')
-        self.element_strategy = one_of_strategies(strategies)
+        assert 0 <= min_size <= average_size <= max_size
+        self.element_strategy = elements
 
     def calc_label(self):
         return combine_labels(self.class_label, self.element_strategy.label)
@@ -126,7 +124,7 @@ class ListStrategy(SearchStrategy):
         elements = cu.many(
             data,
             min_size=self.min_size, max_size=self.max_size,
-            average_size=self.average_length
+            average_size=self.average_size
         )
         result = []
         while elements.more():
@@ -134,42 +132,22 @@ class ListStrategy(SearchStrategy):
         return result
 
     def __repr__(self):
-        return (
-            'ListStrategy(%r, min_size=%r, average_size=%r, max_size=%r)'
-        ) % (
-            self.element_strategy, self.min_size, self.average_length,
-            self.max_size
+        return '%s(%r, min_size=%r, average_size=%r, max_size=%r)' % (
+            self.__class__.__name__, self.element_strategy, self.min_size,
+            self.average_size, self.max_size
         )
 
 
-class UniqueListStrategy(SearchStrategy):
+class UniqueListStrategy(ListStrategy):
 
     def __init__(
         self,
         elements, min_size, max_size, average_size,
         key
     ):
-        super(UniqueListStrategy, self).__init__()
-        assert min_size <= average_size <= max_size
-        self.min_size = min_size
-        self.max_size = max_size
-        self.average_size = average_size
-        self.element_strategy = elements
+        super(UniqueListStrategy, self).__init__(
+            elements, average_size, min_size, max_size)
         self.key = key
-
-    def do_validate(self):
-        self.element_strategy.validate()
-        if self.is_empty:
-            raise InvalidArgument((
-                'Cannot create non-empty lists with elements drawn from '
-                'strategy %r because it has no values.') % (
-                self.element_strategy,))
-
-    def calc_is_empty(self, recur):
-        if self.min_size == 0:
-            return False
-        else:
-            return recur(self.element_strategy)
 
     def do_draw(self, data):
         if self.element_strategy.is_empty:

--- a/src/hypothesis/searchstrategy/strategies.py
+++ b/src/hypothesis/searchstrategy/strategies.py
@@ -603,8 +603,7 @@ class FilteredStrategy(SearchStrategy):
 
     @property
     def branches(self):
-        branches = [
+        return [
             FilteredStrategy(strategy=strategy, condition=self.condition)
             for strategy in self.filtered_strategy.branches
         ]
-        return branches

--- a/src/hypothesis/stateful.py
+++ b/src/hypothesis/stateful.py
@@ -41,15 +41,13 @@ from hypothesis._settings import Verbosity
 from hypothesis._settings import settings as Settings
 from hypothesis.reporting import report, verbose_report, current_verbosity
 from hypothesis.strategies import just, lists, builds, one_of, runner, \
-    integers
+    tuples, integers, fixed_dictionaries
 from hypothesis.vendor.pretty import CUnicodeIO, RepresentationPrinter
 from hypothesis.internal.reflection import proxies, nicerepr
 from hypothesis.internal.conjecture.data import StopTest
 from hypothesis.internal.conjecture.utils import integer_range, \
     calc_label_from_name
 from hypothesis.searchstrategy.strategies import SearchStrategy
-from hypothesis.searchstrategy.collections import TupleStrategy, \
-    FixedKeysDictStrategy
 
 STATE_MACHINE_RUN_LABEL = calc_label_from_name('another state machine step')
 
@@ -536,10 +534,9 @@ class RuleBasedStateMachine(GenericStateMachine):
                         break
                 converted_arguments[k] = v
             if valid:
-                strategies.append(TupleStrategy((
-                    just(rule),
-                    FixedKeysDictStrategy(converted_arguments)
-                ), tuple))
+                strategies.append(tuples(
+                    just(rule), fixed_dictionaries(converted_arguments)
+                ))
         if not strategies:
             raise InvalidDefinition(
                 u'No progress can be made from state %r' % (self,)

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -444,7 +444,7 @@ def tuples(*args):
         check_strategy(arg)
 
     from hypothesis.searchstrategy.collections import TupleStrategy
-    return TupleStrategy(args, tuple)
+    return TupleStrategy(args)
 
 
 @defines_strategy

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -509,10 +509,19 @@ def lists(
     list, and by shrinking each individual element of the list.
     """
     check_valid_sizes(min_size, average_size, max_size)
-    if elements is None or (max_size is not None and max_size <= 0):
-        if max_size is None or max_size > 0:
+    if elements is None:
+        note_deprecation(
+            'Passing a strategy for `elements` of the list will be required '
+            'in a future version of Hypothesis.  To create lists that are '
+            'always empty, use `builds(list)` or `lists(nothing())`.'
+        )
+        if min_size or average_size or max_size:
+            # Checked internally for lists with an elements strategy, but
+            # we're about to skip that and return builds(list) instead...
             raise InvalidArgument(
-                u'Cannot create non-empty lists without an element type'
+                'Cannot create a non-empty collection (min_size=%r, '
+                'average_size=%r, max_size=%r) without elements.'
+                % (min_size, average_size, max_size)
             )
         else:
             return builds(list)
@@ -570,6 +579,12 @@ def sets(elements=None, min_size=None, average_size=None, max_size=None):
     Examples from this strategy shrink by trying to remove elements from the
     set, and by shrinking each individual element of the set.
     """
+    if elements is None:
+        note_deprecation(
+            'Passing a strategy for `elements` of the set will be required '
+            'in a future version of Hypothesis.  To create sets that are '
+            'always empty, use `builds(set)` or `sets(nothing())`.'
+        )
     return lists(
         elements=elements, min_size=min_size, average_size=average_size,
         max_size=max_size, unique=True
@@ -581,6 +596,13 @@ def sets(elements=None, min_size=None, average_size=None, max_size=None):
 def frozensets(elements=None, min_size=None, average_size=None, max_size=None):
     """This is identical to the sets function but instead returns
     frozensets."""
+    if elements is None:
+        note_deprecation(
+            'Passing a strategy for `elements` of the frozenset will be '
+            'required in a future version of Hypothesis.  To create '
+            'frozensets that are always empty, use `builds(frozenset)` '
+            'or `frozensets(nothing())`.'
+        )
     return lists(
         elements=elements, min_size=min_size, average_size=average_size,
         max_size=max_size, unique=True
@@ -597,6 +619,13 @@ def iterables(elements=None, min_size=None, average_size=None, max_size=None,
     which cannot be indexed and do not have a fixed length. This ensures
     that you do not accidentally depend on sequence behaviour.
     """
+    if elements is None:
+        note_deprecation(
+            'Passing a strategy for `elements` of the iterable will be '
+            'required in a future version of Hypothesis.  To create '
+            'iterables that are always empty, use `iterables(nothing())`.'
+        )
+
     @implements_iterator
     class PrettyIter(object):
         def __init__(self, values):

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -562,7 +562,7 @@ def lists(
         )
     else:
         return ListStrategy(
-            (elements,), average_length=average_size,
+            elements, average_size=average_size,
             min_size=min_size, max_size=max_size,
         )
 

--- a/tests/common/__init__.py
+++ b/tests/common/__init__.py
@@ -54,7 +54,8 @@ def abc(x, y, z):
 
 
 standard_types = [
-    lists(max_size=0), tuples(), sets(max_size=0), frozensets(max_size=0),
+    lists(none(), max_size=0), tuples(),
+    sets(none(), max_size=0), frozensets(none(), max_size=0),
     fixed_dictionaries({}),
     abc(booleans(), booleans(), booleans()),
     abc(booleans(), booleans(), integers()),

--- a/tests/cover/test_direct_strategies.py
+++ b/tests/cover/test_direct_strategies.py
@@ -105,13 +105,11 @@ def fn_ktest(*fnkwargs):
     (ds.fractions, {'max_denominator': 0}),
     (ds.fractions, {'max_denominator': 1.5}),
     (ds.fractions, {'min_value': complex(1, 2)}),
-    (ds.lists, {}),
     (ds.lists, {'average_size': '5'}),
     (ds.lists, {'average_size': float('nan')}),
     (ds.lists, {'min_size': 10, 'max_size': 9}),
     (ds.lists, {'min_size': -10, 'max_size': -9}),
     (ds.lists, {'max_size': -9}),
-    (ds.lists, {'max_size': 10}),
     (ds.lists, {'min_size': -10}),
     (ds.lists, {'max_size': 10, 'average_size': 20}),
     (ds.lists, {'min_size': 1.0, 'average_size': 0.5}),
@@ -180,7 +178,7 @@ def test_validates_keyword_arguments(fn, kwargs):
     (ds.fractions, {'min_value': fractions.Fraction(1, 2)}),
     (ds.fractions, {'min_value': '1/2', 'max_denominator': 1}),
     (ds.fractions, {'max_value': '1/2', 'max_denominator': 1}),
-    (ds.lists, {'max_size': 0}),
+    (ds.lists, {'elements': ds.nothing(), 'max_size': 0}),
     (ds.lists, {'elements': ds.integers()}),
     (ds.lists, {'elements': ds.integers(), 'max_size': 5}),
     (ds.lists, {'elements': ds.booleans(), 'min_size': 5}),
@@ -388,3 +386,14 @@ def test_iterables_are_exhaustible(it):
 
 def test_minimal_iterable():
     assert list(find(ds.iterables(ds.integers()), lambda x: True)) == []
+
+
+@checks_deprecated_behaviour
+def test_iterables_without_elements_is_deprecated():
+    assert list(ds.iterables().example()) == []
+
+
+@checks_deprecated_behaviour
+def test_lists_wit_max_size_no_elements_is_deprecated_and_error():
+    with pytest.raises(InvalidArgument):
+        ds.lists(max_size=1).example()

--- a/tests/cover/test_direct_strategies.py
+++ b/tests/cover/test_direct_strategies.py
@@ -397,3 +397,8 @@ def test_iterables_without_elements_is_deprecated():
 def test_lists_wit_max_size_no_elements_is_deprecated_and_error():
     with pytest.raises(InvalidArgument):
         ds.lists(max_size=1).example()
+
+
+@checks_deprecated_behaviour
+def test_empty_elements_with_max_size_is_deprecated():
+    ds.lists(ds.nothing(), max_size=1).example()

--- a/tests/cover/test_flatmap.py
+++ b/tests/cover/test_flatmap.py
@@ -21,8 +21,8 @@ import pytest
 
 from hypothesis import find, given, assume, settings
 from hypothesis.database import ExampleDatabase
-from hypothesis.strategies import just, text, lists, floats, tuples, \
-    booleans, integers
+from hypothesis.strategies import just, text, lists, builds, floats, \
+    tuples, booleans, integers
 from hypothesis.internal.compat import Counter
 
 ConstantLists = integers().flatmap(lambda i: lists(just(i)))
@@ -72,7 +72,7 @@ def test_flatmap_retrieve_from_db():
 
 
 def test_flatmap_does_not_reuse_strategies():
-    s = lists(max_size=0).flatmap(just)
+    s = builds(list).flatmap(just)
     assert s.example() is not s.example()
 
 

--- a/tests/cover/test_one_of.py
+++ b/tests/cover/test_one_of.py
@@ -18,6 +18,7 @@
 from __future__ import division, print_function, absolute_import
 
 import hypothesis.strategies as st
+from hypothesis import given
 from tests.common.debug import assert_no_examples
 
 
@@ -25,3 +26,13 @@ def test_one_of_empty():
     e = st.one_of()
     assert e.is_empty
     assert_no_examples(e)
+
+
+@given(st.one_of(st.integers().filter(bool)))
+def test_one_of_filtered(i):
+    assert bool(i)
+
+
+@given(st.one_of(st.just(100).flatmap(st.integers)))
+def test_one_of_flatmapped(i):
+    assert i >= 100

--- a/tests/cover/test_reusable_values.py
+++ b/tests/cover/test_reusable_values.py
@@ -42,8 +42,8 @@ def reusable():
             allow_nan=st.booleans()
         ),
 
-        st.builds(st.just, st.lists(max_size=0)),
-        st.builds(st.sampled_from, st.lists(st.lists(max_size=0))),
+        st.builds(st.just, st.builds(list)),
+        st.builds(st.sampled_from, st.lists(st.builds(list))),
 
         st.lists(reusable).map(st.one_of),
         st.lists(reusable).map(lambda ls: st.tuples(*ls)),

--- a/tests/cover/test_sets.py
+++ b/tests/cover/test_sets.py
@@ -42,7 +42,7 @@ def test_sets_of_small_average_size():
     assert len(sets(integers(), average_size=1.0).example()) <= 10
 
 
-@given(sets(max_size=0))
+@given(sets(integers(), max_size=0))
 def test_empty_sets(x):
     assert x == set()
 

--- a/tests/cover/test_simple_collections.py
+++ b/tests/cover/test_simple_collections.py
@@ -33,9 +33,9 @@ from hypothesis.internal.compat import OrderedDict
 
 @pytest.mark.parametrize((u'col', u'strat'), [
     ((), tuples()),
-    ([], lists(max_size=0)),
-    (set(), sets(max_size=0)),
-    (frozenset(), frozensets(max_size=0)),
+    ([], lists(none(), max_size=0)),
+    (set(), sets(none(), max_size=0)),
+    (frozenset(), frozensets(none(), max_size=0)),
     ({}, fixed_dictionaries({})),
 ])
 def test_find_empty_collection_gives_empty(col, strat):
@@ -158,7 +158,7 @@ def test_minimize_dicts_with_incompatible_keys():
 
 
 def test_multiple_empty_lists_are_independent():
-    x = find(lists(lists(max_size=0)), lambda t: len(t) >= 2)
+    x = find(lists(lists(none(), max_size=0)), lambda t: len(t) >= 2)
     u, v = x
     assert u is not v
 

--- a/tests/cover/test_testdecorators.py
+++ b/tests/cover/test_testdecorators.py
@@ -522,6 +522,6 @@ def test_prints_notes_once_on_failure():
     assert lines.count('Hi there') == 1
 
 
-@given(lists(max_size=0))
+@given(lists(integers(), max_size=0))
 def test_empty_lists(xs):
     assert xs == []

--- a/tests/cover/test_type_lookup.py
+++ b/tests/cover/test_type_lookup.py
@@ -21,7 +21,8 @@ import pytest
 
 import hypothesis.strategies as st
 from hypothesis import given, infer
-from hypothesis.errors import InvalidArgument, ResolutionFailed
+from hypothesis.errors import InvalidArgument, ResolutionFailed, \
+    HypothesisDeprecationWarning
 from hypothesis.searchstrategy import types
 from hypothesis.internal.compat import PY2, integer_types
 
@@ -38,7 +39,7 @@ for thing in (getattr(st, name) for name in sorted(st._strategies)
             ex = thing(*([st.nothing()] * n)).example()
             types_with_core_strat.add(type(ex))
             break
-        except (TypeError, InvalidArgument):
+        except (TypeError, InvalidArgument, HypothesisDeprecationWarning):
             continue
 
 

--- a/tests/numpy/test_fill_values.py
+++ b/tests/numpy/test_fill_values.py
@@ -23,7 +23,7 @@ from tests.common.debug import minimal, find_any
 from hypothesis.extra.numpy import arrays
 
 
-@given(arrays(object, 100, st.lists(max_size=0)))
+@given(arrays(object, 100, st.builds(list)))
 def test_generated_lists_are_distinct(ls):
     assert len(set(map(id, ls))) == len(ls)
 


### PR DESCRIPTION
We have a [catalogue of style guide violations](https://github.com/HypothesisWorks/hypothesis-python/blob/master/guides/api-style.rst#a-catalogue-of-current-violations), of which allowing `elements=None` for empty collections is probably the most egregious (that's what the `nothing()` strategy is for!).  Part of issue #1155.

This pull deprecates passing `elements=None`, and makes the consequential changes to our test suite.