### PR TITLE
Allow relative error of floating-point epsilon in cathetus tests

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch relaxes constraints on the expected values returned
+by the standard library function :func:`hypot` and the internal
+helper function :func:`~hypotheses.internal.cathetus`, this to
+fix near-exact test-failures on some 32-bit systems.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,16 +10,20 @@ environment:
       secure: TpmpMHwgS4xxcbbzROle2xyb3i+VPP8cT5ZL4dF/UrA=
 
   matrix:
+    - PYTHON: "C:\\Python27"
+      PYTHON_VERSION: "2.7.14"
+      PYTHON_ARCH: "32"
+
     - PYTHON: "C:\\Python27-x64"
-      PYTHON_VERSION: "2.7.13"
+      PYTHON_VERSION: "2.7.14"
       PYTHON_ARCH: "64"
 
-    - PYTHON: "C:\\Python35-x64"
-      PYTHON_VERSION: "3.5.3"
-      PYTHON_ARCH: "64"
+    - PYTHON: "C:\\Python36"
+      PYTHON_VERSION: "3.6.5"
+      PYTHON_ARCH: "32"
 
     - PYTHON: "C:\\Python36-x64"
-      PYTHON_VERSION: "3.6.1"
+      PYTHON_VERSION: "3.6.5"
       PYTHON_ARCH: "64"
 
 # Appveyor "helpfully" ignores skip directives in the commit message body

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -55,7 +55,7 @@ Thanks to J.J. Green for this feature.
 -------------------
 
 This release removes support for Django 1.8, which reached end of life on
-2018-04-01.  `You can see Django's release and support schedule
+2018-04-01.  You can see Django's release and support schedule
 `on the Django Project website <https://www.djangoproject.com/download/#supported-versions>`_.
 
 -------------------
@@ -111,7 +111,7 @@ in any order, though you should only do so once each.
 Applying :func:`@given <hypothesis.given>` twice was already deprecated, and
 applying :func:`@settings(...) <hypothesis.settings>` twice is deprecated in
 this release and will become an error in a future version. Neither could ever
-be used twice to good effect.)
+be used twice to good effect.
 
 Using :func:`@settings(...) <hypothesis.settings>` as the sole decorator on
 a test is completely pointless, so this common usage error will become an

--- a/src/hypothesis/internal/cathetus.py
+++ b/src/hypothesis/internal/cathetus.py
@@ -32,6 +32,10 @@ def cathetus(h, a):
     (NaNs and infinities) is designed to be as consistent as possible with
     the C99 hypot() specifications.
 
+    This function relies on the system ``sqrt`` function and so, like it,
+    may be inaccurate up to a relative error of (around) floating-point
+    epsilon.
+
     Based on the C99 implementation https://github.com/jjgreen/cathetus
     """
     if isnan(h):

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -1592,6 +1592,10 @@ def complex_numbers(min_magnitude=0, max_magnitude=None,
     is an error to enable ``allow_nan``.  If ``max_magnitude`` is finite,
     it is an error to enable ``allow_infinity``.
 
+    The magnitude contraints are respected up to a relative error
+    of (around) floating-point epsilon, due to implementation via
+    the system ``sqrt`` function.
+
     Examples from this strategy shrink by shrinking their real and
     imaginary parts, as :func:`~hypothesis.strategies.floats`.
 

--- a/tests/cover/test_cathetus.py
+++ b/tests/cover/test_cathetus.py
@@ -19,6 +19,7 @@ from __future__ import division, print_function, absolute_import
 
 import sys
 import math
+from sys import float_info
 
 import pytest
 
@@ -94,8 +95,8 @@ def test_cathetus_infinite(h, a):
     (0, 0, 0),
     (1, 0, 1),
 ])
-def test_cathetus_exact(h, a, b):
-    assert cathetus(h, a) == b
+def test_cathetus_signs(h, a, b):
+    assert abs(cathetus(h, a) - b) <= abs(b) * float_info.epsilon
 
 
 @pytest.mark.parametrize('a,b,h', [
@@ -148,5 +149,5 @@ def test_cathetus_exact(h, a, b):
     (68, 285, 293),
 ])
 def test_pythagorean_triples(a, b, h):
-    assert math.hypot(a, b) == h, 'defective pythagoran triple'
-    assert cathetus(h, a) == b
+    assert abs(math.hypot(a, b) - h) <= abs(h) * float_info.epsilon
+    assert abs(cathetus(h, a) - b) <= abs(b) * float_info.epsilon


### PR DESCRIPTION
Fixes #1207, non-exact results on [32-bit Windows](https://ci.appveyor.com/project/conda-forge/hypothesis-feedstock/build/1.0.172/job/wy4p8vutiirr676c).  As a library function `hypot()` is permitted epsilon relative error, I found that exact results were obtained on my 64-bit glibc machine and so imposed these more stringent requirements in the tests. Oops.

I've made the same change for calls to `cathetus()`, since that has the same permitted relative error (via `sqrt()`, _except_ for the subnormal tests, since those are essentially integer calculations.