### PR TITLE
The code of conduct is not just for the Python community

### DIFF
--- a/CODE_OF_CONDUCT.rst
+++ b/CODE_OF_CONDUCT.rst
@@ -1,0 +1,47 @@
+---------------
+Code of conduct
+---------------
+
+Hypothesis's community is an inclusive space, and everyone in it is expected to abide by a code of conduct.
+This applies in issues, pull requests, etc. as well as in the various Hypothesis community spaces.
+
+At the high level the code of conduct goes like this:
+
+1. Be kind
+2. Be respectful
+3. Be helpful
+
+While it is impossible to enumerate everything that is unkind, disrespectful or unhelpful, here are some specific things that are definitely against the code of conduct:
+
+1. -isms and -phobias (e.g. racism, sexism, transphobia and homophobia) are unkind, disrespectful *and* unhelpful. Just don't.
+2. All software is broken. This is not a moral failing on the part of the authors. Don't give people a hard time for bad code.
+3. It's OK not to know things. Everybody was a beginner once, nobody should be made to feel bad for it.
+4. It's OK not to *want* to know something. If you think someone's question is fundamentally flawed, you should still ask permission before explaining what they should actually be asking.
+5. Note that "I was just joking" is not a valid defence.
+6. Don't suggest violence as a response to things, e.g. "People who do/think X should be Y-ed".
+   Even if you think it is obvious hyperbole and that it's very clear that no actual threat is meant,
+   it still contributes to a culture that makes people feel unsafe.
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~
+Resolution of Violations
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+David R. MacIver (the project lead) acts as the main point of contact and enforcer for code of conduct violations.
+You can email him at david@drmaciver.com, message him as DRMacIver on irc.freenode.net, or for violations on GitHub
+that you want to draw his attention to you can also mention him as @DRMacIver.
+
+Other people (especially Hypothesis team members) should feel free to call people on code of conduct violations when they see them,
+and it is appreciated but not required (especially if doing so would make you feel uncomfortable or unsafe).
+
+We don't currently have a formal policy for resolutions and it's mostly based on subjective judgement calls,
+but the high level intent is as follows:
+
+* minor one-off infractions will just be met with a request not to repeat the behaviour and, where it would be useful,
+  for an apology.
+* Major infractions and repeat offenders will be banned from the community.
+
+If you disagree with David's judgement on any particular event, please feel free to tell him so.
+
+Also, people who have a track record of bad behaviour outside of the Hypothesis community may be banned even
+if they obey all these rules if their presence is making people uncomfortable.

--- a/hypothesis-python/docs/community.rst
+++ b/hypothesis-python/docs/community.rst
@@ -13,41 +13,5 @@ The two major places for community discussion are:
 Feel free to use these to ask for help, provide feedback, or discuss anything remotely
 Hypothesis related at all.
 
----------------
-Code of conduct
----------------
-
-Hypothesis's community is an inclusive space, and everyone in it is expected to abide by a code of conduct.
-
-At the high level the code of conduct goes like this:
-
-1. Be kind
-2. Be respectful
-3. Be helpful
-
-While it is impossible to enumerate everything that is unkind, disrespectful or unhelpful, here are some specific things that are definitely against the code of conduct:
-
-1. -isms and -phobias (e.g. racism, sexism, transphobia and homophobia) are unkind, disrespectful *and* unhelpful. Just don't.
-2. All software is broken. This is not a moral failing on the part of the authors. Don't give people a hard time for bad code.
-3. It's OK not to know things. Everybody was a beginner once, nobody should be made to feel bad for it.
-4. It's OK not to *want* to know something. If you think someone's question is fundamentally flawed, you should still ask permission before explaining what they should actually be asking.
-5. Note that "I was just joking" is not a valid defence.
-6. Don't suggest violence as a response to things, e.g. "People who do/think X should be Y-ed".
-   Even if you think it is obvious hyperbole and that it's very clear that no actual threat is meant,
-   it still contributes to a culture that makes people feel unsafe.
-
-
-What happens when this goes wrong?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-For minor infractions, I'll just call people on it and ask them to apologise and not do it again. You should
-feel free to do this too if you're comfortable doing so.
-
-Major infractions and repeat offenders will be banned from the community.
-
-Also, people who have a track record of bad behaviour outside of the Hypothesis community may be banned even
-if they obey all these rules if their presence is making people uncomfortable.
-
-At the current volume level it's not hard for me to pay attention to the whole community, but if you think I've
-missed something please feel free to alert me. You can either message me as DRMacIver on freenode or send a me
-an email at david@drmaciver.com.
+Please note that `the Hypothesis code of conduct <https://github.com/HypothesisWorks/hypothesis-python/blob/master/CODE_OF_CONDUCT.rst>`_
+applies in all Hypothesis community spaces.


### PR DESCRIPTION
I've been thinking for a while anyway that we should move the code of conduct into [the official GitHub recognised location](https://help.github.com/articles/adding-a-code-of-conduct-to-your-project/) but in the bold new era of monorepoization it's extra important.