### PR TITLE
Improvements to behaviour of stateful testing

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,10 @@
+RELEASE_TYPE: patch
+
+This release improves the behaviour of  :doc:`stateful testing <stateful>`
+in two ways:
+
+* Previously some runs would run no steps (:issue:`376`). This should no longer
+  happen.
+* RuleBasedStateMachine tests which used bundles extensively would often shrink
+  terribly. This should now be significantly improved, though there is likely
+  a lot more room for improvement.

--- a/tests/cover/test_stateful.py
+++ b/tests/cover/test_stateful.py
@@ -679,3 +679,19 @@ def test_invariant_checks_initial_state():
 
     with pytest.raises(ValueError):
         run_state_machine_as_test(BadPrecondition)
+
+
+def test_always_runs_at_least_one_step():
+    class CountSteps(RuleBasedStateMachine):
+        def __init__(self):
+            super(CountSteps, self).__init__()
+            self.count = 0
+
+        @rule()
+        def do_something(self):
+            self.count += 1
+
+        def teardown(self):
+            assert self.count > 0
+
+    run_state_machine_as_test(CountSteps)


### PR DESCRIPTION
This fixes some issues I've been running into with my experiments testing [sympy](https://github.com/sympy/sympy/) with the stateful testing.

Fixes #376. 

Unfortunately the "Improves shrinking" aspect of it is very hard to demonstrate in a test so I currently haven't. 😞 I can report that it significantly improves shrinking in my particular use case and didn't make any of the current tests fail, but that's not very satisfying. OTOH the improvements to shrinking largely consisted of deleting code and noticing that all the tests still pass, so I don't feel too bad about that.

## Background

Man there was some weird nonsense in how we were getting values out of bundles. I'm not 100% sure what I was thinking at the time, but I'm pretty sure I didn't validate my belief that it actually helped.

We were essentially shuffling the values in bundles on access, and every now and then some more just for the lulz. This was basically adversarially bad for the shrinker - it meant that it was very hard to ever get rid of any value we had ever generated, because it changed the interpretation of everything that came after. #1187 is still a problem for the new, simpler, approach, but it's a much smaller part of the problem we were actually having than I thought it was!