### PR TITLE
Improve docs for min_satisfying_examples

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -3,3 +3,8 @@ RELEASE_TYPE: patch
 This patch fixes the `~hypothesis.settings.min_satisfying_examples` settings
 documentation, by explaining that example shrinking is tracked at the level
 of the underlying bytestream rather than the output value.
+
+The output from :func:`~hypothesis.find` in verbose mode has also been
+adjusted - see :ref:`the example session <verbose-output>` - to avoid
+duplicating lines when the example repr is constant, even if the underlying
+representation has been shrunken.

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch fixes the `~hypothesis.settings.min_satisfying_examples` settings
+documentation, by explaining that example shrinking is tracked at the level
+of the underlying bytestream rather than the output value.

--- a/docs/details.rst
+++ b/docs/details.rst
@@ -50,7 +50,7 @@ additional information you might need in your test.
 Test Statistics
 ---------------
 
-If you are using py.test you can see a number of statistics about the executed tests
+If you are using :pypi:`pytest` you can see a number of statistics about the executed tests
 by passing the command line argument ``--hypothesis-show-statistics``. This will include
 some general statistics about the test:
 
@@ -79,7 +79,7 @@ You would see:
 The final "Stopped because" line is particularly important to note: It tells you the
 setting value that determined when the test should stop trying new examples. This
 can be useful for understanding the behaviour of your tests. Ideally you'd always want
-this to be ``max_examples``.
+this to be :obj:`~hypothesis.settings.max_examples`.
 
 In some cases (such as filtered and recursive strategies) you will see events mentioned
 which describe some aspect of the data generation:
@@ -137,7 +137,7 @@ You will then see output like:
       * 18.84%, i mod 3 = 2
 
 Arguments to ``event`` can be any hashable type, but two events will be considered the same
-if they are the same when converted to a string with ``str``.
+if they are the same when converted to a string with :obj:`python:str`.
 
 ------------------
 Making assumptions
@@ -147,8 +147,8 @@ Sometimes Hypothesis doesn't give you exactly the right sort of data you want - 
 mostly of the right shape, but some examples won't work and you don't want to care about
 them. You *can* just ignore these by aborting the test early, but this runs the risk of
 accidentally testing a lot less than you think you are. Also it would be nice to spend
-less time on bad examples - if you're running 200 examples per test (the default) and
-it turns out 150 of those examples don't match your needs, that's a lot of wasted time.
+less time on bad examples - if you're running 100 examples per test (the default) and
+it turns out 70 of those examples don't match your needs, that's a lot of wasted time.
 
 .. autofunction:: hypothesis.assume
 
@@ -376,7 +376,7 @@ using :func:`@given <hypothesis.given>` with instance methods works: ``self``
 will be passed to the function as normal and not be parametrized over.
 
 The function returned by given has all the same arguments as the original
-test, minus those that are filled in by ``given``.
+test, minus those that are filled in by :func:`@given <hypothesis.given>`.
 
 -------------------------
 Custom function execution
@@ -387,6 +387,8 @@ examples.
 
 This lets you do things like set up and tear down around each example, run
 examples in a subprocess, transform coroutine tests into normal tests, etc.
+For example, :class:`~hypothesis.extra.django.TransactionTestCase` in the
+Django extra runs each example in a separate database transaction.
 
 The way this works is by introducing the concept of an executor. An executor
 is essentially a function that takes a block of code and run it. The default
@@ -397,7 +399,7 @@ executor is:
     def default_executor(function):
         return function()
 
-You define executors by defining a method execute_example on a class. Any
+You define executors by defining a method ``execute_example`` on a class. Any
 test methods on that class with :func:`@given <hypothesis.given>` used on them will use
 ``self.execute_example`` as an executor with which to run tests. For example,
 the following executor runs all its code twice:

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -90,14 +90,11 @@ and :func:`@given <hypothesis.given>`.
     >>> from hypothesis import find, settings, Verbosity
     >>> from hypothesis.strategies import lists, booleans
     >>> find(lists(integers()), any, settings=settings(verbosity=Verbosity.verbose))
-    Trying example []
+    Tried non-satisfying example []
     Found satisfying example [-1198601713, -67, 116, -29578]
     Shrunk example to [-67, 116, -29578]
     Shrunk example to [116, -29578]
-    Shrunk example to [116, -29578]
     Shrunk example to [-29578]
-    Shrunk example to [-115]
-    Shrunk example to [-115]
     Shrunk example to [-115]
     Shrunk example to [115]
     Shrunk example to [-57]

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -110,7 +110,7 @@ and :func:`@given <hypothesis.given>`.
     [1]
 
 The four levels are quiet, normal, verbose and debug. normal is the default,
-while in quiet Hypothesis will not print anything out, even the final
+while in quiet mode Hypothesis will not print anything out, not even the final
 falsifying example. debug is basically verbose but a bit more so. You probably
 don't want it.
 
@@ -119,7 +119,7 @@ You can also override the default by setting the environment variable
 setting ``HYPOTHESIS_VERBOSITY_LEVEL=verbose`` will run all your tests printing
 intermediate results and errors.
 
-If you are using ``pytest``, you may also need to
+If you are using :pypi:`pytest`, you may also need to
 :doc:`disable output capturing for passing tests <pytest:capture>`.
 
 -------------------------

--- a/src/hypothesis/_settings.py
+++ b/src/hypothesis/_settings.py
@@ -409,8 +409,8 @@ settings.define_setting(
     default=5,
     description="""
 Raise Unsatisfiable for any tests which do not produce at least this many
-values that pass all assume() calls and which have not exhaustively covered the
-search space.
+values that pass all :func:`hypothesis.assume` calls and which have not
+exhaustively covered the search space.
 """
 )
 

--- a/src/hypothesis/_settings.py
+++ b/src/hypothesis/_settings.py
@@ -411,6 +411,10 @@ settings.define_setting(
 Raise Unsatisfiable for any tests which do not produce at least this many
 values that pass all :func:`hypothesis.assume` calls and which have not
 exhaustively covered the search space.
+
+Note that examples are compared at the level of the underlying byte-stream -
+for example, :func:`~hypothesis.strategies.booleans` contains 256 unique
+examples at this level because it always uses one byte.
 """
 )
 

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -1111,6 +1111,7 @@ def find(specifier, condition, settings=None, random=None, database_key=None):
     random = random or new_random()
     successful_examples = [0]
     last_data = [None]
+    last_repr = [None]
 
     def template_condition(data):
         with BuildContext(data):
@@ -1127,22 +1128,19 @@ def find(specifier, condition, settings=None, random=None, database_key=None):
 
         if settings.verbosity == Verbosity.verbose:
             if not successful_examples[0]:
-                report(lambda: u'Trying example %s' % (
-                    nicerepr(result),
-                ))
+                report(
+                    u'Tried non-satisfying example %s' % (nicerepr(result),))
             elif success:
                 if successful_examples[0] == 1:
-                    report(lambda: u'Found satisfying example %s' % (
-                        nicerepr(result),
-                    ))
+                    last_repr[0] = nicerepr(result)
+                    report(u'Found satisfying example %s' % (last_repr[0],))
                     last_data[0] = data
                 elif (
                     sort_key(hbytes(data.buffer)) <
                     sort_key(last_data[0].buffer)
-                ):
-                    report(lambda: u'Shrunk example to %s' % (
-                        nicerepr(result),
-                    ))
+                ) and nicerepr(result) != last_repr[0]:
+                    last_repr[0] = nicerepr(result)
+                    report(u'Shrunk example to %s' % (last_repr[0],))
                     last_data[0] = data
         if success and not data.frozen:
             data.mark_interesting()

--- a/tests/cover/test_verbosity.py
+++ b/tests/cover/test_verbosity.py
@@ -82,7 +82,7 @@ def test_prints_initial_attempts_on_find():
                 return x not in seen
             find(integers(), not_first)
 
-    assert u'Trying example' in o.getvalue()
+    assert u'Tried non-satisfying example' in o.getvalue()
 
 
 def test_includes_intermediate_results_in_verbose_mode():


### PR DESCRIPTION
Closes #518, treating it as a docs issue (comparing arbitrary outputs is impractical, so our whole system is designed to work at the level of byte-streams).

In a similar vein, I've stopped `find()` from displaying this distinction when run in verbose mode (though of course it still happens in debug mode).  Finally, there are some more formatting and cross-reference fixes as usual.