### PR TITLE
make test_uses_provided_seed stop failing on the second run

### DIFF
--- a/tests/cover/test_testdecorators.py
+++ b/tests/cover/test_testdecorators.py
@@ -346,6 +346,7 @@ def test_uses_provided_seed():
 
     @given(integers())
     @seed(42)
+    @settings(database=None)
     def test_foo(x):
         pass
 


### PR DESCRIPTION
Before this, `test_uses_provided_seed` uses database examples when they're there, and fails with this warning:

```
================================================================================================= FAILURES =================================================================================================
_________________________________________________________________________________________ test_uses_provided_seed __________________________________________________________________________________________
Traceback (most recent call last):
  File "/Users/davidchudzicki/hypothesis-python/tests/cover/test_testdecorators.py", line 352, in test_uses_provided_seed
    test_foo()
  File "/Users/davidchudzicki/hypothesis-python/tests/cover/test_testdecorators.py", line 348, in test_foo
    @seed(42)
  File "/Users/davidchudzicki/hypothesis-python/src/hypothesis/core.py", line 1049, in wrapped_test
    state.run()
  File "/Users/davidchudzicki/hypothesis-python/src/hypothesis/core.py", line 749, in run
    'In future use of @seed will imply database=None in your '
  File "/Users/davidchudzicki/hypothesis-python/src/hypothesis/_settings.py", line 743, in note_deprecation
    warnings.warn(warning, stacklevel=3)
hypothesis.errors.HypothesisDeprecationWarning: In future use of @seed will imply database=None in your settings, but your test is currently using examples from the database. To get the future behaviour, update your settings for this test to include database=None.
```

This doesn't affect CI, but it's annoying when it fails locally on the 2nd run.

This addresses part of https://github.com/HypothesisWorks/hypothesis-python/issues/1174.