### PR TITLE
Add Code of Conduct line against jokes about violence

### DIFF
--- a/docs/community.rst
+++ b/docs/community.rst
@@ -33,7 +33,7 @@ While it is impossible to enumerate everything that is unkind, disrespectful or 
 4. It's OK not to *want* to know something. If you think someone's question is fundamentally flawed, you should still ask permission before explaining what they should actually be asking.
 5. Note that "I was just joking" is not a valid defence.
 6. Don't suggest violence as a response to things, e.g. "People who do/think X should be Y-ed".
-   Even when it's obvious hyperbole and it's very clear that no actual threat is meant (which is usually the case),
+   Even if you think it is obvious hyperbole and that it's very clear that no actual threat is meant,
    it still contributes to a culture that makes people feel unsafe.
 
 

--- a/docs/community.rst
+++ b/docs/community.rst
@@ -32,6 +32,10 @@ While it is impossible to enumerate everything that is unkind, disrespectful or 
 3. It's OK not to know things. Everybody was a beginner once, nobody should be made to feel bad for it.
 4. It's OK not to *want* to know something. If you think someone's question is fundamentally flawed, you should still ask permission before explaining what they should actually be asking.
 5. Note that "I was just joking" is not a valid defence.
+6. Don't suggest violence as a response to things, e.g. "People who do/think X should be Y-ed".
+   Even when it's obvious hyperbole and it's very clear that no actual threat is meant (which is usually the case),
+   it still contributes to a culture that makes people feel unsafe.
+
 
 What happens when this goes wrong?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This came up (in a fairly benign way! Nobody was threatened, and clearly no harm was meant) in a recent pull request, and I've had to ask people to similarly avoid such things on IRC a few times.

Given this is as far as I can recall the only remotely code of conduct shaped thing I've ever had to enforce, it seems worth making it explicit...