### PR TITLE
Block install with EOL Django 1.8.x, as of 2018-04-01

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,6 @@ env:
         - TASK=check-faker070
         - TASK=check-faker-latest
         - TASK=check-django20
-        - TASK=check-django18
         - TASK=check-django111
         - TASK=check-pandas19
         - TASK=check-pandas20

--- a/Makefile
+++ b/Makefile
@@ -161,16 +161,13 @@ check-faker070: $(TOX)
 check-faker-latest: $(TOX)
 	$(TOX) --recreate -e faker-latest
 
-check-django18: $(TOX)
-	$(TOX) --recreate -e django18
-
 check-django111: $(TOX)
 	$(TOX) --recreate -e django111
 
 check-django20: $(BEST_PY3) $(TOX)
 	$(TOX) --recreate -e django20
 
-check-django: check-django18 check-django111 check-django20
+check-django: check-django111 check-django20
 
 check-pandas19: $(TOX)
 	$(TOX) --recreate -e pandas19

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: minor
+
+This release removes support for Django 1.8, which reached end of life on
+2018-04-01.  `You can see Django's release and support schedule
+`on the Django Project website <https://www.djangoproject.com/download/#supported-versions>`_.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -25,7 +25,7 @@ information to the contrary.
 3.52.3 - 2018-04-01
 -------------------
 
-This patch fixes the `~hypothesis.settings.min_satisfying_examples` settings
+This patch fixes the :obj:`~hypothesis.settings.min_satisfying_examples` settings
 documentation, by explaining that example shrinking is tracked at the level
 of the underlying bytestream rather than the output value.
 

--- a/setup.py
+++ b/setup.py
@@ -52,22 +52,15 @@ with open(local_file('src/hypothesis/version.py')) as o:
 assert __version__ is not None
 
 
-# We only support the releases of Django that are supported by the Django
-# core team.  See https://www.djangoproject.com/download/#supported-versions
-django_pin = 'django>=1.8'
-if setuptools_version >= (8, 0):
-    # New versions of setuptools allow us to set very precise pins; older
-    # versions of setuptools are coarser.  We special-case this so users with
-    # old tools can still install an sdist from PyPI.
-    django_pin += ',!=1.9.*,!=1.10.*'
-
 extras = {
     'datetime':  ['pytz'],
     'pytz':  ['pytz'],
     'fakefactory': ['Faker>=0.7'],
     'numpy': ['numpy>=1.9.0'],
     'pytest': ['pytest>=2.8.0'],
-    'django': ['pytz', django_pin],
+    # We only support Django versions with upstream support - see
+    # https://www.djangoproject.com/download/#supported-versions
+    'django': ['pytz', 'django>=1.11'],
 }
 
 extras['faker'] = extras['fakefactory']

--- a/tests/common/setup.py
+++ b/tests/common/setup.py
@@ -31,9 +31,6 @@ def run():
     filterwarnings('error')
     filterwarnings('ignore', category=ImportWarning)
     filterwarnings('ignore', category=FutureWarning, module='pandas._version')
-    # Only applies to Django 1.8, so this filter will go very soon!
-    filterwarnings('ignore', category=DeprecationWarning,
-                   module='tests.django.toystore.models')
 
     set_hypothesis_home_dir(mkdtemp())
 

--- a/tox.ini
+++ b/tox.ini
@@ -103,14 +103,6 @@ commands =
     python -m pytest tests/pandas -n2
 
 
-[testenv:django18]
-setenv=
-  PYTHONWARNINGS={env:PYTHONWARNINGS:}
-commands =
-    pip install .[pytz]
-    pip install django~=1.8.18
-    python -m tests.django.manage test tests.django
-
 [testenv:django111]
 commands =
     pip install .[pytz]


### PR DESCRIPTION
Django 1.8 will reach end of life tomorrow, so this patch removes our support for it.  Yay simpler build and install!