### PR TITLE
Fix Numpy dtype test on big-endian platforms

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,8 @@
+RELEASE_TYPE: patch
+
+This patch fixes our tests for Numpy dtype strategies on big-endian platforms,
+where the strategy behaved correctly but the test assumed that the native byte
+order was little-endian.
+
+There is no user impact unless you are running our test suite on big-endian
+platforms.  Thanks to Graham Inggs for reporting :issue:`1164`.

--- a/tests/numpy/test_gen_data.py
+++ b/tests/numpy/test_gen_data.py
@@ -17,6 +17,8 @@
 
 from __future__ import division, print_function, absolute_import
 
+import sys
+
 import numpy as np
 import pytest
 from flaky import flaky
@@ -185,12 +187,14 @@ def test_can_turn_off_subarrays(dt):
         assert field.shape == ()
 
 
-@given(nps.integer_dtypes(endianness='>'))
-def test_can_restrict_endianness(dt):
-    if dt.itemsize == 1:
-        assert dt.byteorder == '|'
+@pytest.mark.parametrize('byteorder', ['<', '>'])
+@given(data=st.data())
+def test_can_restrict_endianness(data, byteorder):
+    dtype = data.draw(nps.integer_dtypes(byteorder, sizes=(16, 32, 64)))
+    if byteorder == ('<' if sys.byteorder == 'little' else '>'):
+        assert dtype.byteorder == '='
     else:
-        assert dt.byteorder == '>'
+        assert dtype.byteorder == byteorder
 
 
 @given(nps.integer_dtypes(sizes=8))


### PR DESCRIPTION
Closes #1164 (cc @ginggs).  I've made this a patch release because while it only really affects downstream distributors, they're also going to appreciate having a version number for the fix :smile: 