### PR TITLE
Improve printing of stateful testing

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,9 @@
+RELEASE_TYPE: patch
+
+This release improves the output of failures with
+:ref:`rule based stateful testing <rulebasedstateful>` in two ways:
+
+* The output from it is now usually valid Python code.
+* When the same value has two different names because it belongs to two different
+  bundles, it will now display with the name associated with the correct bundle
+  for a rule argument where it is used.

--- a/docs/stateful.rst
+++ b/docs/stateful.rst
@@ -148,7 +148,7 @@ we would see the following output when run under pytest:
 
     AssertionError: assert set() == {b''}
 
-    ------------ Hypothesis ------------ 
+    ------------ Hypothesis ------------
 
     state = DatabaseComparison()
     v1 = state.k(k=b'')

--- a/tests/cover/test_stateful.py
+++ b/tests/cover/test_stateful.py
@@ -250,7 +250,8 @@ def test_bad_machines_fail(machine):
         raise
     v = o.getvalue()
     print_unicode(v)
-    assert len(v.splitlines()) <= 50
+    steps = [l for l in v.splitlines() if 'Step ' in l or 'state.' in l]
+    assert 1 <= len(steps) <= 50
 
 
 def test_multiple_rules_same_func():


### PR DESCRIPTION
This fixes another long-standing annoyance: Almost the first thing you want to do with a stateful testing failure is turn it into a program that reproduces that failure. Why not make the computer do that for you??

Output from stateful testing now looks like:

```python
state = DatabaseComparison()
v1 = state.k(k=b'')
v2 = state.v(v=v1)
state.save(k=v1, v=v2)
state.values_agree(k=v1)
state.teardown()
```

Isn't that better?

Note: Currently we don't show invariants in this output. We probably should but there are a bunch of questions (showing them everywhere creates a lot of clutter. Do we show them only where they failed? What if there are side effects so that the invariant *should* have been checked before hand? What if the invariant has a precondition? etc.) that I decided not to try to resolve that issue in this PR.

While I was in the area I replaced our (my) terrible awful intro example to rule based stateful testing  in the documentation with one that will hopefully make more sense to people.