### PR TITLE
Deprecate average_size argument to lists(), sets(), etc

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,13 @@
+RELEASE_TYPE: minor
+
+This release deprecates the ``average_size`` argument to
+:func:`~hypothesis.strategies.lists` and other collection strategies.
+
+The ``average_size`` argument was treated as a hint about the distribution
+of examples from a strategy.  In turn, this is a remnant of earlier versions
+of Hypothesis with a different conceptual model and much weaker engine for
+generating and shrinking examples.  More recent strategies simply describe
+what constitutes a valid example, and let the internals handle the rest.
+
+``average_size`` is immediately discarded internally, so you can simply delete
+it wherever it appears in your tests without changing their behaviour at all.

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -2,12 +2,11 @@ RELEASE_TYPE: minor
 
 This release deprecates the ``average_size`` argument to
 :func:`~hypothesis.strategies.lists` and other collection strategies.
+You should simply delete it wherever it was used in your tests, as it
+no longer has any effect.
 
-The ``average_size`` argument was treated as a hint about the distribution
-of examples from a strategy.  In turn, this is a remnant of earlier versions
-of Hypothesis with a different conceptual model and much weaker engine for
-generating and shrinking examples.  More recent strategies simply describe
-what constitutes a valid example, and let the internals handle the rest.
-
-``average_size`` is immediately discarded internally, so you can simply delete
-it wherever it appears in your tests without changing their behaviour at all.
+In early versions of Hypothesis, the ``average_size`` argument was treated
+as a hint about the distribution of examples from a strategy.  Subsequent
+improvements to the conceptual model and the engine for generating and
+shrinking examples mean it is more effective to simply describe what
+constitutes a valid example, and let our internals handle the distribution.

--- a/src/hypothesis/extra/numpy.py
+++ b/src/hypothesis/extra/numpy.py
@@ -17,8 +17,6 @@
 
 from __future__ import division, print_function, absolute_import
 
-import math
-
 import numpy as np
 
 import hypothesis.strategies as st
@@ -132,7 +130,6 @@ class ArrayStrategy(SearchStrategy):
                 elements = cu.many(
                     data,
                     min_size=self.array_size, max_size=self.array_size,
-                    average_size=self.array_size
                 )
                 i = 0
                 while elements.more():
@@ -160,10 +157,6 @@ class ArrayStrategy(SearchStrategy):
             elements = cu.many(
                 data,
                 min_size=0, max_size=self.array_size,
-                # sqrt isn't chosen for any particularly principled reason. It
-                # just grows reasonably quickly but sublinearly, and for small
-                # arrays it represents a decent fraction of the array size.
-                average_size=math.sqrt(self.array_size),
             )
 
             needs_fill = np.full(self.array_size, True)

--- a/src/hypothesis/extra/numpy.py
+++ b/src/hypothesis/extra/numpy.py
@@ -17,6 +17,8 @@
 
 from __future__ import division, print_function, absolute_import
 
+import math
+
 import numpy as np
 
 import hypothesis.strategies as st
@@ -130,6 +132,7 @@ class ArrayStrategy(SearchStrategy):
                 elements = cu.many(
                     data,
                     min_size=self.array_size, max_size=self.array_size,
+                    average_size=self.array_size
                 )
                 i = 0
                 while elements.more():
@@ -157,6 +160,10 @@ class ArrayStrategy(SearchStrategy):
             elements = cu.many(
                 data,
                 min_size=0, max_size=self.array_size,
+                # sqrt isn't chosen for any particularly principled reason. It
+                # just grows reasonably quickly but sublinearly, and for small
+                # arrays it represents a decent fraction of the array size.
+                average_size=math.sqrt(self.array_size),
             )
 
             needs_fill = np.full(self.array_size, True)

--- a/src/hypothesis/extra/pandas/impl.py
+++ b/src/hypothesis/extra/pandas/impl.py
@@ -122,7 +122,6 @@ class ValueIndexStrategy(st.SearchStrategy):
 
         iterator = cu.many(
             data, min_size=self.min_size, max_size=self.max_size,
-            average_size=(self.min_size + self.max_size) / 2
         )
 
         while iterator.more():

--- a/src/hypothesis/extra/pandas/impl.py
+++ b/src/hypothesis/extra/pandas/impl.py
@@ -122,6 +122,7 @@ class ValueIndexStrategy(st.SearchStrategy):
 
         iterator = cu.many(
             data, min_size=self.min_size, max_size=self.max_size,
+            average_size=(self.min_size + self.max_size) / 2
         )
 
         while iterator.more():

--- a/src/hypothesis/internal/conjecture/utils.py
+++ b/src/hypothesis/internal/conjecture/utils.py
@@ -362,10 +362,16 @@ class many(object):
         add_stuff_to_result()
     """
 
-    def __init__(self, data, min_size, max_size, average_size):
+    def __init__(self, data, min_size, max_size):
         self.min_size = min_size
         self.max_size = max_size
         self.data = data
+        average_size = min(
+            # Should generate at least an increment above minimum,
+            max(min_size * 2, min_size + 5),
+            # but not more than the midpoint between minimum and maximum
+            0.5 * (min_size + max_size),
+        )
         self.stopping_value = 1 - 1.0 / (1 + average_size)
         self.count = 0
         self.rejections = 0

--- a/src/hypothesis/internal/conjecture/utils.py
+++ b/src/hypothesis/internal/conjecture/utils.py
@@ -362,16 +362,11 @@ class many(object):
         add_stuff_to_result()
     """
 
-    def __init__(self, data, min_size, max_size):
+    def __init__(self, data, min_size, max_size, average_size):
+        assert 0 <= min_size <= average_size <= max_size
         self.min_size = min_size
         self.max_size = max_size
         self.data = data
-        average_size = min(
-            # Should generate at least an increment above minimum,
-            max(min_size * 2, min_size + 5),
-            # but not more than the midpoint between minimum and maximum
-            0.5 * (min_size + max_size),
-        )
         self.stopping_value = 1 - 1.0 / (1 + average_size)
         self.count = 0
         self.rejections = 0

--- a/src/hypothesis/internal/validation.py
+++ b/src/hypothesis/internal/validation.py
@@ -131,10 +131,10 @@ def check_valid_sizes(min_size, average_size, max_size):
         from hypothesis._settings import note_deprecation
         note_deprecation(
             'The average_size argument has been disabled, is deprecated, '
-            'and will be removed in a future version.  The average_size hint '
-            'is a holdout from earlier versions where Hypothesis needed help '
-            'to generate data in sensible sizes, but subsequent improvements '
-            'have rendered it obsolete.'
+            'and will be removed in a future version.  Upgrades since '
+            'Hypothesis 1.x mean we can generate useful data without this '
+            'hint.  Please open an issue if the default distribution of '
+            'examples does not work for your tests.'
         )
 
     check_valid_size(min_size, 'min_size')

--- a/src/hypothesis/internal/validation.py
+++ b/src/hypothesis/internal/validation.py
@@ -130,11 +130,9 @@ def check_valid_sizes(min_size, average_size, max_size):
     if average_size is not None:
         from hypothesis._settings import note_deprecation
         note_deprecation(
-            'The average_size argument has been disabled, is deprecated, '
-            'and will be removed in a future version.  Upgrades since '
-            'Hypothesis 1.x mean we can generate useful data without this '
-            'hint.  Please open an issue if the default distribution of '
-            'examples does not work for your tests.'
+            'You should remove the average_size argument, because it is '
+            'deprecated and no longer has any effect.  Please open an issue '
+            'if the default distribution of examples does not work for you.'
         )
 
     check_valid_size(min_size, 'min_size')

--- a/src/hypothesis/internal/validation.py
+++ b/src/hypothesis/internal/validation.py
@@ -127,15 +127,16 @@ def check_valid_interval(lower_bound, upper_bound, lower_name, upper_name):
 
 @check_function
 def check_valid_sizes(min_size, average_size, max_size):
+    if average_size is not None:
+        from hypothesis._settings import note_deprecation
+        note_deprecation(
+            'The average_size argument has been disabled, is deprecated, '
+            'and will be removed in a future version.  The average_size hint '
+            'is a holdout from earlier versions where Hypothesis needed help '
+            'to generate data in sensible sizes, but subsequent improvements '
+            'have rendered it obsolete.'
+        )
+
     check_valid_size(min_size, 'min_size')
     check_valid_size(max_size, 'max_size')
-    check_valid_size(average_size, 'average_size')
     check_valid_interval(min_size, max_size, 'min_size', 'max_size')
-    check_valid_interval(average_size, max_size, 'average_size', 'max_size')
-    check_valid_interval(min_size, average_size, 'min_size', 'average_size')
-
-    if average_size == 0 and (max_size is None or max_size > 0):
-        raise InvalidArgument(
-            'Cannot have average_size=%r with non-zero max_size=%r' % (
-                average_size, max_size
-            ))

--- a/src/hypothesis/searchstrategy/collections.py
+++ b/src/hypothesis/searchstrategy/collections.py
@@ -67,6 +67,10 @@ class ListStrategy(SearchStrategy):
         self.min_size = min_size or 0
         self.max_size = max_size or float('inf')
         assert 0 <= min_size <= max_size
+        self.average_size = min(
+            max(self.min_size * 2, self.min_size + 5),
+            0.5 * (self.min_size + self.max_size),
+        )
         self.element_strategy = elements
 
     def calc_label(self):
@@ -101,6 +105,7 @@ class ListStrategy(SearchStrategy):
         elements = cu.many(
             data,
             min_size=self.min_size, max_size=self.max_size,
+            average_size=self.average_size
         )
         result = []
         while elements.more():
@@ -128,6 +133,7 @@ class UniqueListStrategy(ListStrategy):
         elements = cu.many(
             data,
             min_size=self.min_size, max_size=self.max_size,
+            average_size=self.average_size
         )
         seen = set()
         result = []

--- a/src/hypothesis/searchstrategy/collections.py
+++ b/src/hypothesis/searchstrategy/collections.py
@@ -62,15 +62,11 @@ class ListStrategy(SearchStrategy):
     """A strategy for lists which takes a strategy for its elements and the
     allowed lengths, and generates lists with the correct size and contents."""
 
-    def __init__(
-        self,
-        elements, average_size=50.0, min_size=0, max_size=float('inf')
-    ):
+    def __init__(self, elements, min_size=0, max_size=float('inf')):
         SearchStrategy.__init__(self)
-        self.average_size = average_size
         self.min_size = min_size or 0
         self.max_size = max_size or float('inf')
-        assert 0 <= min_size <= average_size <= max_size
+        assert 0 <= min_size <= max_size
         self.element_strategy = elements
 
     def calc_label(self):
@@ -105,7 +101,6 @@ class ListStrategy(SearchStrategy):
         elements = cu.many(
             data,
             min_size=self.min_size, max_size=self.max_size,
-            average_size=self.average_size
         )
         result = []
         while elements.more():
@@ -113,17 +108,16 @@ class ListStrategy(SearchStrategy):
         return result
 
     def __repr__(self):
-        return '%s(%r, min_size=%r, average_size=%r, max_size=%r)' % (
+        return '%s(%r, min_size=%r, max_size=%r)' % (
             self.__class__.__name__, self.element_strategy, self.min_size,
-            self.average_size, self.max_size
+            self.max_size
         )
 
 
 class UniqueListStrategy(ListStrategy):
 
-    def __init__(self, elements, min_size, max_size, average_size, key):
-        super(UniqueListStrategy, self).__init__(
-            elements, average_size, min_size, max_size)
+    def __init__(self, elements, min_size, max_size, key):
+        super(UniqueListStrategy, self).__init__(elements, min_size, max_size)
         self.key = key
 
     def do_draw(self, data):
@@ -134,7 +128,6 @@ class UniqueListStrategy(ListStrategy):
         elements = cu.many(
             data,
             min_size=self.min_size, max_size=self.max_size,
-            average_size=self.average_size
         )
         seen = set()
         result = []

--- a/src/hypothesis/searchstrategy/regex.py
+++ b/src/hypothesis/searchstrategy/regex.py
@@ -250,11 +250,11 @@ def regex_strategy(regex):
             return st.binary()
 
     if is_unicode:
-        base_padding_strategy = st.text(average_size=1)
+        base_padding_strategy = st.text()
         empty = st.just(u'')
         newline = st.just(u'\n')
     else:
-        base_padding_strategy = st.binary(average_size=1)
+        base_padding_strategy = st.binary()
         empty = st.just(b'')
         newline = st.just(b'\n')
 

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -505,9 +505,8 @@ def lists(
     None). If max_size is 0 then elements may be None and only the empty list
     will be drawn.
 
-    The average_size argument is deprecated.  This hint is a holdout from
-    earlier versions where Hypothesis needed help to generate data in sensible
-    sizes, but subsequent improvements have rendered it obsolete.
+    The average_size argument is deprecated.  Internal upgrades since
+    Hypothesis 1.x mean we no longer needed this hint to generate useful data.
 
     If unique is True (or something that evaluates to True), we compare direct
     object equality, as if unique_by was `lambda x: x`. This comparison only
@@ -822,9 +821,8 @@ def text(
 
     min_size and max_size have the usual interpretations.
 
-    The average_size argument is deprecated.  This hint is a holdout from
-    earlier versions where Hypothesis needed help to generate data in sensible
-    sizes, but subsequent improvements have rendered it obsolete.
+    The average_size argument is deprecated.  Internal upgrades since
+    Hypothesis 1.x mean we no longer needed this hint to generate useful data.
 
     Examples from this strategy shrink towards shorter strings, and with the
     characters in the text shrinking as per the alphabet strategy.
@@ -892,9 +890,8 @@ def binary(
 
     min_size and max_size have the usual interpretations.
 
-    The average_size argument is deprecated.  This hint is a holdout from
-    earlier versions where Hypothesis needed help to generate data in sensible
-    sizes, but subsequent improvements have rendered it obsolete.
+    The average_size argument is deprecated.  Internal upgrades since
+    Hypothesis 1.x mean we no longer needed this hint to generate useful data.
 
     Examples from this strategy shrink towards smaller strings and lower byte
     values.

--- a/tests/common/__init__.py
+++ b/tests/common/__init__.py
@@ -30,7 +30,7 @@ from hypothesis.strategies import integers, floats, just, one_of, \
     none, randoms, builds, fixed_dictionaries, recursive
 
 
-__all__ = ['small_verifier', 'standard_types', 'OrderedPair', 'TIME_INCREMENT']
+__all__ = ['standard_types', 'OrderedPair', 'TIME_INCREMENT']
 
 OrderedPair = namedtuple('OrderedPair', ('left', 'right'))
 
@@ -42,7 +42,7 @@ ordered_pair = integers().flatmap(
 
 def constant_list(strat):
     return strat.flatmap(
-        lambda v: lists(just(v), average_size=10),
+        lambda v: lists(just(v)),
     )
 
 
@@ -82,9 +82,8 @@ standard_types = [
     complex_numbers(),
     fractions(),
     decimals(),
-    lists(lists(booleans(), average_size=10), average_size=10),
-    lists(lists(booleans(), average_size=100)),
-    lists(floats(0.0, 0.0), average_size=1.0),
+    lists(lists(booleans())),
+    lists(floats(0.0, 0.0)),
     ordered_pair, constant_list(integers()),
     integers().filter(lambda x: abs(x) > 100),
     floats(min_value=-sys.float_info.max, max_value=sys.float_info.max),

--- a/tests/cover/test_argument_validation.py
+++ b/tests/cover/test_argument_validation.py
@@ -38,14 +38,9 @@ for ex in [
     e(st.text),
     e(st.binary)
 ]:
-    adjust(ex, average_size=10, max_size=9),
-    adjust(ex, average_size=10, min_size=11),
-
     adjust(ex, min_size=-1)
-    adjust(ex, average_size=-1)
     adjust(ex, max_size=-1)
     adjust(ex, min_size='no')
-    adjust(ex, average_size='no')
     adjust(ex, max_size='no')
 
 

--- a/tests/cover/test_direct_strategies.py
+++ b/tests/cover/test_direct_strategies.py
@@ -105,19 +105,14 @@ def fn_ktest(*fnkwargs):
     (ds.fractions, {'max_denominator': 0}),
     (ds.fractions, {'max_denominator': 1.5}),
     (ds.fractions, {'min_value': complex(1, 2)}),
-    (ds.lists, {'average_size': '5'}),
-    (ds.lists, {'average_size': float('nan')}),
     (ds.lists, {'min_size': 10, 'max_size': 9}),
     (ds.lists, {'min_size': -10, 'max_size': -9}),
     (ds.lists, {'max_size': -9}),
     (ds.lists, {'min_size': -10}),
-    (ds.lists, {'max_size': 10, 'average_size': 20}),
-    (ds.lists, {'min_size': 1.0, 'average_size': 0.5}),
+    (ds.lists, {'min_size': float('nan')}),
     (ds.lists, {'elements': 'hi'}),
     (ds.text, {'min_size': 10, 'max_size': 9}),
-    (ds.text, {'max_size': 10, 'average_size': 20}),
     (ds.binary, {'min_size': 10, 'max_size': 9}),
-    (ds.binary, {'max_size': 10, 'average_size': 20}),
     (ds.floats, {'min_value': float('nan')}),
     (ds.floats, {'min_value': '0'}),
     (ds.floats, {'max_value': '0'}),
@@ -185,8 +180,6 @@ def test_validates_keyword_arguments(fn, kwargs):
     (ds.lists, {'elements': ds.integers(), 'max_size': 5}),
     (ds.lists, {'elements': ds.booleans(), 'min_size': 5}),
     (ds.lists, {'elements': ds.booleans(), 'min_size': 5, 'max_size': 10}),
-    (ds.lists, {
-        'average_size': 20, 'elements': ds.booleans(), 'max_size': 25}),
     (ds.sets, {
         'min_size': 10, 'max_size': 10, 'elements': ds.integers(),
     }),
@@ -396,7 +389,7 @@ def test_iterables_without_elements_is_deprecated():
 
 
 @checks_deprecated_behaviour
-def test_lists_wit_max_size_no_elements_is_deprecated_and_error():
+def test_lists_with_max_size_no_elements_is_deprecated_and_error():
     with pytest.raises(InvalidArgument):
         ds.lists(max_size=1).example()
 
@@ -404,3 +397,8 @@ def test_lists_wit_max_size_no_elements_is_deprecated_and_error():
 @checks_deprecated_behaviour
 def test_empty_elements_with_max_size_is_deprecated():
     ds.lists(ds.nothing(), max_size=1).example()
+
+
+@checks_deprecated_behaviour
+def test_average_size_is_deprecated():
+    ds.lists(ds.integers(), average_size=1).example()

--- a/tests/cover/test_draw_example.py
+++ b/tests/cover/test_draw_example.py
@@ -32,4 +32,4 @@ def test_single_example(spec):
 @pytest.mark.parametrize(
     u'spec', standard_types, ids=list(map(repr, standard_types)))
 def test_list_example(spec):
-    lists(spec, average_size=2).example()
+    lists(spec).example()

--- a/tests/cover/test_flakiness.py
+++ b/tests/cover/test_flakiness.py
@@ -86,8 +86,8 @@ def single_bool_lists(draw):
 @example([False, False, False, True], [3], None,)
 @settings(max_examples=0)
 @given(
-    lists(booleans(), average_size=20) | single_bool_lists(),
-    lists(integers(1, 3), average_size=20), random_module())
+    lists(booleans()) | single_bool_lists(),
+    lists(integers(1, 3)), random_module())
 def test_failure_sequence_inducing(building, testing, rnd):
     buildit = iter(building)
     testit = iter(testing)

--- a/tests/cover/test_health_checks.py
+++ b/tests/cover/test_health_checks.py
@@ -119,7 +119,7 @@ def test_filtering_most_things_fails_a_health_check():
 
 
 def test_large_data_will_fail_a_health_check():
-    @given(st.lists(st.binary(min_size=1024, max_size=1024), average_size=100))
+    @given(st.lists(st.binary(min_size=1024)))
     @settings(database=None, buffer_size=1000)
     def test(x):
         pass

--- a/tests/cover/test_recursive.py
+++ b/tests/cover/test_recursive.py
@@ -24,10 +24,7 @@ from hypothesis import find, given
 from hypothesis.errors import InvalidArgument
 
 
-@given(
-    st.recursive(
-        st.booleans(), lambda x: st.lists(x, average_size=20),
-        max_leaves=10))
+@given(st.recursive(st.booleans(), st.lists, max_leaves=10))
 def test_respects_leaf_limit(xs):
     def flatten(x):
         if isinstance(x, list):

--- a/tests/cover/test_sets.py
+++ b/tests/cover/test_sets.py
@@ -17,16 +17,8 @@
 
 from __future__ import division, print_function, absolute_import
 
-import pytest
-
 from hypothesis import find, given, settings
-from hypothesis.errors import InvalidArgument
-from hypothesis.strategies import sets, lists, floats, randoms, integers
-
-
-def test_unique_lists_error_on_too_large_average_size():
-    with pytest.raises(InvalidArgument):
-        lists(integers(), unique=True, average_size=10, max_size=5).example()
+from hypothesis.strategies import sets, floats, randoms, integers
 
 
 @given(randoms())
@@ -36,10 +28,6 @@ def test_can_draw_sets_of_hard_to_find_elements(rnd):
     find(
         sets(rarebool, min_size=2), lambda x: True,
         random=rnd, settings=settings(database=None))
-
-
-def test_sets_of_small_average_size():
-    assert len(sets(integers(), average_size=1.0).example()) <= 10
 
 
 @given(sets(integers(), max_size=0))

--- a/tests/cover/test_simple_collections.py
+++ b/tests/cover/test_simple_collections.py
@@ -72,7 +72,7 @@ def test_minimizes_list_of_lists():
 
 def test_minimize_long_list():
     assert find(
-        lists(booleans(), average_size=100), lambda x: len(x) >= 70
+        lists(booleans(), min_size=50), lambda x: len(x) >= 70
     ) == [False] * 70
 
 

--- a/tests/cover/test_simple_numbers.py
+++ b/tests/cover/test_simple_numbers.py
@@ -158,14 +158,10 @@ def test_can_minimal_float_far_from_integral():
 
 def test_list_of_fractional_float():
     assert set(minimal(
-        lists(floats(), average_size=20),
+        lists(floats(), min_size=5),
         lambda x: len([t for t in x if t >= 1.5]) >= 5,
         timeout_after=60,
-    )) in (
-        set((1.5,)),
-        set((1.5, 2.0)),
-        set((2.0,)),
-    )
+    )).issubset([1.5, 2.0])
 
 
 def test_minimal_fractional_float():

--- a/tests/cover/test_simple_strings.py
+++ b/tests/cover/test_simple_strings.py
@@ -82,11 +82,9 @@ def test_does_not_generate_surrogates(t):
 
 
 def test_does_not_simplify_into_surrogates():
-    f = find(text(average_size=25.0), lambda x: x >= u'\udfff')
+    f = find(text(), lambda x: x >= u'\udfff')
     assert f == u'\ue000'
-    f = find(
-        text(average_size=25.0),
-        lambda x: len([t for t in x if t >= u'\udfff']) >= 10)
+    f = find(text(min_size=10), lambda x: sum(t >= u'\udfff' for t in x) >= 10)
     assert f == u'\ue000' * 10
 
 

--- a/tests/cover/test_stateful.py
+++ b/tests/cover/test_stateful.py
@@ -266,7 +266,7 @@ def test_multiple_rules_same_func():
 class GivenLikeStateMachine(GenericStateMachine):
 
     def steps(self):
-        return lists(booleans(), average_size=25.0)
+        return lists(booleans())
 
     def execute_step(self, step):
         assume(any(step))

--- a/tests/cover/test_testdecorators.py
+++ b/tests/cover/test_testdecorators.py
@@ -216,7 +216,7 @@ def test_removing_an_element_from_a_unique_list(xs, y):
 
 
 @fails
-@given(lists(integers(), average_size=25.0), data())
+@given(lists(integers(), min_size=2), data())
 def test_removing_an_element_from_a_non_unique_list(xs, data):
     y = data.draw(sampled_from(xs))
     xs.remove(y)

--- a/tests/cover/test_validation.py
+++ b/tests/cover/test_validation.py
@@ -133,17 +133,6 @@ def test_list_unique_and_unique_by_cannot_both_be_enabled():
     assert 'unique_by' in e.value.args[0]
 
 
-def test_an_average_size_must_be_positive():
-    with pytest.raises(InvalidArgument):
-        lists(integers(), average_size=0.0).example()
-    with pytest.raises(InvalidArgument):
-        lists(integers(), average_size=-1.0).example()
-
-
-def test_an_average_size_may_be_zero_if_max_size_is():
-    lists(integers(), average_size=0.0, max_size=0)
-
-
 def test_min_before_max():
     with pytest.raises(InvalidArgument):
         integers(min_value=1, max_value=0).validate()

--- a/tests/nocover/test_pretty_repr.py
+++ b/tests/nocover/test_pretty_repr.py
@@ -56,11 +56,10 @@ def builds_ignoring_invalid(target, *args, **kwargs):
 size_strategies = dict(
     min_size=st.integers(min_value=0, max_value=100) | st.none(),
     max_size=st.integers(min_value=0, max_value=100) | st.none(),
-    average_size=st.floats(min_value=0.0, max_value=100.0) | st.none()
 )
 
 
-values = st.integers() | st.text(average_size=2.0)
+values = st.integers() | st.text()
 
 
 Strategies = st.recursive(
@@ -77,10 +76,10 @@ Strategies = st.recursive(
         builds_ignoring_invalid(st.lists, x, **size_strategies),
         builds_ignoring_invalid(st.sets, x, **size_strategies),
         builds_ignoring_invalid(
-            lambda v: st.tuples(*v), st.lists(x, average_size=2.0)),
+            lambda v: st.tuples(*v), st.lists(x)),
         builds_ignoring_invalid(
             lambda v: st.one_of(*v),
-            st.lists(x, average_size=2.0, min_size=1)),
+            st.lists(x, min_size=1)),
         builds_ignoring_invalid(
             st.dictionaries, x, x,
             dict_class=st.sampled_from([dict, OrderedDict]),

--- a/tests/nocover/test_recursive.py
+++ b/tests/nocover/test_recursive.py
@@ -36,7 +36,7 @@ def test_can_generate_with_large_branching():
 
     xs = find(
         st.recursive(
-            st.integers(), lambda x: st.lists(x, average_size=50),
+            st.integers(), lambda x: st.lists(x, min_size=25),
             max_leaves=100),
         lambda x: isinstance(x, list) and len(flatten(x)) >= 50
     )
@@ -50,7 +50,7 @@ def test_can_generate_some_depth_with_large_branching():
         else:
             return 1
     xs = find(
-        st.recursive(st.integers(), lambda x: st.lists(x, average_size=100)),
+        st.recursive(st.integers(), st.lists),
         lambda x: depth(x) > 1
     )
     assert xs in ([0], [[]])
@@ -90,11 +90,7 @@ def test_drawing_many_near_boundary():
 @example(Random(-1363972488426139))
 @example(Random(-4))
 def test_can_use_recursive_data_in_sets(rnd):
-    nested_sets = st.recursive(
-        st.booleans(),
-        lambda js: st.frozensets(js, average_size=2.0),
-        max_leaves=10
-    )
+    nested_sets = st.recursive(st.booleans(), st.frozensets, max_leaves=10)
     find_any(nested_sets, random=rnd)
 
     def flatten(x):
@@ -137,8 +133,7 @@ def test_can_form_sets_of_recursive_data():
 def test_can_flatmap_to_recursive_data(rnd):
     stuff = st.lists(st.integers(), min_size=1).flatmap(
         lambda elts: st.recursive(
-            st.sampled_from(elts), lambda x: st.lists(x, average_size=25),
-            max_leaves=25
+            st.sampled_from(elts), st.lists, max_leaves=25
         ))
 
     def flatten(x):

--- a/tests/nocover/test_strategy_state.py
+++ b/tests/nocover/test_strategy_state.py
@@ -143,7 +143,7 @@ class HypothesisSpec(RuleBasedStateMachine):
 
     @rule(target=strategies, elements=strategies)
     def list_strategy(self, elements):
-        return lists(elements, average_size=AVERAGE_LIST_LENGTH)
+        return lists(elements)
 
     @rule(target=strategies, left=strategies, right=strategies)
     def or_strategy(self, left, right):

--- a/tests/quality/test_discovery_ability.py
+++ b/tests/quality/test_discovery_ability.py
@@ -131,7 +131,7 @@ test_can_produce_stripped_strings = define_test(
 )
 
 test_can_produce_multi_line_strings = define_test(
-    text(average_size=25.0), lambda x: u'\n' in x
+    text(), lambda x: u'\n' in x
 )
 
 test_can_produce_ascii_strings = define_test(
@@ -175,7 +175,7 @@ test_can_produce_floats_in_middle = define_test(
 )
 
 test_can_produce_long_lists = define_test(
-    lists(integers(), average_size=25.0), long_list
+    lists(integers()), long_list
 )
 
 test_can_produce_short_lists = define_test(
@@ -183,7 +183,7 @@ test_can_produce_short_lists = define_test(
 )
 
 test_can_produce_the_same_int_twice = define_test(
-    lists(integers(), average_size=25.0),
+    lists(integers()),
     lambda t: len(set(t)) < len(t)
 )
 
@@ -235,24 +235,24 @@ test_ints_can_occasionally_be_really_large = define_test(
 )
 
 test_mixing_is_sometimes_distorted = define_test(
-    lists(booleans() | tuples(), average_size=25.0), distorted,
+    lists(booleans() | tuples()), distorted,
     condition=lambda x: len(set(map(type, x))) == 2,
 )
 
 test_mixes_2_reasonably_often = define_test(
-    lists(booleans() | tuples(), average_size=25.0),
+    lists(booleans() | tuples()),
     lambda x: len(set(map(type, x))) > 1,
     condition=bool,
 )
 
 test_partial_mixes_3_reasonably_often = define_test(
-    lists(booleans() | tuples() | just(u'hi'), average_size=25.0),
+    lists(booleans() | tuples() | just(u'hi')),
     lambda x: 1 < len(set(map(type, x))) < 3,
     condition=bool,
 )
 
 test_mixes_not_too_often = define_test(
-    lists(booleans() | tuples(), average_size=25.0),
+    lists(booleans() | tuples()),
     lambda x: len(set(map(type, x))) == 1,
     condition=bool,
 )


### PR DESCRIPTION
The `average_size` argument was treated as a hint about the distribution of examples from a strategy.  In turn, this is a remnant of earlier versions of Hypothesis with a different conceptual model and much weaker engine for generating and shrinking examples.  More recent strategies simply describe what constitutes a valid example, and let the internals handle the rest.

Closes #1155.  See our API style guide or the linked issue for more details.  Notes:

- Behaviour of collection sizes has not changed if `average_size` was not specified before - the internal defaults were always overridden
- Once the argument is completely removed, backwards compatibility will remain trivial by use of keyword arguments (which are idiomatic now anyway)