### PR TITLE
Various improvements to the database setting

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,15 @@
+RELEASE_TYPE: minor
+
+This release includes several improvements to the handling of the
+:obj:`~hypothesis.settings.database` setting.
+
+- The :obj:`~hypothesis.settings.database_file` setting was a historical
+  artefact, and you should just use :obj:`~hypothesis.settings.database`
+  directly.
+- The :envvar:`HYPOTHESIS_DATABASE_FILE` environment variable is
+  deprecated, in favor of :meth:`~hypothesis.settings.load_profile` and
+  the :obj:`~hypothesis.settings.database` setting.
+- If you have not configured the example database at all and the default
+  location is not usable (due to e.g. permissions issues), Hypothesis
+  will fall back to an in-memory database.  This is not persisted between
+  sessions, but means that the defaults work on read-only filesystems.

--- a/docs/database.rst
+++ b/docs/database.rst
@@ -24,13 +24,17 @@ File locations
 The default storage format is as a fairly opaque directory structure. Each test
 corresponds to a directory, and each example to a file within that directory.
 The standard location for it is ``.hypothesis/examples`` in your current working
-directory. You can override this by setting the :obj:`~hypothesis.settings.database_file`
-setting, or with the ``HYPOTHESIS_DATABASE_FILE`` environment variable.
+directory. You can override this by setting the
+:obj:`~hypothesis.settings.database` setting.
 
 There is also a legacy sqlite3 based format. This is mostly still supported for
 compatibility reasons, and support will be dropped in some future version of
 Hypothesis. If you use a database file name ending in .db, .sqlite or .sqlite3
 that format will be used instead.
+
+If you have not configured a database and the default location is unusable
+(e.g. because you do not have read/write permission), Hypothesis will issue
+a warning and then fall back to an in-memory database.
 
 --------------------------------------------
 Upgrading Hypothesis and changing your tests

--- a/src/hypothesis/_settings.py
+++ b/src/hypothesis/_settings.py
@@ -135,11 +135,7 @@ class settings(settingsMeta('settings', (object,), {})):
         else:
             raise AttributeError('settings has no attribute %s' % (name,))
 
-    def __init__(
-            self,
-            parent=None,
-            **kwargs
-    ):
+    def __init__(self, parent=None, **kwargs):
         self._construction_complete = False
         self._database = kwargs.pop('database', not_set)
         database_file = kwargs.get('database_file', not_set)
@@ -161,7 +157,7 @@ class settings(settingsMeta('settings', (object,), {})):
         for name, value in kwargs.items():
             if name not in all_settings:
                 raise InvalidArgument(
-                    'Invalid argument %s' % (name,))
+                    'Invalid argument: %r is not a valid setting' % (name,))
             setattr(self, name, value)
         self.storage = threading.local()
         self._construction_complete = True
@@ -237,7 +233,7 @@ class settings(settingsMeta('settings', (object,), {})):
 
     @classmethod
     def define_setting(
-        cls, name, description, default, options=None, deprecation=None,
+        cls, name, description, default, options=None,
         validator=None, show_default=True, future_default=not_set,
         deprecation_message=None,
     ):

--- a/src/hypothesis/_settings.py
+++ b/src/hypothesis/_settings.py
@@ -32,9 +32,8 @@ from enum import Enum, IntEnum, unique
 import attr
 
 from hypothesis.errors import InvalidArgument, HypothesisDeprecationWarning
-from hypothesis.configuration import hypothesis_home_dir
 from hypothesis.internal.compat import text_type
-from hypothesis.utils.conventions import UniqueIdentifier, not_set
+from hypothesis.utils.conventions import UniqueIdentifier, infer, not_set
 from hypothesis.internal.reflection import proxies, \
     get_pretty_function_description
 from hypothesis.internal.validation import try_convert
@@ -503,10 +502,7 @@ def _validate_database(db):
 
 settings.define_setting(
     'database',
-    default=lambda: _validate_database(
-        os.getenv('HYPOTHESIS_DATABASE_FILE') or
-        os.path.join(hypothesis_home_dir(), 'examples')
-    ),
+    default=lambda: _validate_database(infer),
     show_default=False,
     description="""
 An instance of hypothesis.database.ExampleDatabase that will be

--- a/src/hypothesis/_settings.py
+++ b/src/hypothesis/_settings.py
@@ -33,7 +33,7 @@ import attr
 
 from hypothesis.errors import InvalidArgument, HypothesisDeprecationWarning
 from hypothesis.internal.compat import text_type
-from hypothesis.utils.conventions import UniqueIdentifier, infer, not_set
+from hypothesis.utils.conventions import UniqueIdentifier, not_set
 from hypothesis.internal.reflection import proxies, \
     get_pretty_function_description
 from hypothesis.internal.validation import try_convert
@@ -494,9 +494,9 @@ warnings.simplefilter('error', HypothesisDeprecationWarning).
 
 def _validate_database(db, __from_db_file=False):
     from hypothesis.database import ExampleDatabase
-    if db is None or db is not_set or isinstance(db, ExampleDatabase):
+    if db is None or isinstance(db, ExampleDatabase):
         return db
-    if __from_db_file or db is infer:
+    if __from_db_file or db is not_set:
         return ExampleDatabase(db)
     raise InvalidArgument(
         'Arguments to the database setting must be None or an instance of '
@@ -508,7 +508,7 @@ def _validate_database(db, __from_db_file=False):
 
 settings.define_setting(
     'database',
-    default=lambda: _validate_database(infer),
+    default=lambda: _validate_database(not_set),
     show_default=False,
     description="""
 An instance of hypothesis.database.ExampleDatabase that will be

--- a/src/hypothesis/database.py
+++ b/src/hypothesis/database.py
@@ -40,9 +40,9 @@ def _db_for_path(path=None):
     if path is infer:
         path = os.getenv('HYPOTHESIS_DATABASE_FILE')
         if path is not None:  # pragma: no cover
-            # Note: for Hypothesis 4, there should still be a deprecation
-            # warning (noting that the var is ignored) to ease debugging for
-            # anyone using it and migrating to a new version.
+            # Note: we should retain an explicit deprecation warning for a
+            # further period after this is removed, to ease debugging for
+            # anyone migrating to a new version.
             note_deprecation(
                 'The $HYPOTHESIS_DATABASE_FILE environment variable is '
                 'deprecated, and will be ignored by a future version of '

--- a/src/hypothesis/database.py
+++ b/src/hypothesis/database.py
@@ -30,14 +30,14 @@ from hypothesis._settings import note_deprecation
 from hypothesis.configuration import storage_directory
 from hypothesis.internal.compat import FileNotFoundError, hbytes, \
     b64decode, b64encode
-from hypothesis.utils.conventions import infer
+from hypothesis.utils.conventions import not_set
 
 sqlite3 = None
 SQLITE_PATH = re.compile(r"\.\(db|sqlite|sqlite3\)$")
 
 
 def _db_for_path(path=None):
-    if path is infer:
+    if path is not_set:
         path = os.getenv('HYPOTHESIS_DATABASE_FILE')
         if path is not None:  # pragma: no cover
             # Note: we should retain an explicit deprecation warning for a

--- a/src/hypothesis/database.py
+++ b/src/hypothesis/database.py
@@ -20,19 +20,48 @@ from __future__ import division, print_function, absolute_import
 import os
 import re
 import binascii
+import warnings
 import threading
 from hashlib import sha1
 from contextlib import contextmanager
 
+from hypothesis.errors import HypothesisWarning
 from hypothesis._settings import note_deprecation
+from hypothesis.configuration import storage_directory
 from hypothesis.internal.compat import FileNotFoundError, hbytes, \
     b64decode, b64encode
+from hypothesis.utils.conventions import infer
 
 sqlite3 = None
 SQLITE_PATH = re.compile(r"\.\(db|sqlite|sqlite3\)$")
 
 
 def _db_for_path(path=None):
+    if path is infer:
+        path = os.getenv('HYPOTHESIS_DATABASE_FILE')
+        if path is not None:  # pragma: no cover
+            # Note: for Hypothesis 4, there should still be a deprecation
+            # warning (noting that the var is ignored) to ease debugging for
+            # anyone using it and migrating to a new version.
+            note_deprecation(
+                'The $HYPOTHESIS_DATABASE_FILE environment variable is '
+                'deprecated, and will be ignored by a future version of '
+                'Hypothesis.  Configure your database location via a '
+                'settings profile instead.'
+            )
+            return _db_for_path(path)
+        # Note: storage_directory attempts to create the dir in question, so
+        # if os.access fails there *must* be a fatal permissions issue.
+        path = storage_directory('examples')
+        if os.access(path, os.R_OK | os.W_OK | os.X_OK):
+            return _db_for_path(path)
+        else:  # pragma: no cover
+            warnings.warn(HypothesisWarning(
+                'The database setting is not configured, and the default '
+                'location is unusable - falling back to an in-memory '
+                'database for this session.  path=%r' % (path,)
+            ))
+            return InMemoryExampleDatabase()
     if path in (None, ':memory:'):
         return InMemoryExampleDatabase()
     path = str(path)

--- a/tests/cover/test_duplication.py
+++ b/tests/cover/test_duplication.py
@@ -38,6 +38,7 @@ def test_does_not_duplicate_blocks(n):
     counts = Counter()
 
     @given(Blocks(n))
+    @settings(database=None)
     def test(b):
         counts[b] += 1
     test()

--- a/tests/cover/test_settings.py
+++ b/tests/cover/test_settings.py
@@ -229,6 +229,15 @@ def test_can_have_none_database():
     assert settings(database=None).database is None
 
 
+@pytest.mark.parametrize('db', [None, ExampleDatabase(':memory:')])
+def test_database_type_must_be_ExampleDatabase(db):
+    with settings(database=db):
+        settings_property_db = settings.database
+        with pytest.raises(InvalidArgument):
+            settings(database='.hypothesis/examples')
+        assert settings.database is settings_property_db
+
+
 @checks_deprecated_behaviour
 def test_can_have_none_database_file():
     assert settings(database_file=None).database is None

--- a/tests/cover/test_settings.py
+++ b/tests/cover/test_settings.py
@@ -229,10 +229,12 @@ def test_can_have_none_database():
     assert settings(database=None).database is None
 
 
+@checks_deprecated_behaviour
 def test_can_have_none_database_file():
     assert settings(database_file=None).database is None
 
 
+@checks_deprecated_behaviour
 def test_can_override_database_file():
     f = mkdtemp()
     x = settings(database_file=f)

--- a/tests/cover/test_shrinking_limits.py
+++ b/tests/cover/test_shrinking_limits.py
@@ -33,6 +33,6 @@ def test_max_shrinks():
 
     find(
         st.binary(min_size=100, max_size=100), tracktrue,
-        settings=settings(max_shrinks=1)
+        settings=settings(max_shrinks=1, database=None)
     )
     assert len(seen) == 2

--- a/tests/cover/test_verbosity.py
+++ b/tests/cover/test_verbosity.py
@@ -60,7 +60,7 @@ def test_does_not_log_in_quiet_mode():
 
 def test_includes_progress_in_verbose_mode():
     with capture_verbosity(Verbosity.verbose) as o:
-        with settings(verbosity=Verbosity.verbose):
+        with settings(verbosity=Verbosity.verbose, database=None):
             find(lists(integers()), lambda x: sum(x) >= 1000000)
 
     out = o.getvalue()

--- a/tests/cover/test_weird_settings.py
+++ b/tests/cover/test_weird_settings.py
@@ -19,8 +19,10 @@ from __future__ import division, print_function, absolute_import
 
 from hypothesis import given, settings
 from hypothesis import strategies as st
+from tests.common.utils import checks_deprecated_behaviour
 
 
+@checks_deprecated_behaviour
 def test_setting_database_to_none_disables_the_database():
     @given(st.booleans())
     @settings(database_file=None)


### PR DESCRIPTION
- The `database_file` setting is deprecated in favor of the `database` setting, which is now implemented in the normal way (without otherwise changing their behavior).  Closes #175.
- From the same issue, `$HYPOTHESIS_DATABASE_FILE` is deprecated in favor of the settings profile system.
- If the `database` setting is using the default value (ie `.hypothesis/examples/`) and this directory is unusable due to e.g. permissions problems, we now issue a warning and fall back to an in-memory database (but *only* if the path was not set by the user).  Closes #242 and closes #768 - while it is still possible to have path-related problems, they will now be the user's responsibility.
- Added `settings(database=None)` to tests that fail if there are saved examples, to ease local development.