### PR TITLE
Use warnings-as-errors in our tests (yep, it finally works!)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.pyc
 venv*
 .cache
+.pytest_cache
 .hypothesis
 docs/_build
 *.egg-info

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch contains some internal refactoring so that we can run
+with warnings as errors in CI.

--- a/src/hypothesis/internal/coverage.py
+++ b/src/hypothesis/internal/coverage.py
@@ -57,7 +57,8 @@ IN_COVERAGE_TESTS = os.getenv('HYPOTHESIS_INTERNAL_COVERAGE') == 'true'
 
 
 if IN_COVERAGE_TESTS:
-    log = open('branch-check', 'w')
+    with open('branch-check', 'w'):
+        pass
     written = set()
 
     def record_branch(name, value):
@@ -65,11 +66,8 @@ if IN_COVERAGE_TESTS:
         if key in written:
             return
         written.add(key)
-        log.write(
-            json.dumps({'name': name, 'value': value})
-        )
-        log.write('\n')
-        log.flush()
+        with open('branch-check', 'a') as log:
+            log.write(json.dumps({'name': name, 'value': value}) + '\n')
 
     description_stack = []
 

--- a/tests/common/setup.py
+++ b/tests/common/setup.py
@@ -31,6 +31,9 @@ def run():
     filterwarnings('error')
     filterwarnings('ignore', category=ImportWarning)
     filterwarnings('ignore', category=FutureWarning, module='pandas._version')
+    # Only applies to Django 1.8, so this filter will go very soon!
+    filterwarnings('ignore', category=DeprecationWarning,
+                   module='tests.django.toystore.models')
 
     set_hypothesis_home_dir(mkdtemp())
 

--- a/tests/common/setup.py
+++ b/tests/common/setup.py
@@ -18,19 +18,19 @@
 from __future__ import division, print_function, absolute_import
 
 import os
-import warnings
 from tempfile import mkdtemp
+from warnings import filterwarnings
 
 from hypothesis import settings, unlimited
-from hypothesis.errors import HypothesisDeprecationWarning
 from hypothesis.configuration import set_hypothesis_home_dir
 from hypothesis.internal.charmap import charmap, charmap_file
 from hypothesis.internal.coverage import IN_COVERAGE_TESTS
 
 
 def run():
-    warnings.filterwarnings('error', category=UnicodeWarning)
-    warnings.filterwarnings('error', category=HypothesisDeprecationWarning)
+    filterwarnings('error')
+    filterwarnings('ignore', category=ImportWarning)
+    filterwarnings('ignore', category=FutureWarning, module='pandas._version')
 
     set_hypothesis_home_dir(mkdtemp())
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,9 @@ passenv=
     TOXENV
 setenv=
     ; Need to ignore warnings from pandas._version: https://github.com/pandas-dev/pandas/issues/19944
-    PYTHONWARNINGS={env:PYTHONWARNINGS:error::FutureWarning,default::FutureWarning:pandas._version}
+    ; Also ignore warnings in our build toolchain: pip, setuptools, tox, and virtualenv (site, distutils)
+    ; See https://github.com/tox-dev/tox/issues/436 for some discussion of this problem.
+    PYTHONWARNINGS={env:PYTHONWARNINGS:error,default::FutureWarning:pandas._version,default:::pip,default:::setuptools,default:::tox,default:::virtualenv,default:::site,default:::distutils}
     brief: HYPOTHESIS_PROFILE=speedy
 commands =
     full: bash scripts/basic-test.sh

--- a/tox.ini
+++ b/tox.ini
@@ -13,10 +13,6 @@ passenv=
     COVERAGE_FILE
     TOXENV
 setenv=
-    ; Need to ignore warnings from pandas._version: https://github.com/pandas-dev/pandas/issues/19944
-    ; Also ignore warnings in our build toolchain: pip, setuptools, tox, and virtualenv (site, distutils)
-    ; See https://github.com/tox-dev/tox/issues/436 for some discussion of this problem.
-    PYTHONWARNINGS={env:PYTHONWARNINGS:error,default::FutureWarning:pandas._version,default:::pip,default:::setuptools,default:::tox,default:::virtualenv,default:::site,default:::distutils}
     brief: HYPOTHESIS_PROFILE=speedy
 commands =
     full: bash scripts/basic-test.sh


### PR DESCRIPTION
Closes #1175.  

The key insight is that doing this via the `PYTHONWARNING` environment variable is simply too difficult - the whole testing stack leaks warnings like crazy, and essentially can't be fixed without dropping support for older versions of Python.  Instead, we can use `warnings.filterwarnings` in `conftest.py` - which only applies to code we run *during* our tests, but not in our tools.

I'm keen to write an article about this with @dchudz to evangelize this tactic :smile: 